### PR TITLE
InterfaceMapping: fix endpoint regex

### DIFF
--- a/src/elm/Types/InterfaceMapping.elm
+++ b/src/elm/Types/InterfaceMapping.elm
@@ -120,7 +120,7 @@ type Retention
 
 validEndpointRegex : Regex
 validEndpointRegex =
-    Regex.fromString "^(/(%{([a-zA-Z][a-zA-Z0-9_]*)}|[a-zA-Z][a-zA-Z0-9]*)){1,64}"
+    Regex.fromString "^(/(%{([a-zA-Z][a-zA-Z0-9_]*)}|[a-zA-Z][a-zA-Z0-9_]*)){1,64}$"
         |> Maybe.withDefault Regex.never
 
 


### PR DESCRIPTION
sync the regex with the one used by astarte-core

Signed-off-by: Mattia Pavinati <mattia.pavinati@ispirata.com>