### PR TITLE
InterfaceBuilder.elm: explicit_timestamp default true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.11.0-beta.3] - unreleased
 ### Added
 - Support for data triggers matching "any interfaces".
+### Changed
+- New datastream mappings have explicit\_timestamp by default
 
 ### Fixed
 - Handle property interfaces in Device data page.

--- a/src/elm/Page/InterfaceBuilder.elm
+++ b/src/elm/Page/InterfaceBuilder.elm
@@ -150,7 +150,7 @@ init mode session =
       , objectReliability = InterfaceMapping.Unreliable
       , objectRetention = InterfaceMapping.Discard
       , objectExpiry = 0
-      , objectExplicitTimestamp = False
+      , objectExplicitTimestamp = True
       , deleteModalVisibility = Modal.hidden
       , confirmModalVisibility = Modal.hidden
       , confirmInterfaceName = ""
@@ -258,7 +258,7 @@ update session msg model =
                             { reliability = InterfaceMapping.Unreliable
                             , retention = InterfaceMapping.Discard
                             , expiry = 0
-                            , explicitTimestamp = False
+                            , explicitTimestamp = True
                             }
             in
             ( { model
@@ -793,11 +793,22 @@ update session msg model =
                 shown =
                     True
 
+                isProperty =
+                    model.interface.iType == Interface.Properties
+
+                initialMapping =
+                    if isProperty then
+                        InterfaceMapping.empty
+
+                    else
+                        InterfaceMapping.empty
+                            |> InterfaceMapping.setExplicitTimestamp True
+
                 newMappingBuilderModel =
                     MappingBuilder.init
-                        InterfaceMapping.empty
+                        initialMapping
                         mappingEditMode
-                        (model.interface.iType == Interface.Properties)
+                        isProperty
                         (model.interface.aggregation == Interface.Object)
                         shown
             in


### PR DESCRIPTION
When creating a new mapping for a datastream interface,
set the explicit_timestamp to true.
Fix #19

Signed-off-by: Mattia Pavinati <mattia.pavinati@ispirata.com>