### PR TITLE
Update docker image nginx version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New datastream mappings have explicit\_timestamp by default
 - Data triggers will match path /* by default
 - Expect API configuration URLs not ending with /v1
+- Build Docker image with the latest nginx 1.x version
 
 ### Fixed
 - Handle property interfaces in Device data page.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-stretch as builder
+FROM node:13-buster as builder
 
 WORKDIR /app
 ADD . .
@@ -7,6 +7,6 @@ RUN apt-get -qq install netbase build-essential autoconf libffi-dev
 RUN npm install
 RUN npm run deploy
 
-FROM nginx:1.13
+FROM nginx:1
 COPY --from=builder /app/dist/ /usr/share/nginx/html/
 ADD default.conf /etc/nginx/conf.d/


### PR DESCRIPTION
nginx version 1.13 is not secure. Switch to the latest 1.x version

Signed-off-by: Mattia Pavinati <mattia.pavinati@ispirata.com>