### PR TITLE
InterfaceBuilder.elm: enable server owned aggregate objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Data triggers will match path /* by default
 - Expect API configuration URLs not ending with /v1
 - Build Docker image with the latest nginx 1.x version
+- Enable server owned, object aggregated, datastream interfaces.
 
 ### Fixed
 - Handle property interfaces in Device data page.

--- a/src/elm/Page/InterfaceBuilder.elm
+++ b/src/elm/Page/InterfaceBuilder.elm
@@ -600,7 +600,6 @@ update session msg model =
                     if newAggregation == Interface.Object then
                         model.interface
                             |> Interface.setAggregation Interface.Object
-                            |> Interface.setOwnership Interface.Device
                             |> Interface.setObjectMappingAttributes
                                 model.objectReliability
                                 model.objectRetention
@@ -1189,14 +1188,14 @@ renderContent model interface interfaceEditMode accordionState =
                                 (Radio.radioList "interfaceOwnership"
                                     [ Radio.create
                                         [ Radio.id "iorb1"
-                                        , Radio.disabled <| interfaceEditMode || interface.aggregation == Interface.Object
+                                        , Radio.disabled <| interfaceEditMode
                                         , Radio.checked <| interface.ownership == Interface.Device
                                         , Radio.onClick <| UpdateInterfaceOwnership Interface.Device
                                         ]
                                         "Device"
                                     , Radio.create
                                         [ Radio.id "iorb2"
-                                        , Radio.disabled <| interfaceEditMode || interface.aggregation == Interface.Object
+                                        , Radio.disabled <| interfaceEditMode
                                         , Radio.checked <| interface.ownership == Interface.Server
                                         , Radio.onClick <| UpdateInterfaceOwnership Interface.Server
                                         ]


### PR DESCRIPTION
Astarte 0.11 supports server owned aggregate objects Interfaces.
Re-enable the form control.

Signed-off-by: Mattia Pavinati <mattia.pavinati@ispirata.com>