### PR TITLE
Deduct components URLs when base API URL is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Layout and palette restyle.
+- Configuration accepts both base Astarte API URL and specific component URLs.
 
 ## [0.11.0-rc.0] - 2020-01-26
 ### Added

--- a/src/elm/AstarteApi.elm
+++ b/src/elm/AstarteApi.elm
@@ -88,6 +88,8 @@ type alias Config =
     { secureConnection : Bool
     , realmManagementUrl : String
     , appengineUrl : String
+    , pairingUrl : String
+    , flowUrl : String
     , realm : String
     , token : String
     }
@@ -686,6 +688,8 @@ encodeConfig config =
         [ ( "secure_connection", Encode.bool config.secureConnection )
         , ( "realm_management_url", Encode.string config.realmManagementUrl )
         , ( "appengine_url", Encode.string config.appengineUrl )
+        , ( "pairing_url", Encode.string config.appengineUrl )
+        , ( "flow_url", Encode.string config.appengineUrl )
         , ( "realm", Encode.string config.realm )
         , ( "token", Encode.string config.token )
         ]
@@ -697,6 +701,8 @@ configDecoder =
         |> required "secure_connection" Decode.bool
         |> required "realm_management_url" Decode.string
         |> required "appengine_url" Decode.string
+        |> required "pairing_url" Decode.string
+        |> required "flow_url" Decode.string
         |> required "realm" Decode.string
         |> required "token" Decode.string
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -150,24 +150,27 @@ init jsParam location key =
 initNewSession : String -> Config -> Session
 initNewSession hostUrl config =
     let
-        ( secure, realUrl, appUrl ) =
+        apiConfig =
             case Config.getParams config of
                 Just params ->
-                    ( params.secureConnection
-                    , params.realmManagementApiUrl
-                    , params.appengineApiUrl
-                    )
+                    { secureConnection = params.secureConnection
+                    , realmManagementUrl = params.realmManagementApiUrl
+                    , appengineUrl = params.appengineApiUrl
+                    , pairingUrl = params.pairingApiUrl
+                    , flowUrl = params.flowApiUrl
+                    , realm = ""
+                    , token = ""
+                    }
 
                 Nothing ->
-                    ( False, "", "" )
-
-        apiConfig =
-            { secureConnection = secure
-            , realmManagementUrl = realUrl
-            , appengineUrl = appUrl
-            , realm = ""
-            , token = ""
-            }
+                    { secureConnection = False
+                    , realmManagementUrl = ""
+                    , appengineUrl = ""
+                    , pairingUrl = ""
+                    , flowUrl = ""
+                    , realm = ""
+                    , token = ""
+                    }
     in
     { hostUrl = hostUrl
     , loginStatus = NotLoggedIn

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -32,13 +32,7 @@ let channel = null;
 let app;
 
 $.getJSON("/user-config/config.json", function(result) {
-  if (result.realm_management_api_url) {
-    dashboardConfig = result;
-  } else {
-    console.log(
-      "Invalid Astarte dashboard configuration file. Starting in editor only mode"
-    );
-  }
+  dashboardConfig = result;
 })
   .fail(function(jqXHR, textStatus, errorThrown) {
     console.log(


### PR DESCRIPTION
Use "base api url" to deduct each component URL.
If a specific component url is present, use that instead of
the generated one.

Signed-off-by: Mattia <mattia.pavinati@gmail.com>