### PR TITLE
index.js: Fix AppEngine endpoint URL

### DIFF
--- a/src/static/index.js
+++ b/src/static/index.js
@@ -92,7 +92,7 @@ function openSocket(params) {
     protocol = "ws";
   }
 
-  let socketUrl = `${protocol}://${params.appengineUrl}/socket`;
+  let socketUrl = `${protocol}://${params.appengineUrl}/v1/socket`;
   let socketParams = { params: { realm: params.realm, token: params.token } };
   phoenixSocket = new Socket(socketUrl, socketParams);
   phoenixSocket.onError(socketErrorHandler);


### PR DESCRIPTION
When /v1 enpoints were removed from the JSON config,
they were added only in the Elm side of API handling.

Previous releases were not affected because they supported the
deprecated socket URL

Bug introduced in d1a922c9b20298fc98da4c5e50e5feaae07935ab

Signed-off-by: Mattia <mattia.pavinati@gmail.com>