### PR TITLE
Use grey for "never connected" device

### DIFF
--- a/src/elm/Page/Device.elm
+++ b/src/elm/Page/Device.elm
@@ -1367,7 +1367,7 @@ renderConnectionStatus device =
     case ( device.lastConnection, device.connected ) of
         ( Nothing, _ ) ->
             Html.span []
-                [ Icons.render Icons.FullCircle [ Spacing.mr1 ]
+                [ Icons.render Icons.FullCircle [ class "icon-never-connected", Spacing.mr1 ]
                 , Html.text "Never connected"
                 ]
 

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -55,7 +55,7 @@ $fa-font-path:        "../../../node_modules/@fortawesome/fontawesome-free/webfo
 
 $connected-color:       $green;
 $disconnected-color:    $red;
-$never-connected-color: #101010;
+$never-connected-color: $grey;
 
 .color-green {
     color: $green;


### PR DESCRIPTION
Black may give the idea something is wrong with the device. Use grey
instead.

Signed-off-by: Mattia <mattia.pavinati@gmail.com>