### PR TITLE
Fix typos in Home

### DIFF
--- a/src/elm/Page/Home.elm
+++ b/src/elm/Page/Home.elm
@@ -331,7 +331,7 @@ triggersCard width triggerCount =
 apiHealthCard : Card.Width -> Maybe Bool -> Maybe Bool -> Grid.Column Msg
 apiHealthCard width appengineHelath realmManagementHealth =
     Card.view width
-        "API Health"
+        "API Status"
         [ Grid.row []
             [ Grid.col [ Col.sm12 ]
                 [ Card.htmlRow ( "Realm management API", renderHealth appengineHelath )

--- a/src/elm/Page/Home.elm
+++ b/src/elm/Page/Home.elm
@@ -223,7 +223,7 @@ welcomeCard width =
                         , Html.br [] []
                         , Html.text "Read the"
                         , Html.a [ target "_blank", href "https://docs.astarte-platform.org/" ] [ Html.text " documentation " ]
-                        , Html.text "for more detailed informations on Astarte."
+                        , Html.text "for detailed information on Astarte."
                         ]
                     ]
                 , Html.div


### PR DESCRIPTION
- Information is uncountable, remove ending s.
- more is unnecessary when coupled with the word detailed.

Signed-off-by: Mattia <mattia.pavinati@gmail.com>