### PR TITLE
Interface: set explicit timestamp when changing type to datastream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Layout and palette restyle.
 - Configuration accepts both base Astarte API URL and specific component URLs.
 - Public keys are shown using monospace fonts
+- Explicit timestamp is enabled for all mappings when interface type is changed to datastream.
 
 ## [0.11.0-rc.0] - 2020-01-26
 ### Added

--- a/src/elm/Types/Interface.elm
+++ b/src/elm/Types/Interface.elm
@@ -134,7 +134,14 @@ setType iType interface =
     let
         updatedMappings =
             if iType == Datastream then
-                Dict.map (\_ m -> m |> InterfaceMapping.setAllowUnset False) interface.mappings
+                Dict.map
+                    (\_ mapping ->
+                        { mapping
+                            | allowUnset = False
+                            , explicitTimestamp = True
+                        }
+                    )
+                    interface.mappings
 
             else
                 Dict.map


### PR DESCRIPTION
Set explicit timestamp when changing interface type to datastream

Signed-off-by: Mattia <mattia.pavinati@gmail.com>