### PR TITLE
Date locale conversion via JS Ports

### DIFF
--- a/src/elm/Ports.elm
+++ b/src/elm/Ports.elm
@@ -18,8 +18,11 @@
 
 
 port module Ports exposing
-    ( listenToDeviceEvents
+    ( TaggedDate
+    , isoDateToLocalizedString
+    , listenToDeviceEvents
     , loadReactPage
+    , onDateConverted
     , onDeviceEventReceived
     , onPageRequested
     , onSessionChange
@@ -72,3 +75,19 @@ port unloadReactPage : () -> Cmd msg
 
 
 port onPageRequested : (Value -> msg) -> Sub msg
+
+
+
+-- As for 13/05/2020 there is no Elm package for datetime to local aware string conversion
+
+
+type alias TaggedDate =
+    { name : String
+    , date : Maybe String
+    }
+
+
+port isoDateToLocalizedString : TaggedDate -> Cmd msg
+
+
+port onDateConverted : (Value -> msg) -> Sub msg

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -59,6 +59,16 @@ $.getJSON("/user-config/config.json", function(result) {
 
     app.ports.listenToDeviceEvents.subscribe(connectToChannel);
 
+    app.ports.isoDateToLocalizedString.subscribe((taggedDate) => {
+      if (taggedDate.date) {
+        const convertedDate = new Date(taggedDate.date);
+        app.ports.onDateConverted.send({
+          name: taggedDate.name,
+          date: convertedDate.toLocaleString()
+        });
+      }
+    });
+
     window.addEventListener(
       "storage",
       function(event) {


### PR DESCRIPTION
Elm 0.19.1 does not support locale aware Time.Posix to string
conversion, and there are no adopted packages in the Elm ecosystem
that handles locales and formats.
Use Ports to send dates to the JS side and convert them there.

Signed-off-by: Mattia <mattia.pavinati@gmail.com>