### PR TITLE
Leave astarte channels rooms when changing pages

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -724,16 +724,31 @@ setRoute model ( maybeRoute, maybeToken ) =
     let
         ( page, command, updatedSession ) =
             processRoute model.config model.session ( maybeRoute, maybeToken )
+
+        reactEnvCommand =
+            if isReactBased page then
+                Cmd.none
+
+            else
+                Ports.unloadReactPage ()
+
+        astarteChannelsCommand =
+            case page of
+                Realm _ (DevicePage _) ->
+                    Cmd.none
+
+                _ ->
+                    Ports.leaveDeviceRoom ()
     in
     ( { model
         | selectedPage = page
         , session = updatedSession
       }
-    , if isReactBased page then
-        command
-
-      else
-        Cmd.batch [ command, Ports.unloadReactPage () ]
+    , Cmd.batch
+        [ command
+        , reactEnvCommand
+        , astarteChannelsCommand
+        ]
     )
 
 

--- a/src/elm/Ports.elm
+++ b/src/elm/Ports.elm
@@ -20,6 +20,7 @@
 port module Ports exposing
     ( TaggedDate
     , isoDateToLocalizedString
+    , leaveDeviceRoom
     , listenToDeviceEvents
     , loadReactPage
     , onDateConverted
@@ -58,6 +59,9 @@ type alias InterfaceId =
 
 
 port listenToDeviceEvents : DeviceSocketParams -> Cmd msg
+
+
+port leaveDeviceRoom : () -> Cmd msg
 
 
 port onDeviceEventReceived : (Value -> msg) -> Sub msg

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -64,6 +64,7 @@ $.getJSON("/user-config/config.json", function(result) {
 
     app.ports.loadReactPage.subscribe(loadPage);
     app.ports.unloadReactPage.subscribe(clearReact);
+    app.ports.leaveDeviceRoom.subscribe(leaveDeviceRoom);
 
     app.ports.listenToDeviceEvents.subscribe(watchDeviceEvents);
 
@@ -227,6 +228,13 @@ function watchDeviceEvents(params) {
     .catch((err) => {
       sendErrorMessage(`Couldn't join device ${deviceId} room`);
     });
+}
+
+function leaveDeviceRoom() {
+  for (let room of astarteClient.joinedRooms()) {
+    console.log("leaving room " + room);
+    astarteClient.leaveRoom(room);
+  }
 }
 
 function sendErrorMessage(errorMessage) {


### PR DESCRIPTION
When leaving a device page, leave the device room and
stop listening for trigger events.

Signed-off-by: Mattia <mattia.pavinati@gmail.com>