### PR TITLE
Interface: consider hyphens as lowercase

### DIFF
--- a/src/elm/Types/Interface.elm
+++ b/src/elm/Types/Interface.elm
@@ -457,7 +457,7 @@ isGoodInterfaceName interfaceName =
 
 isLowerCase : String -> Bool
 isLowerCase str =
-    String.all Char.isLower str
+    String.all (\c -> Char.isLower c || c == '-') str
 
 
 isTitleCase : String -> Bool


### PR DESCRIPTION
When cheking for lowercase interface names, treat hyphens as a valid lowercase character

Signed-off-by: Mattia Pavinati <mattia.pavinati@ispirata.com>