### PR TITLE
Home: fix service health labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Match API labels with their corresponding status.
+
 ## [0.11.1] - 2020-05-18
 ### Added
 - Byte multiples in device stats stable.

--- a/src/elm/Page/Home.elm
+++ b/src/elm/Page/Home.elm
@@ -329,13 +329,13 @@ triggersCard width triggerCount =
 
 
 apiHealthCard : Card.Width -> Maybe Bool -> Maybe Bool -> Grid.Column Msg
-apiHealthCard width appengineHelath realmManagementHealth =
+apiHealthCard width appengineHealth realmManagementHealth =
     Card.view width
         "API Status"
         [ Grid.row []
             [ Grid.col [ Col.sm12 ]
-                [ Card.htmlRow ( "Realm management API", renderHealth appengineHelath )
-                , Card.htmlRow ( "AppEngine API", renderHealth realmManagementHealth )
+                [ Card.htmlRow ( "AppEngine API", renderHealth appengineHealth )
+                , Card.htmlRow ( "Realm management API", renderHealth realmManagementHealth )
                 ]
             ]
         ]


### PR DESCRIPTION
Map astarte service API status with the appropriate label

Signed-off-by: Mattia Pavinati <mattia.pavinati@ispirata.com>