### PR TITLE
DevicesPage.js: fix device table pagination

### DIFF
--- a/src/react/DevicesPage.js
+++ b/src/react/DevicesPage.js
@@ -181,8 +181,8 @@ export default class DevicesPage extends React.Component {
     switch (this.state.phase) {
       case "ok":
         if (this.state.totalDevices) {
-          const { activePage, cachedPages } = this.state;
-          const viewAblePages = cachedPages.length;
+          const { activePage, cachedPages, maxPage } = this.state;
+          const viewAblePages = Math.min(cachedPages.length, maxPage);
           const devices = cachedPages[activePage].devices;
 
           innerHTML = (


### PR DESCRIPTION
Hide pages with no devices.
This was happening to the last page when the device number is a multiple of the number or devices shown per page.

Signed-off-by: Mattia <mattia.pavinati@gmail.com>