### PR TITLE
TriggerBuilder: Fix datatrigger validation from source

### DIFF
--- a/src/elm/Page/TriggerBuilder.elm
+++ b/src/elm/Page/TriggerBuilder.elm
@@ -384,7 +384,17 @@ update session msg model =
                             , sourceBufferStatus = Valid
                             , trigger = trigger
                           }
-                        , Cmd.none
+                        , case trigger.simpleTrigger of
+                            Trigger.Data dataTrigger ->
+                                AstarteApi.getInterface session.apiConfig
+                                    dataTrigger.interfaceName
+                                    dataTrigger.interfaceMajor
+                                    GetInterfaceDone
+                                    (ShowError "Could not retrieve selected interface")
+                                    RedirectToLogin
+
+                            _ ->
+                                Cmd.none
                         , ExternalMsg.Noop
                         )
 


### PR DESCRIPTION
Retrieve the interface data when validating a data trigger from source
Fixes #111

Signed-off-by: Mattia <mattia.pavinati@ispirata.com>