### PR TITLE
Uniform icon alignment between Elm and React pages

### DIFF
--- a/src/elm/Page/Device.elm
+++ b/src/elm/Page/Device.elm
@@ -794,8 +794,8 @@ view model flashMessages =
                         [ Html.h2
                             [ Spacing.pl2 ]
                             [ Html.a
-                                [ href "/devices", Spacing.mr2 ]
-                                [ Icons.render Icons.Back [ class "align-text-bottom" ] ]
+                                [ href "/devices", Spacing.mr2, class "align-bottom" ]
+                                [ Icons.render Icons.Back [] ]
                             , Html.text "Device"
                             ]
                         , FlashMessageHelpers.renderFlashMessages flashMessages Forward

--- a/src/elm/Page/InterfaceBuilder.elm
+++ b/src/elm/Page/InterfaceBuilder.elm
@@ -1011,8 +1011,8 @@ view model flashMessages =
                 [ Html.h2
                     [ Spacing.pl2 ]
                     [ Html.a
-                        [ href "/interfaces", Spacing.mr2 ]
-                        [ Icons.render Icons.Back [ class "align-text-bottom" ] ]
+                        [ href "/interfaces", Spacing.mr2, class "align-bottom" ]
+                        [ Icons.render Icons.Back [] ]
                     , Html.text "Interface Editor"
                     ]
                 ]

--- a/src/elm/Page/TriggerBuilder.elm
+++ b/src/elm/Page/TriggerBuilder.elm
@@ -1321,8 +1321,8 @@ view model flashMessages =
                 [ Html.h2
                     [ Spacing.pl2 ]
                     [ Html.a
-                        [ href "/triggers", Spacing.mr2 ]
-                        [ Icons.render Icons.Back [ class "align-text-bottom" ] ]
+                        [ href "/triggers", Spacing.mr2, class "align-bottom" ]
+                        [ Icons.render Icons.Back [] ]
                     , Html.text "Trigger Editor"
                     ]
                 ]


### PR DESCRIPTION
Allign back icons to the line bottom.

Signed-off-by: Mattia Pavinati <mattia.pavinati@ispirata.com>