### PR TITLE
InterfacesPage: Fix interface name max width

### DIFF
--- a/src/react/InterfacesPage.js
+++ b/src/react/InterfacesPage.js
@@ -26,7 +26,7 @@ import {
 
 const InterfaceRow = ({ name, majors }) => (
   <ListGroup.Item>
-    <Container className="p-0">
+    <Container className="p-0" fluid>
       <Row>
         <Col>
           <Link to={`/interfaces/${name}/${Math.max(...majors)}`}>


### PR DESCRIPTION
Allow the interface name container to span the whole
container length

Signed-off-by: Mattia Pavinati <mattia.pavinati@ispirata.com>