### PR TITLE
Encode group names when used in URLs

### DIFF
--- a/src/elm/Route.elm
+++ b/src/elm/Route.elm
@@ -178,7 +178,14 @@ toString route =
                     [ "groups" ]
 
                 Realm (GroupDevices groupName) ->
-                    [ "groups", groupName ]
+                    let
+                        -- Double encoding to preserve the URL format when groupName contains % and /
+                        encodedGroupName =
+                            groupName
+                            |> Url.percentEncode
+                            |> Url.percentEncode
+                    in
+                    [ "groups", encodedGroupName ]
 
                 Realm FlowInstances ->
                     [ "flows" ]

--- a/src/react/AstarteClient.js
+++ b/src/react/AstarteClient.js
@@ -181,15 +181,16 @@ class AstarteClient {
     });
   }
 
-  getDevicesInGroup(params) {
-    let { groupName, details } = params;
-    let endpointUri = new URL(
-      this.apiConfig["groupDevices"]({ ...this.config, groupName: groupName })
-    );
-
+  getDevicesInGroup({ groupName, details }) {
     if (!groupName) {
       throw Error("Invalid group name");
     }
+
+    /* Double encoding to preserve the URL format when groupName contains % and / */
+    const encodedGroupName = encodeURIComponent(encodeURIComponent(groupName));
+    const endpointUri = new URL(
+      this.apiConfig["groupDevices"]({ ...this.config, groupName: encodedGroupName })
+    );
 
     if (details) {
       endpointUri.search = new URLSearchParams({ details: true });

--- a/src/react/GroupsPage.js
+++ b/src/react/GroupsPage.js
@@ -91,10 +91,11 @@ export default ({ astarte, history }) => {
             </thead>
             <tbody>
               {Array.from(groups.values()).map((group, index) => {
+                const encodedGroupName = encodeURIComponent(encodeURIComponent(group.name));
                 return (
                   <tr key={group.name}>
                     <td>
-                      <Link to={`/groups/${group.name}`}>{group.name}</Link>
+                      <Link to={`/groups/${encodedGroupName}/`}>{group.name}</Link>
                     </td>
                     <td>{group.connectedDevices}</td>
                     <td>{group.totalDevices}</td>

--- a/src/react/Router.js
+++ b/src/react/Router.js
@@ -129,9 +129,10 @@ function Login(props) {
 }
 
 function GroupDevicesSubPath(props) {
-  let { groupName } = useParams();
+  const { groupName } = useParams();
+  const decodedGroupName = decodeURIComponent(groupName);
 
-  return <GroupDevicesPage groupName={groupName} {...props} />;
+  return <GroupDevicesPage groupName={decodedGroupName} {...props} />;
 }
 
 function FlowDetails(props) {


### PR DESCRIPTION
Group names can contain characters lik % & / ? wich will interfeere
with the REST URL format if unescaped.

see https://github.com/astarte-platform/astarte/issues/456

Signed-off-by: Mattia Pavinati <mattia.pavinati@ispirata.com>