### PR TITLE
Fix parsing of group name from URL

### DIFF
--- a/src/react/Router.js
+++ b/src/react/Router.js
@@ -141,10 +141,8 @@ function Login(props) {
 }
 
 function GroupDevicesSubPath(props) {
-  const { groupName } = useParams();
-  const decodedGroupName = decodeURIComponent(groupName);
-
-  return <GroupDevicesPage groupName={decodedGroupName} {...props} />;
+  const parsedGroupName = decodeURIComponent(window.location.pathname.split('/')[2]);
+  return <GroupDevicesPage groupName={parsedGroupName} {...props} />;
 }
 
 function FlowDetails(props) {


### PR DESCRIPTION
React Router presents an odd behavior when matching group name of the current route:
navigating to a group URL yields a different result that reaching it from the app.

This PR fixes the issue by relying on window.location directly to match the group name.