### PR TITLE
Fix build script error

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -47,12 +47,14 @@ module.exports = merge(common, {
         ]
     },
     plugins: [
-        new CopyWebpackPlugin([{
-            from: 'src/static/img/',
-            to: 'static/img/'
-        }, {
-            from: 'src/favicon.ico'
-        }]),
+        new CopyWebpackPlugin({
+            patterns: [{
+                from: 'src/static/img/',
+                to: 'static/img/'
+            }, {
+                from: 'src/favicon.ico'
+            }]
+        }),
         new MiniCssExtractPlugin({
             filename: "[name].css",
             chunkFilename: "[id].css"


### PR DESCRIPTION
webpack.prod.js
Fix CopyWebpackPlugin params structure that changed with the new
major version.

Signed-off-by: Mattia Pavinati <mattia.pavinati@ispirata.com>