### PR TITLE
Fix sourcemap warnings with dev-server

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -7,6 +7,7 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, 'dist/'),
     filename: 'static/js/[name]-[hash].js',
+    publicPath: '/',
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.elm', '.scss'],

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -7,6 +7,7 @@ const entryPath = path.join(__dirname, 'src/static/index.js');
 module.exports = merge(common, {
   mode: 'development',
   entry: ['webpack-dev-server/client?http://localhost:8080', entryPath],
+  devtool: 'source-map',
   devServer: {
     // serve index.html in place of 404 responses
     historyApiFallback: {


### PR DESCRIPTION
Configure webpack to use generated sourcemaps

Signed-off-by: Mattia Pavinati <mattia.pavinati@ispirata.com>