### PR TITLE
Add Cypress tests for Realm Settings page

### DIFF
--- a/cypress/fixtures/config_auth.json
+++ b/cypress/fixtures/config_auth.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "jwt_public_key_pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAMNV2kf6Xkh6O3HfDTXXC1O5YWA7v+dd\n4BdlYn5cwk/X5D/TLnWRSwAhhyoyjNM5293idDmpVp62+nZnUS3RVe0CAwEAAQ==\n-----END PUBLIC KEY-----\n"
+  }
+}

--- a/src/react/RealmSettingsPage.jsx
+++ b/src/react/RealmSettingsPage.jsx
@@ -60,6 +60,7 @@ export default ({ astarte, history }) => {
       .catch(() => setPhase('err'));
   }, [astarte, setUserPublicKey, setDraftPublicKey, setPhase]);
 
+  const canUpdatePublicKey = draftPublicKey !== userPublicKey && draftPublicKey.trim() !== '';
   let innerHTML;
 
   switch (phase) {
@@ -79,11 +80,7 @@ export default ({ astarte, history }) => {
               />
             </Form.Group>
             {/* TODO: this action is destructive, maybe we should use danger/warning variants */}
-            <Button
-              variant="primary"
-              disabled={draftPublicKey === userPublicKey}
-              onClick={showModal}
-            >
+            <Button variant="primary" disabled={!canUpdatePublicKey} onClick={showModal}>
               Apply
             </Button>
           </Form>


### PR DESCRIPTION
This PR adds basic functionality tests to ensure the settings page is correctly loaded and the user cannot update the public key with clearly invalid values