### PR TITLE
Fix inconsistencies in Cypress tests

### DIFF
--- a/cypress/fixtures/interfaces.json
+++ b/cypress/fixtures/interfaces.json
@@ -2,6 +2,9 @@
   "data": [
     "test.astarte.FirstInterface",
     "test.astarte.SecondInterface",
-    "test.astarte.ThirdInterface"
+    "test.astarte.ThirdInterface",
+    "test.astarte.ParametricObjectInterface",
+    "com.example.ExampleInterface",
+    "com.test.TestInterface"
   ]
 }

--- a/cypress/integration/device_page_test.js
+++ b/cypress/integration/device_page_test.js
@@ -4,7 +4,7 @@ describe('Device page tests', () => {
       cy.fixture('device').as('device');
     });
 
-    it('redirects to home', function () {
+    it('redirects to login', function () {
       cy.visit(`/devices/${this.device.data.id}`);
       cy.location('pathname').should('eq', '/login');
     });

--- a/cypress/integration/devices_page_test.js
+++ b/cypress/integration/devices_page_test.js
@@ -1,6 +1,6 @@
 describe('Devices page tests', () => {
   context('no access before login', () => {
-    it('redirects to home', function () {
+    it('redirects to login', function () {
       cy.visit('/devices');
       cy.location('pathname').should('eq', '/login');
     });

--- a/cypress/integration/interface_builder_test.js
+++ b/cypress/integration/interface_builder_test.js
@@ -1,6 +1,6 @@
 describe('Interface builder tests', () => {
   context('no access before login', () => {
-    it('redirects to home', () => {
+    it('redirects to login', () => {
       cy.visit('/interfaces/new');
       cy.location('pathname').should('eq', '/login');
 

--- a/cypress/integration/interfaces_page_test.js
+++ b/cypress/integration/interfaces_page_test.js
@@ -7,30 +7,27 @@ describe('Interfaces page tests', () => {
   });
 
   context('require login', () => {
-    before(() => {
-      cy.login();
+    beforeEach(() => {
       cy.fixture('interfaces').as('interfaces');
       cy.fixture('interface_majors').as('interface_majors');
-
       cy.server();
       cy.route('GET', '/realmmanagement/v1/*/interfaces', '@interfaces');
       cy.route('GET', '/realmmanagement/v1/*/interfaces/*', '@interface_majors');
-    });
-
-    beforeEach(() => {
+      cy.login();
       cy.visit('/interfaces');
     });
 
-    it('successfully loads', () => {
+    it('successfully loads the Interfaces page', () => {
       cy.location('pathname').should('eq', '/interfaces');
-
       cy.get('h2').contains('Interfaces');
-      cy.get('.list-group > .list-group-item:nth-child(2) .col > a')
-        .should('have.attr', 'href').and('contains', 'test.astarte.FirstInterface');
-      cy.get('.list-group > .list-group-item:nth-child(3) .col > a')
-        .should('have.attr', 'href').and('contains', 'test.astarte.SecondInterface');
-      cy.get('.list-group > .list-group-item:nth-child(4) .col > a')
-        .should('have.attr', 'href').and('contains', 'test.astarte.ThirdInterface');
+    });
+
+    it('displays links to available interfaces', function () {
+      this.interfaces.data.sort().forEach((interfaceName, index) => {
+        cy.get(`.list-group > .list-group-item:nth-child(${index + 2}) .col > a`)
+          .should('have.attr', 'href')
+          .and('contains', interfaceName);
+      });
     });
   });
 });

--- a/cypress/integration/interfaces_page_test.js
+++ b/cypress/integration/interfaces_page_test.js
@@ -1,6 +1,6 @@
 describe('Interfaces page tests', () => {
   context('no access before login', () => {
-    it('redirects to home', () => {
+    it('redirects to login', () => {
       cy.visit('/interfaces');
       cy.location('pathname').should('eq', '/login');
     });

--- a/cypress/integration/register_device_page_test.js
+++ b/cypress/integration/register_device_page_test.js
@@ -2,7 +2,7 @@ import { urlSafeBase64ToByteArray } from '../../src/react/Base64.ts';
 
 describe('Register device page tests', () => {
   context('no access before login', () => {
-    it('redirects to home', () => {
+    it('redirects to login', () => {
       cy.visit('/devices/register');
       cy.location('pathname').should('eq', '/login');
     });

--- a/cypress/integration/trigger_builder_test.js
+++ b/cypress/integration/trigger_builder_test.js
@@ -1,11 +1,11 @@
 describe('Trigger builder tests', () => {
   context('no access before login', () => {
-    it('redirects to home', () => {
+    it('redirects to login', () => {
       cy.visit('/triggers/new');
       cy.location('pathname').should('eq', '/login');
     });
 
-    it('redirects to home', () => {
+    it('redirects to login', () => {
       cy.visit('/triggers/testTrigger');
       cy.location('pathname').should('eq', '/login');
     });

--- a/cypress/integration/triggers_page_test.js
+++ b/cypress/integration/triggers_page_test.js
@@ -1,6 +1,6 @@
 describe('Triggers page tests', () => {
   context('no access before login', () => {
-    it('redirects to home', () => {
+    it('redirects to login', () => {
       cy.visit('/triggers');
       cy.location('pathname').should('eq', '/login');
     });


### PR DESCRIPTION
This PR focuses on using consistent Cypress fixtures.
In doing so, it:
- reworks fixtures so they can be easily reused
- fixes misleading labels on test cases