### PR TITLE
Add Cypress tests for Home page

### DIFF
--- a/cypress/integration/home_page_test.js
+++ b/cypress/integration/home_page_test.js
@@ -1,0 +1,103 @@
+describe('Home page tests', () => {
+  context('no access before login', () => {
+    it('redirects to login', function () {
+      cy.visit('/');
+      cy.location('pathname').should('eq', '/login');
+    });
+  });
+
+  context('authenticated', () => {
+    beforeEach(() => {
+      cy.fixture('devices_stats').as('devicesStats');
+      cy.fixture('interfaces').as('interfaces');
+      cy.fixture('interface_majors').as('interfaceMajors');
+      cy.fixture('triggers').as('triggers');
+      cy.server();
+      cy.route('GET', '/appengine/v1/*/stats/devices', '@devicesStats');
+      cy.route('GET', '/realmmanagement/v1/*/triggers', '@triggers');
+      cy.route('GET', '/realmmanagement/v1/*/interfaces', '@interfaces');
+      cy.route('GET', '/realmmanagement/v1/*/interfaces/*', '@interfaceMajors');
+      cy.route('GET', '/appengine/health', '');
+      cy.route('GET', '/realmmanagement/health', '');
+      cy.route('GET', '/pairing/health', '');
+      cy.route('GET', '/flow/health', '');
+      cy.login();
+      cy.visit('/');
+    });
+
+    it('successfully loads the Home page', () => {
+      cy.location('pathname').should('eq', '/');
+      cy.get('h2').contains('Astarte Dashboard');
+    });
+
+    it('has an API Status card with a table to display services health', () => {
+      cy.get('#status-card')
+        .contains('API Status')
+        .parents('.card')
+        .within(() => {
+          const services = ['Realm Management', 'AppEngine', 'Pairing', 'Flow'];
+          cy.get('table tbody').find('tr').should('have.length', services.length);
+          services.forEach((service, index) => {
+            cy.get(`table tbody tr:nth-child(${index + 1})`).within(() => {
+              cy.contains(service);
+              cy.contains('This service is operating normally');
+            });
+          });
+        });
+    });
+
+    it('has a Devices card that shows stats on devices', function () {
+      cy.get('#devices-card')
+        .contains('Devices')
+        .parents('.card')
+        .within(() => {
+          cy.contains('Registered devices').next().contains(this.devicesStats.data.total_devices);
+          cy.contains('Connected devices')
+            .next()
+            .contains(this.devicesStats.data.connected_devices);
+        });
+    });
+
+    it('has a Interfaces card that shows available interfaces', function () {
+      cy.get('#interfaces-card')
+        .contains('Interfaces')
+        .parents('.card')
+        .within(() => {
+          this.interfaces.data.slice(0, 4).forEach((interfaceName) => {
+            cy.contains(interfaceName);
+          });
+          if (this.interfaces.data.length > 5) {
+            cy.contains(`${this.interfaces.data.length - 4} more installed interfaces`);
+          }
+          cy.get('button').contains('Install a new interface');
+          const interfaceName = this.interfaces.data[0];
+          const interfaceMajor = Math.max(this.interfaceMajors.data);
+          cy.contains(interfaceName).click();
+          cy.location('pathname').should('eq', `/interfaces/${interfaceName}/${interfaceMajor}`);
+        });
+      cy.visit('/');
+      cy.get('#interfaces-card button').contains('Install a new interface').click();
+      cy.location('pathname').should('eq', '/interfaces/new');
+    });
+
+    it('has a Triggers card that shows available triggers', function () {
+      cy.get('#triggers-card')
+        .contains('Triggers')
+        .parents('.card')
+        .within(() => {
+          this.triggers.data.slice(0, 4).forEach((trigger) => {
+            cy.contains(trigger);
+          });
+          if (this.triggers.data.length > 5) {
+            cy.contains(`${this.triggers.data.length - 4} more installed triggers`);
+          }
+          cy.get('button').contains('Install a new trigger');
+          cy.contains(this.triggers.data[0]).click();
+          cy.location('pathname').should('eq', `/triggers/${this.triggers.data[0]}`);
+        });
+      cy.visit('/');
+      cy.get('#triggers-card button').contains('Install a new trigger').click();
+      cy.location('pathname').should('eq', '/triggers/new');
+    });
+  });
+});

--- a/src/react/HomePage.jsx
+++ b/src/react/HomePage.jsx
@@ -115,7 +115,7 @@ export default ({ astarte, history }) => {
 };
 
 const ApiStatusCard = ({ appengine, realmManagement, pairing, showFlowStatus, flow }) => (
-  <Card className="h-100">
+  <Card id="status-card" className="h-100">
     <Card.Header as="h5">API Status</Card.Header>
     <Card.Body>
       <Table responsive>
@@ -137,7 +137,7 @@ const ApiStatusCard = ({ appengine, realmManagement, pairing, showFlowStatus, fl
 );
 
 const DevicesCard = ({ connectedDevices, totalDevices }) => (
-  <Card className="h-100">
+  <Card id="devices-card" className="h-100">
     <Card.Header as="h5">Devices</Card.Header>
     <Card.Body>
       <Container className="h-100 p-0" fluid>
@@ -163,7 +163,7 @@ const DevicesCard = ({ connectedDevices, totalDevices }) => (
 );
 
 const InterfacesCard = ({ interfaceList, onInterfaceClick, onInstallInterfaceClick }) => (
-  <Card className="h-100">
+  <Card id="interfaces-card" className="h-100">
     <Card.Header as="h5">Interfaces</Card.Header>
     <Card.Body className="d-flex flex-column">
       {interfaceList.length > 0 ? (
@@ -200,7 +200,7 @@ const InterfacesCard = ({ interfaceList, onInterfaceClick, onInstallInterfaceCli
 );
 
 const TriggersCard = ({ triggerList, onInstallTriggerClick }) => (
-  <Card className="h-100">
+  <Card id="triggers-card" className="h-100">
     <Card.Header as="h5">Triggers</Card.Header>
     <Card.Body className="d-flex flex-column">
       {triggerList.length > 0 ? (
@@ -292,8 +292,9 @@ const InterfaceList = ({ interfaces, onInterfaceClick, maxShownInterfaces }) => 
       {remainingInterfaces > 0 && (
         <li>
           <Link to="/interfaces">
-            {remainingInterfaces} more installed
-            {remainingInterfaces > 1 ? 'interfaces' : 'interface'}…
+            {`${remainingInterfaces} more installed ${
+              remainingInterfaces > 1 ? 'interfaces' : 'interface'
+            }…`}
           </Link>
         </li>
       )}
@@ -318,8 +319,9 @@ const TriggerList = ({ triggers, maxShownTriggers }) => {
       {remainingTriggers > 0 && (
         <li>
           <Link to="/triggers">
-            {remainingTriggers} more installed
-            {remainingTriggers > 1 ? 'triggers' : 'trigger'}…
+            {`${remainingTriggers} more installed ${
+              remainingTriggers > 1 ? 'triggers' : 'trigger'
+            }…`}
           </Link>
         </li>
       )}


### PR DESCRIPTION
This PR adds basic Cypress tests to check if the homepage renders correctly.
It tests for proper behavior on the homepage cards: API Status, Devices, Interfaces, Triggers.