### PR TITLE
Add device filtering to the devices page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support device groups in device triggers.
 - Initial device introspection during device registration.
 - Pipeline source visual editor.
+- Search filters for devices page.
 
 ### Fixed
 - Fix bug which caused marking triggers as invalid on parametric endpoints containing an underscore.

--- a/cypress/integration/devices_page_test.js
+++ b/cypress/integration/devices_page_test.js
@@ -50,5 +50,24 @@ describe('Devices page tests', () => {
       });
       cy.location('pathname').should('eq', '/devices/register');
     });
+
+    it('correctly filters by connection status', () => {
+      cy.get('#checkbox-connected').check();
+      cy.get('#checkbox-disconnected').uncheck();
+      cy.get('#checkbox-never-connected').uncheck();
+      cy.get('table tbody tr i')
+        .should('have.length', 1)
+        .each(($icon) => {
+          expect($icon).to.have.class('icon-connected');
+        });
+    });
+
+    it('correctly filters by device handle', function () {
+      const deviceName = this.devices.data[0].aliases.name;
+      const filter = deviceName.substring(2, 7);
+      cy.get('#filterId').type(filter);
+      cy.get('table tbody tr').should('have.length', 1);
+      cy.get('table tbody tr td:nth-child(2)').should('contain', deviceName);
+    });
   });
 });


### PR DESCRIPTION
Allow users to filter the device list by connection status and
device id or device name.
Fixes #184, #185

Signed-off-by: Mattia Pavinati <mattia.pavinati@ispirata.com>