### PR TITLE
Add Cypress tests for Pipeline page

### DIFF
--- a/cypress/integration/pipeline_page_test.js
+++ b/cypress/integration/pipeline_page_test.js
@@ -1,0 +1,53 @@
+describe('Pipeline page tests', () => {
+  context('no access before login', () => {
+    it('redirects to login', () => {
+      cy.visit('/pipelines/pipeline_name');
+      cy.location('pathname').should('eq', '/login');
+    });
+  });
+
+  context('authenticated', () => {
+    beforeEach(() => {
+      cy.fixture('pipeline.sample-computation')
+        .as('pipeline')
+        .then((pipeline) => {
+          cy.server();
+          cy.route('GET', `/flow/v1/*/pipelines/${pipeline.data.name}`, '@pipeline').as(
+            'getPipeline',
+          );
+          cy.route({
+            method: 'DELETE',
+            url: `/flow/v1/*/pipelines/${pipeline.data.name}`,
+            status: 204,
+            response: '',
+          }).as('deletePipeline');
+          cy.login();
+          cy.visit(`/pipelines/${pipeline.data.name}`);
+          cy.wait('@getPipeline');
+        });
+    });
+
+    it('successfully loads Pipeline page', function () {
+      cy.location('pathname').should('eq', `/pipelines/${this.pipeline.data.name}`);
+      cy.get('h2').contains('Pipeline Details');
+    });
+
+    it("correctly displays the pipeline's properties", function () {
+      cy.get('.main-content').within(() => {
+        cy.contains('Name').next().contains(this.pipeline.data.name);
+        if (this.pipeline.data.description) {
+          cy.contains('Description').next().contains(this.pipeline.data.description);
+        }
+        cy.contains('Source');
+      });
+    });
+
+    it('can delete the pipeline', () => {
+      cy.get('.main-content').within(() => {
+        cy.contains('Delete pipeline').click();
+        cy.wait('@deletePipeline');
+        cy.location('pathname').should('eq', '/pipelines');
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds basic checks in Cypress to make sure the Pipeline page correctly renders the pipeline's details.