### PR TITLE
Add Cypress tests for Flows page

### DIFF
--- a/cypress/fixtures/flow.room1-occupation.json
+++ b/cypress/fixtures/flow.room1-occupation.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "config": {
+      "amqp_exchange": "astarte_events_testrealm_room1_occupation",
+      "devices": ["0ma4SioESHKk28VhYGcW1w", "PO6RuqIXQuysOCAJrcedqA"],
+      "interfaces": [
+        {
+          "interface_name": "com.astarte-platform.examples.RoomOccupation",
+          "mappings": [{ "endpoint": "/estimated", "type": "integer" }],
+          "ownership": "device",
+          "type": "datastream",
+          "version_major": 0,
+          "version_minor": 1
+        }
+      ],
+      "pairing_jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1OTI4MjkwMjAsImFfcGEiOlsiLio6Oi4qIl19.tZtMfABhuRXr9z5XBd_BFzFtz-QD60QiKTM5hRRZ3x0",
+      "realm": "testrealm",
+      "room_id": "q4zjsC7GSqmrQzhHIsAUMQ",
+      "room_size": 42.3
+    },
+    "name": "room1-occupation",
+    "pipeline": "room-occupation"
+  }
+}

--- a/cypress/fixtures/flows.json
+++ b/cypress/fixtures/flows.json
@@ -1,0 +1,1 @@
+{ "data": ["room1-occupation", "room2-occupation", "room3-occupation"] }

--- a/cypress/integration/flows_page_test.js
+++ b/cypress/integration/flows_page_test.js
@@ -1,0 +1,80 @@
+describe('Flows page tests', () => {
+  context('no access before login', () => {
+    it('redirects to login', () => {
+      cy.visit('/flows');
+      cy.location('pathname').should('eq', '/login');
+    });
+  });
+
+  context('authenticated', () => {
+    beforeEach(() => {
+      cy.fixture('flows').as('flows');
+      cy.fixture('flow.room1-occupation').as('flow');
+      cy.server();
+      cy.route('GET', '/flow/v1/*/flows/*', '@flow').as('getFlow');
+      cy.route({
+        method: 'DELETE',
+        url: `/flow/v1/*/flows/*`,
+        status: 204,
+        response: '',
+      });
+      cy.login();
+      cy.visit('/flows');
+    });
+
+    it('successfully loads Flows page', () => {
+      cy.location('pathname').should('eq', '/flows');
+      cy.get('h2').contains('Running Flows');
+    });
+
+    it('correctly reports there are no flows running', () => {
+      cy.route('GET', '/flow/v1/*/flows', { data: [] }).as('getFlows');
+      cy.wait(['@getFlows']);
+      cy.get('.main-content').within(() => {
+        cy.contains('No running flows');
+        cy.get('table').should('not.exist');
+      });
+    });
+
+    it('correctly displays running flows in a table', function () {
+      cy.route('GET', '/flow/v1/*/flows', '@flows').as('getFlows');
+      cy.wait(['@getFlows', '@getFlow']);
+      cy.get('.main-content').within(() => {
+        cy.get('table tbody').find('tr').should('have.length', this.flows.data.length);
+        this.flows.data.forEach((_, index) => {
+          cy.get(`table tbody tr:nth-child(${index + 1})`).within(() => {
+            cy.contains(this.flow.data.name);
+            cy.contains(this.flow.data.pipeline);
+            cy.get('.btn.btn-danger');
+          });
+        });
+      });
+    });
+
+    it('each flow name is a link to its dedicated page', function () {
+      cy.route('GET', '/flow/v1/*/flows', '@flows').as('getFlows');
+      cy.wait(['@getFlows', '@getFlow']);
+      cy.get('.main-content').within(() => {
+        cy.get('table tbody tr:nth-child(1)').contains(this.flow.data.name).click();
+        cy.location('pathname').should('eq', `/flows/${this.flow.data.name}`);
+      });
+    });
+
+    it('shows a confirm dialog when deleting a flow', function () {
+      cy.route('GET', '/flow/v1/*/flows', '@flows').as('getFlows');
+      cy.wait(['@getFlows', '@getFlow']);
+      cy.get('.main-content table tbody tr:nth-child(1) .btn.btn-danger').click();
+      cy.get('[role="dialog"]').contains(`Delete flow ${this.flow.data.name}?`);
+      cy.get('[role="dialog"] button').contains('Remove').click();
+      cy.get('[role="dialog"]').should('not.exist');
+      cy.location('pathname').should('eq', '/flows');
+    });
+
+    it('has a button to instantiate a new flow', () => {
+      cy.get('.main-content').within(() => {
+        cy.get('button').contains('New flow').click();
+        cy.location('pathname').should('eq', '/pipelines');
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds basic checks in Cypress to make sure the Flows page correctly renders the list of flows and support the interactions needed to manage them.