### PR TITLE
Add Cypress tests for Flow page

### DIFF
--- a/cypress/integration/flow_page_test.js
+++ b/cypress/integration/flow_page_test.js
@@ -1,0 +1,33 @@
+describe('Flow page tests', () => {
+  context('no access before login', () => {
+    it('redirects to login', () => {
+      cy.visit('/flows/test-flow');
+      cy.location('pathname').should('eq', '/login');
+    });
+  });
+
+  context('authenticated', () => {
+    beforeEach(() => {
+      cy.fixture('flow.room1-occupation')
+        .as('flow')
+        .then((flow) => {
+          cy.server();
+          cy.route('GET', `/flow/v1/*/flows/${flow.data.name}`, '@flow').as('getFlow');
+          cy.login();
+          cy.visit(`/flows/${flow.data.name}`);
+        });
+    });
+
+    it('successfully loads Flow page', function () {
+      cy.location('pathname').should('eq', `/flows/${this.flow.data.name}`);
+      cy.get('h2').contains('Flow Details');
+    });
+
+    it('correctly displays flow details', function () {
+      cy.get('.main-content').within(() => {
+        cy.contains('Flow configuration');
+        cy.get('pre code');
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds basic checks in Cypress to make sure the Flow page correctly renders a flow with its details