### PR TITLE
Add Cypress tests for New Flow creation

### DIFF
--- a/cypress/fixtures/pipeline.room-occupation.json
+++ b/cypress/fixtures/pipeline.room-occupation.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "description": "",
+    "name": "room-occupation",
+    "schema": {},
+    "source": "astarte_devices_source\n    .realm(${$.config.realm})\n    .amqp_exchange(${$.config.amqp_exchange})\n    .target_devices(${$.config.devices})\n| filter\n    .script(\"\"\"\n            return string.find(message.key, \"com.astarte%-platform.examples.AirSensor\") ~= nil;\n            \"\"\")\n| container\n    .image(\"docker-registry.com/occupancy-compute:latest\")\n| virtual_device_pool\n    .pairing_url(\"https://api.domain.com/pairing/v1\")\n    .realms([{realm: ${$.config.realm}, jwt: ${$.config.pairing_jwt}}])\n    .interfaces(${$.config.interfaces})"
+  }
+}

--- a/cypress/integration/new_flow_page_test.js
+++ b/cypress/integration/new_flow_page_test.js
@@ -1,0 +1,55 @@
+describe('New Flow page tests', () => {
+  context('no access before login', () => {
+    it('redirects to login', () => {
+      cy.visit('/flows/new/test-pipeline');
+      cy.location('pathname').should('eq', '/login');
+    });
+  });
+
+  context('authenticated', () => {
+    beforeEach(() => {
+      cy.fixture('flows').as('flows');
+      cy.fixture('flow.room1-occupation').as('flow');
+      cy.fixture('pipelines').as('pipelines');
+      cy.fixture('pipeline.room-occupation')
+        .as('pipeline')
+        .then((pipeline) => {
+          cy.server();
+          cy.route('GET', '/flow/v1/*/flows', '@flows');
+          cy.route('GET', '/flow/v1/*/flows/*', '@flow');
+          cy.route('GET', '/flow/v1/*/pipelines', '@pipelines');
+          cy.route('GET', '/flow/v1/*/pipelines/*', '@pipeline');
+          cy.route({
+            method: 'POST',
+            url: '/flow/v1/*/flows',
+            status: 201,
+            response: '@flow',
+          }).as('postNewFlow');
+          cy.login();
+          cy.visit(`/flows/new/${pipeline.data.name}`);
+        });
+    });
+
+    it('successfully loads New Flow page', function () {
+      cy.location('pathname').should('eq', `/flows/new/${this.pipeline.data.name}`);
+      cy.get('h2').contains('Flow Configuration');
+    });
+
+    it('correctly reports referenced pipeline', function () {
+      cy.get('.main-content').contains(this.pipeline.data.name);
+    });
+
+    it('can fill out a form to instantiate a new Flow', function () {
+      cy.get('.main-content').within(() => {
+        cy.get('button').contains('Instantiate Flow').should('be.disabled');
+        cy.get('#flowNameInput').clear().type(this.flow.data.name);
+        cy.get('#flowConfigInput')
+          .clear()
+          .type(JSON.stringify(this.flow.data.config), { parseSpecialCharSequences: false });
+        cy.get('button').contains('Instantiate Flow').click();
+        cy.wait('@postNewFlow').its('requestBody').should('deep.eq', this.flow);
+        cy.location('pathname').should('eq', '/flows');
+      });
+    });
+  });
+});

--- a/src/react/FlowConfigurationPage.jsx
+++ b/src/react/FlowConfigurationPage.jsx
@@ -70,7 +70,7 @@ export default ({ astarte, history, pipelineId }) => {
 
   const innerHTML = (
     <Form>
-      <Form.Group controlId="flow.name">
+      <Form.Group controlId="flowNameInput">
         <Form.Label>Name</Form.Label>
         <Form.Control
           type="text"
@@ -83,7 +83,7 @@ export default ({ astarte, history, pipelineId }) => {
       <p>
         <i>{pipelineId}</i>
       </p>
-      <Form.Group controlId="flow.config">
+      <Form.Group controlId="flowConfigInput">
         <Form.Label>Flow config</Form.Label>
         <Form.Control
           as="textarea"


### PR DESCRIPTION
This PR adds basic checks in Cypress to make sure the New Flow page correctly handles interactions to create a new flow