### PR TITLE
Interface.elm: good interface names may contain symbols

### DIFF
--- a/src/elm/Types/Interface.elm
+++ b/src/elm/Types/Interface.elm
@@ -450,7 +450,12 @@ isGoodInterfaceName interfaceName =
 
 isLowerCase : String -> Bool
 isLowerCase str =
-    String.all Char.isLower str
+    String.all isLowerOrSymbol str
+
+
+isLowerOrSymbol : Char -> Bool
+isLowerOrSymbol c =
+    Char.isLower c || (not <| Char.isAlpha c)
 
 
 isTitleCase : String -> Bool


### PR DESCRIPTION
Interface names are considered good names if they represent a
reverse URL notation with only the last group titlecase.
The interface name may contain symbols too.

Signed-off-by: Mattia <mattia.pavinati@ispirata.com>