### PR TITLE
Move API data handling inside Astarte Client

### DIFF
--- a/src/react/DeviceInterfaceValues.jsx
+++ b/src/react/DeviceInterfaceValues.jsx
@@ -18,7 +18,6 @@
 
 import React, { useEffect, useState } from 'react';
 import { Card, Container, Spinner, Table } from 'react-bootstrap';
-import { AstarteDevice } from 'astarte-client';
 
 import BackButton from './ui/BackButton';
 import WaitForData from './components/WaitForData';
@@ -63,17 +62,16 @@ const DeviceInterfaceValues = ({ astarte, deviceId, interfaceName }) => {
 
   useEffect(() => {
     const getInterfaceType = async () => {
-      const deviceInfos = await astarte.getDeviceInfo(deviceId).catch(() => {
+      const device = await astarte.getDeviceInfo(deviceId).catch(() => {
         throw new Error('Device not found.');
       });
-      const device = AstarteDevice.fromObject(deviceInfos.data);
       const interfaceIntrospection = device.introspection[interfaceName];
 
       if (!interfaceIntrospection) {
         throw new Error('Interface not found in device introspection.');
       }
 
-      const interfaceSrc = await astarte
+      const interface = await astarte
         .getInterface({
           interfaceName,
           interfaceMajor: interfaceIntrospection.major,
@@ -82,11 +80,9 @@ const DeviceInterfaceValues = ({ astarte, deviceId, interfaceName }) => {
           throw new Error('Could not retrieve interface properties.');
         });
 
-      const interfaceData = interfaceSrc.data;
-
-      if (interfaceData.type === 'properties') {
+      if (interface.type === 'properties') {
         setInterfaceType('properties');
-      } else if (interfaceData.type === 'datastream' && interfaceData.aggregation === 'object') {
+      } else if (interface.type === 'datastream' && interface.aggregation === 'object') {
         setInterfaceType('datastream-object');
       } else {
         setInterfaceType('datastream-individual');

--- a/src/react/DevicesPage.jsx
+++ b/src/react/DevicesPage.jsx
@@ -30,7 +30,6 @@ import {
   Tooltip,
 } from 'react-bootstrap';
 import _ from 'lodash';
-import { AstarteDevice } from 'astarte-client';
 
 import { Link } from 'react-router-dom';
 import SingleCardPage from './ui/SingleCardPage';
@@ -109,14 +108,10 @@ export default ({ astarte, history }) => {
         from: fromToken,
         limit: DEVICES_PER_REQUEST,
       })
-      .then((resp) => {
-        const nextToken = new URLSearchParams(resp.links.next).get('from_token');
-        const devices = resp.data.map((value) => AstarteDevice.fromObject(value));
+      .then(({ devices, nextToken }) => {
         setRequestToken(nextToken);
-
         setDeviceList((previousList) => {
           const updatedDeviceList = previousList.concat(devices);
-
           const pageCount = Math.ceil(updatedDeviceList.length / DEVICES_PER_PAGE);
           const shouldLoadMore = pageCount < activePage + MAX_SHOWN_PAGES || loadAllDevices;
           if (shouldLoadMore && nextToken) {
@@ -124,7 +119,6 @@ export default ({ astarte, history }) => {
           } else {
             setPhase('ok');
           }
-
           return updatedDeviceList;
         });
       })

--- a/src/react/FlowDetailsPage.jsx
+++ b/src/react/FlowDetailsPage.jsx
@@ -29,8 +29,8 @@ export default ({ astarte, flowName }) => {
   useEffect(() => {
     astarte
       .getFlowDetails(flowName)
-      .then((response) => {
-        setFlow(response.data);
+      .then((flowDetails) => {
+        setFlow(flowDetails);
         setPhase('ok');
       })
       .catch(() => {

--- a/src/react/FlowInstancesPage.jsx
+++ b/src/react/FlowInstancesPage.jsx
@@ -32,13 +32,11 @@ export default ({ astarte, history }) => {
   const deletionAlerts = useAlerts();
 
   useEffect(() => {
-    const handleInstanceResponse = (response) => {
-      const instance = response.data;
+    const handleInstanceResponse = (instance) => {
       setInstances((oldInstances) => oldInstances.concat(instance));
       setPhase('ok');
     };
-    const handleFlowResponse = (response) => {
-      const instanceNames = response.data;
+    const handleFlowResponse = (instanceNames) => {
       if (instanceNames.length === 0) {
         setInstances([]);
         setPhase('ok');

--- a/src/react/GroupDevicesPage.jsx
+++ b/src/react/GroupDevicesPage.jsx
@@ -18,7 +18,6 @@
 
 import React, { useEffect, useState, useCallback } from 'react';
 import { Button, Modal, OverlayTrigger, Spinner, Table, Tooltip } from 'react-bootstrap';
-import { AstarteDevice } from 'astarte-client';
 
 import { Link } from 'react-router-dom';
 import SingleCardPage from './ui/SingleCardPage';
@@ -109,8 +108,7 @@ const GroupDevicesPage = ({ astarte, history, groupName }) => {
   const [isRemovingDevice, setIsRemovingDevice] = useState(false);
 
   const fetchDevices = useCallback(() => {
-    const handleDevicesRequest = (response) => {
-      const newDevices = response.data.map((device) => AstarteDevice.fromObject(device));
+    const handleDevicesRequest = (newDevices) => {
       setDevices(newDevices);
       setPhase('ok');
     };

--- a/src/react/GroupsPage.jsx
+++ b/src/react/GroupsPage.jsx
@@ -19,7 +19,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Button, Spinner, Table } from 'react-bootstrap';
-import { AstarteDevice } from 'astarte-client';
 
 import SingleCardPage from './ui/SingleCardPage';
 import { useAlerts } from './AlertManager';
@@ -30,20 +29,19 @@ export default ({ astarte, history }) => {
   const pageAlerts = useAlerts();
 
   useEffect(() => {
-    const handleDeviceList = (groupName, response) => {
+    const handleDeviceList = (groupName, devices) => {
       setGroups((groupMap) => {
-        const deviceList = response.data.map((value) => AstarteDevice.fromObject(value));
         const newGroupState = groupMap.get(groupName);
         newGroupState.loading = false;
-        newGroupState.totalDevices = deviceList.length;
-        const connectedDevices = deviceList.filter((device) => device.isConnected);
+        newGroupState.totalDevices = devices.length;
+        const connectedDevices = devices.filter((device) => device.isConnected);
         newGroupState.connectedDevices = connectedDevices.length;
         groupMap.set(groupName, newGroupState);
         return new Map(groupMap);
       });
     };
-    const handleGroupsRequest = (response) => {
-      const groupMap = response.data.reduce((acc, groupName) => {
+    const handleGroupsRequest = (groupNames) => {
+      const groupMap = groupNames.reduce((acc, groupName) => {
         acc.set(groupName, { name: groupName, loading: true });
         return acc;
       }, new Map());
@@ -53,7 +51,7 @@ export default ({ astarte, history }) => {
             groupName,
             details: true,
           })
-          .then((res) => handleDeviceList(groupName, res))
+          .then((devices) => handleDeviceList(groupName, devices))
           .catch(() => {
             pageAlerts.showError(`Couldn't get the device list for group ${groupName}`);
           });

--- a/src/react/HomePage.jsx
+++ b/src/react/HomePage.jsx
@@ -58,8 +58,8 @@ export default ({ astarte, history }) => {
 
   const redirectToLastInterface = useCallback((e, interfaceName) => {
     e.preventDefault();
-    astarte.getInterfaceMajors(interfaceName).then((response) => {
-      const latestMajor = Math.max(...response.data);
+    astarte.getInterfaceMajors(interfaceName).then((interfaceMajors) => {
+      const latestMajor = Math.max(...interfaceMajors);
       history.push(`/interfaces/${interfaceName}/${latestMajor}`);
     });
   }, []);

--- a/src/react/InterfacesPage.jsx
+++ b/src/react/InterfacesPage.jsx
@@ -52,12 +52,12 @@ export default ({ history, astarte }) => {
     astarte
       .getInterfaceNames()
       .then((result) => {
-        const interfaceNames = result.data.sort();
+        const interfaceNames = result.sort();
         return Promise.all(
           interfaceNames.map((interfaceName) =>
-            astarte.getInterfaceMajors(interfaceName).then(({ data }) => ({
+            astarte.getInterfaceMajors(interfaceName).then((interfaceMajors) => ({
               name: interfaceName,
-              majors: data.sort().reverse(),
+              majors: interfaceMajors.sort().reverse(),
             })),
           ),
         );

--- a/src/react/NewGroupPage.jsx
+++ b/src/react/NewGroupPage.jsx
@@ -18,7 +18,6 @@
 
 import React, { useEffect, useState } from 'react';
 import { Button, Form, InputGroup, Spinner } from 'react-bootstrap';
-import { AstarteDevice } from 'astarte-client';
 
 import { useAlerts } from './AlertManager';
 import SingleCardPage from './ui/SingleCardPage';
@@ -35,8 +34,7 @@ export default ({ astarte, history }) => {
 
   useEffect(() => {
     const handleDevicesRequest = (response) => {
-      const deviceList = response.data.map((value) => AstarteDevice.fromObject(value));
-      setDevices(deviceList);
+      setDevices(response.devices);
       setPhase('ok');
     };
     const handleDevicesError = () => {

--- a/src/react/PipelineSourcePage.jsx
+++ b/src/react/PipelineSourcePage.jsx
@@ -34,8 +34,8 @@ export default ({ astarte, history, pipelineId }) => {
   const deletionAlerts = useAlerts();
 
   useEffect(() => {
-    const handlePipelineResponse = (response) => {
-      setPipeline(response.data);
+    const handlePipelineResponse = (pipelineDetails) => {
+      setPipeline(pipelineDetails);
       setPhase('ok');
     };
     const handlePipelineError = () => {

--- a/src/react/PipelinesPage.jsx
+++ b/src/react/PipelinesPage.jsx
@@ -25,8 +25,7 @@ export default ({ astarte, history }) => {
   const [pipelines, setPipelines] = useState(null);
 
   useEffect(() => {
-    const handlePipelinesResponse = (response) => {
-      const pipelineList = response.data;
+    const handlePipelinesResponse = (pipelineList) => {
       const promiseList = pipelineList.map((pipelineName) =>
         astarte.getPipelineInputConfig(pipelineName),
       );
@@ -34,7 +33,7 @@ export default ({ astarte, history }) => {
         const pipelineData = [];
         result.forEach((pipelineResult) => {
           if (pipelineResult.status === 'fulfilled') {
-            pipelineData.push(pipelineResult.value.data);
+            pipelineData.push(pipelineResult.value);
           }
         });
         setPipelines(pipelineData);

--- a/src/react/RealmSettingsPage.jsx
+++ b/src/react/RealmSettingsPage.jsx
@@ -51,8 +51,8 @@ export default ({ astarte, history }) => {
   useEffect(() => {
     astarte
       .getConfigAuth()
-      .then((response) => {
-        const publicKey = response.data.jwt_public_key_pem;
+      .then((config) => {
+        const publicKey = config.jwt_public_key_pem;
         setUserPublicKey(publicKey);
         setDraftPublicKey(publicKey);
         setPhase('ok');

--- a/src/react/RegisterDevicePage.jsx
+++ b/src/react/RegisterDevicePage.jsx
@@ -282,8 +282,8 @@ const RegisterDevicePage = ({ astarte, history }) => {
 
     astarte
       .registerDevice(params)
-      .then((response) => {
-        const secret = response.data.credentials_secret;
+      .then((registeredDevice) => {
+        const secret = registeredDevice.credentials_secret;
         setRegisteringDevice(false);
         setDeviceSecret(secret);
         setShowCredentialSecretModal(true);

--- a/src/react/TriggersPage.jsx
+++ b/src/react/TriggersPage.jsx
@@ -36,7 +36,7 @@ const LoadingRow = () => (
 
 export default ({ history, astarte }) => {
   const [triggers, setTriggers] = useState(null);
-  const fetchTriggers = () => astarte.getTriggerNames().then((result) => setTriggers(result.data));
+  const fetchTriggers = () => astarte.getTriggerNames().then(setTriggers);
 
   useEffect(() => {
     fetchTriggers();

--- a/src/react/components/WaitForData.ts
+++ b/src/react/components/WaitForData.ts
@@ -16,7 +16,21 @@
    limitations under the License.
 */
 
-const WaitForData = ({ data, status, showRefreshing = false, fallback, children }) => {
+interface Props<Data> {
+  data: Data;
+  status: 'loading' | 'ok' | 'err';
+  showRefreshing?: boolean;
+  fallback?: React.ReactElement;
+  children: (data: Data) => React.ReactElement;
+}
+
+const WaitForData = <Data = any>({
+  data,
+  status,
+  showRefreshing = false,
+  fallback,
+  children,
+}: Props<Data>): React.ReactElement | null => {
   switch (status) {
     case 'ok':
       return children(data);


### PR DESCRIPTION
This PR moves the logic needed to parse backend API's results inside the Astarte Client, so that React views won't be concerned about implementation details and will get objects easier to consume.