### PR TITLE
Add a typescript Interface model in Astarte Client

### DIFF
--- a/src/astarte-client/index.ts
+++ b/src/astarte-client/index.ts
@@ -22,6 +22,7 @@ export {
   AstarteCustomBlock,
   AstarteNativeBlock,
   AstarteDevice,
+  AstarteMapping,
   AstarteRealm,
   AstarteToken,
 } from './models';

--- a/src/astarte-client/index.ts
+++ b/src/astarte-client/index.ts
@@ -22,6 +22,7 @@ export {
   AstarteCustomBlock,
   AstarteNativeBlock,
   AstarteDevice,
+  AstarteInterface,
   AstarteMapping,
   AstarteRealm,
   AstarteToken,

--- a/src/astarte-client/models/Interface/index.ts
+++ b/src/astarte-client/models/Interface/index.ts
@@ -1,0 +1,63 @@
+/* eslint-disable max-classes-per-file */
+/*
+   This file is part of Astarte.
+
+   Copyright 2020 Ispirata Srl
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import { AstarteMapping } from '../Mapping';
+import { AstarteInterfaceDTO } from '../../types';
+
+export class AstarteInterface {
+  name: string;
+
+  major: number;
+
+  minor: number;
+
+  type: 'properties' | 'datastream';
+
+  ownership: 'device' | 'server';
+
+  aggregation?: 'individual' | 'object';
+
+  description?: string;
+
+  documentation?: string;
+
+  mappings: AstarteMapping[];
+
+  constructor(iface: AstarteInterfaceDTO) {
+    this.name = iface.interface_name;
+    this.major = iface.version_major;
+    this.minor = iface.version_minor;
+    this.type = iface.type;
+    this.ownership = iface.ownership;
+    if (iface.type === 'datastream') {
+      this.aggregation = iface.aggregation;
+    }
+    if (iface.description) {
+      this.description = iface.description;
+    }
+    if (iface.doc) {
+      this.documentation = iface.doc;
+    }
+    this.mappings = iface.mappings.map((mapping) => AstarteMapping.fromObject(mapping));
+  }
+
+  static fromObject(dto: AstarteInterfaceDTO): AstarteInterface {
+    return new AstarteInterface(dto);
+  }
+}

--- a/src/astarte-client/models/Mapping/index.ts
+++ b/src/astarte-client/models/Mapping/index.ts
@@ -1,0 +1,93 @@
+/*
+   This file is part of Astarte.
+
+   Copyright 2020 Ispirata Srl
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import { AstarteMappingDTO } from '../../types';
+
+export class AstarteMapping {
+  endpoint: string;
+
+  type:
+    | 'double'
+    | 'integer'
+    | 'boolean'
+    | 'longinteger'
+    | 'string'
+    | 'binaryblob'
+    | 'datetime'
+    | 'doublearray'
+    | 'integerarray'
+    | 'booleanarray'
+    | 'longintegerarray'
+    | 'stringarray'
+    | 'binaryblobarray'
+    | 'datetimearray';
+
+  reliability?: 'unreliable' | 'guaranteed' | 'unique';
+
+  retention?: 'discard' | 'volatile' | 'stored';
+
+  expiry?: number;
+
+  databaseRetentionPolicy?: 'no_ttl' | 'use_ttl';
+
+  databaseRetentionTtl?: number;
+
+  allowUnset?: boolean;
+
+  explicitTimestamp?: boolean;
+
+  description?: string;
+
+  documentation?: string;
+
+  constructor(mapping: AstarteMappingDTO) {
+    this.endpoint = mapping.endpoint;
+    this.type = mapping.type;
+    if (mapping.reliability != null) {
+      this.reliability = mapping.reliability;
+    }
+    if (mapping.retention != null) {
+      this.retention = mapping.retention;
+    }
+    if (mapping.expiry != null) {
+      this.expiry = mapping.expiry;
+    }
+    if (mapping.database_retention_policy != null) {
+      this.databaseRetentionPolicy = mapping.database_retention_policy;
+    }
+    if (mapping.database_retention_ttl != null) {
+      this.databaseRetentionTtl = mapping.database_retention_ttl;
+    }
+    if (mapping.allow_unset != null) {
+      this.allowUnset = mapping.allow_unset;
+    }
+    if (mapping.explicit_timestamp != null) {
+      this.explicitTimestamp = mapping.explicit_timestamp;
+    }
+    if (mapping.description != null) {
+      this.description = mapping.description;
+    }
+    if (mapping.doc != null) {
+      this.documentation = mapping.doc;
+    }
+  }
+
+  static fromObject(dto: AstarteMappingDTO): AstarteMapping {
+    return new AstarteMapping(dto);
+  }
+}

--- a/src/astarte-client/models/index.ts
+++ b/src/astarte-client/models/index.ts
@@ -20,3 +20,4 @@ export * from './Block';
 export * from './Realm';
 export * from './Token';
 export * from './Device';
+export * from './Mapping';

--- a/src/astarte-client/models/index.ts
+++ b/src/astarte-client/models/index.ts
@@ -21,3 +21,4 @@ export * from './Realm';
 export * from './Token';
 export * from './Device';
 export * from './Mapping';
+export * from './Interface';

--- a/src/astarte-client/types/dto/index.ts
+++ b/src/astarte-client/types/dto/index.ts
@@ -20,3 +20,4 @@ export type { AstarteBlockDTO } from './block.d';
 export type { AstarteCustomBlockDTO } from './customBlock.d';
 export type { AstarteNativeBlockDTO } from './nativeBlock.d';
 export type { AstarteDeviceDTO } from './device.d';
+export type { AstarteMappingDTO } from './mapping.d';

--- a/src/astarte-client/types/dto/index.ts
+++ b/src/astarte-client/types/dto/index.ts
@@ -21,3 +21,4 @@ export type { AstarteCustomBlockDTO } from './customBlock.d';
 export type { AstarteNativeBlockDTO } from './nativeBlock.d';
 export type { AstarteDeviceDTO } from './device.d';
 export type { AstarteMappingDTO } from './mapping.d';
+export type { AstarteInterfaceDTO } from './interface.d';

--- a/src/astarte-client/types/dto/interface.d.ts
+++ b/src/astarte-client/types/dto/interface.d.ts
@@ -1,0 +1,45 @@
+/*
+   This file is part of Astarte.
+
+   Copyright 2020 Ispirata Srl
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+/* eslint camelcase: 0 */
+
+import type { AstarteMappingDTO } from './mapping';
+
+interface AstartePropertiesInterfaceDTO {
+  interface_name: string;
+  version_major: number;
+  version_minor: number;
+  type: 'properties';
+  ownership: 'device' | 'server';
+  description?: string;
+  doc?: string;
+  mappings: AstarteMappingDTO[];
+}
+
+interface AstarteDatastreamInterfaceDTO {
+  interface_name: string;
+  version_major: number;
+  version_minor: number;
+  type: 'datastream';
+  ownership: 'device' | 'server';
+  aggregation: 'individual' | 'object';
+  description?: string;
+  doc?: string;
+  mappings: AstarteMappingDTO[];
+}
+
+export type AstarteInterfaceDTO = AstartePropertiesInterfaceDTO | AstarteDatastreamInterfaceDTO;

--- a/src/astarte-client/types/dto/mapping.d.ts
+++ b/src/astarte-client/types/dto/mapping.d.ts
@@ -1,0 +1,46 @@
+/*
+   This file is part of Astarte.
+
+   Copyright 2020 Ispirata Srl
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+/* eslint camelcase: 0 */
+
+export interface AstarteMappingDTO {
+  endpoint: string;
+  type:
+    | 'double'
+    | 'integer'
+    | 'boolean'
+    | 'longinteger'
+    | 'string'
+    | 'binaryblob'
+    | 'datetime'
+    | 'doublearray'
+    | 'integerarray'
+    | 'booleanarray'
+    | 'longintegerarray'
+    | 'stringarray'
+    | 'binaryblobarray'
+    | 'datetimearray';
+  reliability?: 'unreliable' | 'guaranteed' | 'unique';
+  retention?: 'discard' | 'volatile' | 'stored';
+  expiry?: number;
+  database_retention_policy?: 'no_ttl' | 'use_ttl';
+  database_retention_ttl?: number;
+  allow_unset?: boolean;
+  explicit_timestamp?: boolean;
+  description?: string;
+  doc?: string;
+}


### PR DESCRIPTION
This PR adds an Interface model in Astarte Client to wrap interfaces data in a suitable form for a javascript app. In doing so,
a related Mapping model is introduced too.