### PR TITLE
Add typescript Flow model

### DIFF
--- a/src/astarte-client/models/Flow/index.ts
+++ b/src/astarte-client/models/Flow/index.ts
@@ -16,17 +16,26 @@
    limitations under the License.
 */
 
-import AstarteClient from './client';
+import { AstarteFlowDTO } from '../../types';
 
-export {
-  AstarteCustomBlock,
-  AstarteNativeBlock,
-  AstarteDevice,
-  AstarteFlow,
-  AstarteRealm,
-  AstarteToken,
-} from './models';
+export class AstarteFlow {
+  name: string;
 
-export type { AstarteBlock } from './models';
+  pipeline: string;
 
-export default AstarteClient;
+  config?: {
+    [key: string]: any;
+  };
+
+  constructor(flow: AstarteFlowDTO) {
+    this.name = flow.name;
+    this.pipeline = flow.pipeline;
+    if (flow.config != null) {
+      this.config = flow.config;
+    }
+  }
+
+  static fromObject(dto: AstarteFlowDTO): AstarteFlow {
+    return new AstarteFlow(dto);
+  }
+}

--- a/src/astarte-client/models/index.ts
+++ b/src/astarte-client/models/index.ts
@@ -20,3 +20,4 @@ export * from './Block';
 export * from './Realm';
 export * from './Token';
 export * from './Device';
+export * from './Flow';

--- a/src/astarte-client/types/dto/flow.d.ts
+++ b/src/astarte-client/types/dto/flow.d.ts
@@ -16,17 +16,12 @@
    limitations under the License.
 */
 
-import AstarteClient from './client';
+export interface AstarteFlowDTO {
+  name: string;
 
-export {
-  AstarteCustomBlock,
-  AstarteNativeBlock,
-  AstarteDevice,
-  AstarteFlow,
-  AstarteRealm,
-  AstarteToken,
-} from './models';
+  pipeline: string;
 
-export type { AstarteBlock } from './models';
-
-export default AstarteClient;
+  config?: {
+    [key: string]: unknown;
+  };
+}

--- a/src/astarte-client/types/dto/index.ts
+++ b/src/astarte-client/types/dto/index.ts
@@ -20,3 +20,4 @@ export type { AstarteBlockDTO } from './block.d';
 export type { AstarteCustomBlockDTO } from './customBlock.d';
 export type { AstarteNativeBlockDTO } from './nativeBlock.d';
 export type { AstarteDeviceDTO } from './device.d';
+export type { AstarteFlowDTO } from './flow.d';


### PR DESCRIPTION
This PR adds a typescript Flow model in Astarte Client to better type-check entities handled by the client's APIs.