### PR TITLE
Add typescript Pipeline model

### DIFF
--- a/src/astarte-client/models/Pipeline/index.ts
+++ b/src/astarte-client/models/Pipeline/index.ts
@@ -16,18 +16,27 @@
    limitations under the License.
 */
 
-import AstarteClient from './client';
+import { AstartePipelineDTO } from '../../types';
 
-export {
-  AstarteCustomBlock,
-  AstarteNativeBlock,
-  AstarteDevice,
-  AstarteFlow,
-  AstartePipeline,
-  AstarteRealm,
-  AstarteToken,
-} from './models';
+export class AstartePipeline {
+  name: string;
 
-export type { AstarteBlock } from './models';
+  description: string;
 
-export default AstarteClient;
+  schema: {
+    [key: string]: any;
+  };
+
+  source: string;
+
+  constructor(pipeline: AstartePipelineDTO) {
+    this.name = pipeline.name;
+    this.description = pipeline.description;
+    this.schema = pipeline.schema;
+    this.source = pipeline.source;
+  }
+
+  static fromObject(dto: AstartePipelineDTO): AstartePipeline {
+    return new AstartePipeline(dto);
+  }
+}

--- a/src/astarte-client/models/index.ts
+++ b/src/astarte-client/models/index.ts
@@ -21,3 +21,4 @@ export * from './Realm';
 export * from './Token';
 export * from './Device';
 export * from './Flow';
+export * from './Pipeline';

--- a/src/astarte-client/types/dto/index.ts
+++ b/src/astarte-client/types/dto/index.ts
@@ -21,3 +21,4 @@ export type { AstarteCustomBlockDTO } from './customBlock.d';
 export type { AstarteNativeBlockDTO } from './nativeBlock.d';
 export type { AstarteDeviceDTO } from './device.d';
 export type { AstarteFlowDTO } from './flow.d';
+export type { AstartePipelineDTO } from './pipeline.d';

--- a/src/astarte-client/types/dto/pipeline.d.ts
+++ b/src/astarte-client/types/dto/pipeline.d.ts
@@ -16,18 +16,11 @@
    limitations under the License.
 */
 
-import AstarteClient from './client';
-
-export {
-  AstarteCustomBlock,
-  AstarteNativeBlock,
-  AstarteDevice,
-  AstarteFlow,
-  AstartePipeline,
-  AstarteRealm,
-  AstarteToken,
-} from './models';
-
-export type { AstarteBlock } from './models';
-
-export default AstarteClient;
+export interface AstartePipelineDTO {
+  name: string;
+  description: string;
+  schema: {
+    [key: string]: unknown;
+  };
+  source: string;
+}


### PR DESCRIPTION
This PR adds a typescript Pipeline model in Astarte Client to better type-check entities handled by the client's APIs.