### PR TITLE
main.scss: fix device pie chart on Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [0.11.4] - Unreleased
+### Fixed
+- Device sent bytes pie chart now showing up on Chrome browser.
 
 ## [0.11.3] - 2020-09-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.4] - Unreleased
+
 ## [0.11.3] - 2020-09-24
 ### Added
 - Label for property unset in device live events page.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "astarte-dashboard",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astarte-dashboard",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Astarte dashboard",
   "main": "public/index.html",
   "keywords": [

--- a/src/elm/Page/Device.elm
+++ b/src/elm/Page/Device.elm
@@ -592,6 +592,7 @@ deviceStatsCard device width =
                     [ Flex.block
                     , Flex.justifyCenter
                     , Flex.wrapReverse
+                    , class "align-content-end"
                     ]
                 ]
                 [ PieChart.view chartParams

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -130,6 +130,7 @@ $never-connected-color: #101010;
 
 .device-data-piechart {
     max-height: 20em;
+    height: 100%;
 }
 
 .square {


### PR DESCRIPTION
By default chrome renders the chart with minimum height,
setting height to 100% makes it expand as much as it is allowed.

Signed-off-by: Mattia Pavinati <mattia.pavinati@ispirata.com>