### PR TITLE
Add Cypress tests for interactions in Device page

### DIFF
--- a/cypress/fixtures/device_detailed.json
+++ b/cypress/fixtures/device_detailed.json
@@ -12,26 +12,26 @@
       "com.example.ExampleInterface": {
         "major": 2,
         "minor": 0,
-        "exchanged_msgs": 20,
-        "exchanged_bytes": 200
+        "exchanged_msgs": 3,
+        "exchanged_bytes": 42
       },
       "test.astarte.AggregatedObjectInterface": {
         "major": 1,
         "minor": 0,
-        "exchanged_msgs": 3,
-        "exchanged_bytes": 42
+        "exchanged_msgs": 3000,
+        "exchanged_bytes": 42000
       },
       "test.astarte.IndividualObjectInterface": {
         "major": 1,
         "minor": 0,
-        "exchanged_msgs": 3,
-        "exchanged_bytes": 42
+        "exchanged_msgs": 3000000,
+        "exchanged_bytes": 42000000
       },
       "test.astarte.PropertiesInterface": {
         "major": 1,
         "minor": 0,
-        "exchanged_msgs": 3,
-        "exchanged_bytes": 42
+        "exchanged_msgs": 3000000000,
+        "exchanged_bytes": 42000000000
       }
     },
     "connected": true,
@@ -42,8 +42,8 @@
     "last_seen_ip": "198.51.100.81",
     "credentials_inhibited": true,
     "last_credentials_request_ip": "98.51.100.89",
-    "total_received_bytes": 10240,
-    "total_received_msgs": 10,
+    "total_received_bytes": 45000000000,
+    "total_received_msgs": 4000000000,
     "groups": ["test-devices", "first-floor"],
     "previous_interfaces": [
       {

--- a/cypress/integration/device_page_test.js
+++ b/cypress/integration/device_page_test.js
@@ -14,18 +14,21 @@ describe('Device page tests', () => {
     beforeEach(() => {
       cy.fixture('device').as('device');
       cy.fixture('device_detailed').as('deviceDetailed');
+      cy.login();
     });
 
     it('successfully loads Device page', function () {
       cy.server();
       cy.route('GET', '/appengine/v1/*/devices/*', '@device');
-      cy.login();
       cy.visit(`/devices/${this.device.data.id}`);
       cy.location('pathname').should('eq', `/devices/${this.device.data.id}`);
       cy.get('h2').contains('Device');
     });
 
     it('displays correct properties for a device', function () {
+      cy.server();
+      cy.route('GET', '/appengine/v1/*/devices/*', '@device');
+      cy.visit(`/devices/${this.device.data.id}`);
       cy.get('.main-content').within(() => {
         cy.contains('Device Info')
           .next()
@@ -34,30 +37,30 @@ describe('Device page tests', () => {
             cy.contains('Device name').next().contains('No name alias set');
             cy.contains('Status').next().contains('Never connected');
             cy.contains('Credentials inhibited').next().contains('False');
-            cy.contains('Inhibit credentials').should('not.be.disabled');
+            cy.contains('Inhibit credentials').should('exist').and('not.be.disabled');
             cy.contains('Enable credentials request').should('not.exist');
-            cy.contains('Wipe credential secret').should('not.be.disabled');
+            cy.contains('Wipe credential secret').should('exist').and('not.be.disabled');
           });
 
         cy.contains('Aliases')
           .next()
           .within(() => {
             cy.contains('Device has no aliases');
-            cy.contains('Add new alias').should('not.be.disabled');
+            cy.contains('Add new alias').should('exist').and('not.be.disabled');
           });
 
         cy.contains('Metadata')
           .next()
           .within(() => {
             cy.contains('Device has no metadata');
-            cy.contains('Add new item').should('not.be.disabled');
+            cy.contains('Add new item').should('exist').and('not.be.disabled');
           });
 
         cy.contains('Groups')
           .next()
           .within(() => {
             cy.contains('Device does not belong to any group');
-            cy.contains('Add to existing group').should('not.be.disabled');
+            cy.contains('Add to existing group').should('exist').and('not.be.disabled');
           });
 
         cy.contains('Interfaces')
@@ -83,13 +86,15 @@ describe('Device page tests', () => {
     it('successfully loads Device page for a detailed device', function () {
       cy.server();
       cy.route('GET', '/appengine/v1/*/devices/*', '@deviceDetailed');
-      cy.login();
       cy.visit(`/devices/${this.deviceDetailed.data.id}`);
       cy.location('pathname').should('eq', `/devices/${this.deviceDetailed.data.id}`);
       cy.get('h2').contains('Device');
     });
 
     it('displays correct properties for a detailed device', function () {
+      cy.server();
+      cy.route('GET', '/appengine/v1/*/devices/*', '@deviceDetailed');
+      cy.visit(`/devices/${this.deviceDetailed.data.id}`);
       cy.get('.main-content').within(() => {
         cy.contains('Device Info')
           .next()
@@ -127,7 +132,7 @@ describe('Device page tests', () => {
           .next()
           .within(() => {
             this.deviceDetailed.data.groups.forEach((group) => {
-              cy.contains(group);
+              cy.contains(group).should('have.attr', 'href', `/groups/${group}`);
             });
             cy.contains('Add to existing group').should('not.be.disabled');
           });
@@ -168,6 +173,9 @@ describe('Device page tests', () => {
     });
 
     it('correctly opens the groups modal when adding to new group', function () {
+      cy.server();
+      cy.route('GET', '/appengine/v1/*/devices/*', '@deviceDetailed');
+      cy.visit(`/devices/${this.deviceDetailed.data.id}`);
       cy.get('.main-content').within(() => {
         cy.get('.card-header')
           .contains('Groups')

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,3 +1,5 @@
+import websocketMock from './websocket';
+
 // This hook runs before each test of every test suite
 // So this query will be already mocked in every test
 beforeEach(() => {
@@ -56,5 +58,29 @@ Cypress.Commands.add('moveOnto', { prevSubject: 'element' }, (subject, targetSel
       .trigger('mousedown', { button: 0 }, { force: true })
       .trigger('mousemove', diffX, diffY, { force: true });
     cy.wrap(target.get(0)).trigger('mouseup', { force: true });
+  });
+});
+
+Cypress.Commands.add('mockWebSocket', ({ url }) => {
+  cy.on('window:before:load', (win) => {
+    websocketMock.injectMock(win, url);
+  });
+});
+
+Cypress.Commands.add('sendWebSocketDeviceConnected', ({ deviceId, deviceIpAddress }) => {
+  cy.window().then((win) => {
+    websocketMock.sendDeviceConnected(win, { deviceId, deviceIpAddress });
+  });
+});
+
+Cypress.Commands.add('sendWebSocketDeviceDisconnected', ({ deviceId }) => {
+  cy.window().then((win) => {
+    websocketMock.sendDeviceDisconnected(win, { deviceId });
+  });
+});
+
+Cypress.Commands.add('sendWebSocketDeviceEvent', ({ deviceId, event }) => {
+  cy.window().then((win) => {
+    websocketMock.sendDeviceEvent(win, { deviceId, event });
   });
 });

--- a/cypress/support/websocket.js
+++ b/cypress/support/websocket.js
@@ -1,0 +1,127 @@
+import { WebSocket, Server } from 'mock-socket';
+
+const CHANNEL_EVENTS = {
+  close: 'phx_close',
+  error: 'phx_error',
+  join: 'phx_join',
+  reply: 'phx_reply',
+  leave: 'phx_leave',
+};
+
+const CHANNEL_CUSTOM_EVENTS = {
+  watch: 'watch',
+  watchAdded: 'watch_added',
+  newEvent: 'new_event',
+};
+
+const decodeMessage = (messageString) => {
+  const [joinRef, ref, topic, event, payload] = JSON.parse(messageString);
+  return { joinRef, ref, topic, event, payload };
+};
+
+const encodeMessage = (message) => {
+  const { joinRef, ref, topic, event, payload } = message;
+  return JSON.stringify([joinRef, ref, topic, event, payload]);
+};
+
+const computeMessageAck = (message) => {
+  const { joinRef, ref, topic } = message;
+  const messageAck = {
+    joinRef,
+    ref,
+    topic,
+    event: CHANNEL_EVENTS.reply,
+    payload: { response: {}, status: 'ok' },
+  };
+  return messageAck;
+};
+
+const computeMessageReply = (message) => {
+  const { topic, event, payload } = message;
+  switch (event) {
+    case CHANNEL_CUSTOM_EVENTS.watch:
+      return {
+        joinRef: null,
+        ref: null,
+        topic,
+        event: CHANNEL_CUSTOM_EVENTS.watchAdded,
+        payload,
+      };
+    default:
+      return null;
+  }
+};
+
+const generateDeviceMessage = (context, { deviceId, event }) => {
+  if (!context.currentTopic || !deviceId || !event) {
+    return null;
+  }
+  const message = {
+    joinRef: null,
+    ref: null,
+    topic: context.currentTopic,
+    event: CHANNEL_CUSTOM_EVENTS.newEvent,
+    payload: {
+      device_id: deviceId,
+      event,
+      timestamp: new Date().toISOString(),
+    },
+  };
+  return message;
+};
+
+const sendMessage = (context, message) => {
+  if (!message || !context.mockedSocket) {
+    return;
+  }
+  context.mockedSocket.send(encodeMessage(message));
+};
+
+const injectMock = (context, url) => {
+  if (!url) {
+    return;
+  }
+  context.WebSocket = WebSocket;
+  if (context.mockedServer) {
+    context.mockedServer.stop();
+    context.mockedServer = null;
+    context.mockedSocket = null;
+    context.currentTopic = null;
+  }
+  context.mockedServer = new Server(url);
+  context.mockedServer.on('connection', (socket) => {
+    context.mockedSocket = socket;
+    context.mockedSocket.on('message', (messageString) => {
+      const message = decodeMessage(messageString);
+      context.currentTopic = message.topic;
+      const messageAck = computeMessageAck(message);
+      const messageReply = computeMessageReply(message);
+      sendMessage(context, messageAck);
+      sendMessage(context, messageReply);
+    });
+  });
+};
+
+const sendDeviceConnected = (context, { deviceId, deviceIpAddress }) => {
+  const event = { device_ip_address: deviceIpAddress || '1.1.1.1', type: 'device_connected' };
+  const message = generateDeviceMessage(context, { deviceId, event });
+  sendMessage(context, message);
+};
+
+const sendDeviceDisconnected = (context, { deviceId }) => {
+  const event = { type: 'device_disconnected' };
+  const message = generateDeviceMessage(context, { deviceId, event });
+  sendMessage(context, message);
+};
+
+const sendDeviceEvent = (context, { deviceId, event }) => {
+  const message = generateDeviceMessage(context, { deviceId, event });
+  sendMessage(context, message);
+};
+
+export default {
+  injectMock,
+  sendDeviceConnected,
+  sendDeviceDisconnected,
+  sendDeviceEvent,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9203,6 +9203,15 @@
         "ml-array-rescale": "^1.3.1"
       }
     },
+    "mock-socket": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.0.3.tgz",
+      "integrity": "sha512-SxIiD2yE/By79p3cNAAXyLQWTvEFNEzcAO7PH+DzRqKSFaplAPFjiQLmw8ofmpCsZf+Rhfn2/xCJagpdGmYdTw==",
+      "dev": true,
+      "requires": {
+        "url-parse": "^1.4.4"
+      }
+    },
     "moment": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "html-webpack-plugin": "^4.3.0",
     "mini-css-extract-plugin": "^0.9.0",
     "minimist": "^1.2.5",
+    "mock-socket": "^9.0.3",
     "node-sass": "^4.14.1",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "popper.js": "^1.16.0",


### PR DESCRIPTION
This PR adds more specific Cypress tests on supported info and interactions for the Device page, such as:
- managing credentials
- managing aliases
- managing metadata
- managing inclusions in groups
- correct rendering of device stats
- correct handling and displaying of live device messages