### PR TITLE
Enhance Device model type and validation

### DIFF
--- a/src/astarte-client/client.ts
+++ b/src/astarte-client/client.ts
@@ -21,6 +21,7 @@ import { Socket as PhoenixSocket } from 'phoenix';
 import _ from 'lodash';
 
 import {
+  fromAstarteDeviceDTO,
   fromAstarteInterfaceDTO,
   fromAstartePipelineDTO,
   toAstartePipelineDTO,
@@ -304,16 +305,14 @@ class AstarteClient {
     }
     endpointUri.search = new URLSearchParams(query).toString();
     const response = await this.$get(endpointUri.toString());
-    const devices = response.data.map((device: AstarteDeviceDTO) =>
-      AstarteDevice.fromObject(device),
-    );
+    const devices = response.data.map((device: AstarteDeviceDTO) => fromAstarteDeviceDTO(device));
     const nextToken = new URLSearchParams(response.links.next).get('from_token');
     return { devices, nextToken };
   }
 
   async getDeviceInfo(deviceId: AstarteDevice['id']): Promise<AstarteDevice> {
     const response = await this.$get(this.apiConfig.deviceInfo({ deviceId, ...this.config }));
-    return AstarteDevice.fromObject(response.data);
+    return fromAstarteDeviceDTO(response.data);
   }
 
   async getDeviceData(params: {
@@ -367,7 +366,7 @@ class AstarteClient {
       endpointUri.search = new URLSearchParams({ details: 'true' }).toString();
     }
     const response = await this.$get(endpointUri.toString());
-    return response.data.map((device: AstarteDeviceDTO) => AstarteDevice.fromObject(device));
+    return response.data.map((device: AstarteDeviceDTO) => fromAstarteDeviceDTO(device));
   }
 
   async removeDeviceFromGroup(params: { groupName: string; deviceId: string }): Promise<void> {

--- a/src/astarte-client/transforms/device.ts
+++ b/src/astarte-client/transforms/device.ts
@@ -1,0 +1,97 @@
+/*
+   This file is part of Astarte.
+   Copyright 2020 Ispirata Srl
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import _ from 'lodash';
+
+import { AstarteDevice } from '../models/Device';
+
+import type { AstarteDeviceInterfaceStats } from '../models/Device';
+import type { AstarteDeviceDTO } from '../types';
+
+const fromInterfaceStatsDTO = (iface: any): AstarteDeviceInterfaceStats => {
+  return {
+    name: iface.name,
+    major: iface.major,
+    minor: iface.minor,
+    exchangedMessages: iface.exchanged_msgs,
+    exchangedBytes: iface.exchanged_bytes,
+  };
+};
+
+const toInterfaceStatsDTO = (iface: AstarteDeviceInterfaceStats) => {
+  return {
+    name: iface.name,
+    major: iface.major,
+    minor: iface.minor,
+    exchanged_msgs: iface.exchangedMessages,
+    exchanged_bytes: iface.exchangedBytes,
+  };
+};
+
+export const fromAstarteDeviceDTO = (dto: AstarteDeviceDTO): AstarteDevice => {
+  return new AstarteDevice({
+    id: dto.id,
+    isConnected: !!dto.connected,
+    hasCredentialsInhibited: !!dto.credentials_inhibited,
+    aliases: new Map(Object.entries(dto.aliases || {})),
+    groups: dto.groups || [],
+    introspection: new Map(
+      Object.entries(dto.introspection || {}).map(([interfaceName, iface]) => [
+        interfaceName,
+        fromInterfaceStatsDTO({ name: interfaceName, ...iface }),
+      ]),
+    ),
+    metadata: new Map(Object.entries(dto.metadata || {})),
+    totalReceivedMessages: dto.total_received_msgs || 0,
+    totalReceivedBytes: dto.total_received_bytes || 0,
+    previousInterfaces: (dto.previous_interfaces || []).map(fromInterfaceStatsDTO),
+    firstRegistration:
+      dto.first_registration != null ? new Date(dto.first_registration) : undefined,
+    firstCredentialsRequest:
+      dto.first_credentials_request != null ? new Date(dto.first_credentials_request) : undefined,
+    lastDisconnection:
+      dto.last_disconnection != null ? new Date(dto.last_disconnection) : undefined,
+    lastConnection: dto.last_connection != null ? new Date(dto.last_connection) : undefined,
+    lastSeenIp: dto.last_seen_ip != null ? dto.last_seen_ip : undefined,
+    lastCredentialsRequestIp:
+      dto.last_credentials_request_ip != null ? dto.last_credentials_request_ip : undefined,
+  });
+};
+
+export const toAstarteDeviceDTO = (obj: AstarteDevice): AstarteDeviceDTO => {
+  return {
+    id: obj.id,
+    connected: !!obj.isConnected,
+    credentials_inhibited: !!obj.hasCredentialsInhibited,
+    aliases: Object.fromEntries(obj.aliases),
+    groups: obj.groups || [],
+    introspection: _.mapValues(Object.fromEntries(obj.introspection), (iface) =>
+      toInterfaceStatsDTO(iface),
+    ),
+    metadata: Object.fromEntries(obj.metadata),
+    total_received_msgs: obj.totalReceivedMessages || 0,
+    total_received_bytes: obj.totalReceivedBytes || 0,
+    previous_interfaces: (obj.previousInterfaces || []).map(toInterfaceStatsDTO),
+    first_registration:
+      obj.firstRegistration != null ? obj.firstRegistration.toISOString() : undefined,
+    first_credentials_request:
+      obj.firstCredentialsRequest != null ? obj.firstCredentialsRequest.toISOString() : undefined,
+    last_disconnection:
+      obj.lastDisconnection != null ? obj.lastDisconnection.toISOString() : undefined,
+    last_connection: obj.lastConnection != null ? obj.lastConnection.toISOString() : undefined,
+    last_seen_ip: obj.lastSeenIp != null ? obj.lastSeenIp : undefined,
+    last_credentials_request_ip:
+      obj.lastCredentialsRequestIp != null ? obj.lastCredentialsRequestIp : undefined,
+  };
+};

--- a/src/astarte-client/transforms/index.ts
+++ b/src/astarte-client/transforms/index.ts
@@ -16,6 +16,7 @@
    limitations under the License.
 */
 
+export * from './device';
 export * from './pipeline';
 export * from './interface';
 export * from './mapping';

--- a/src/astarte-client/types/dto/device.d.ts
+++ b/src/astarte-client/types/dto/device.d.ts
@@ -48,8 +48,8 @@ export interface AstarteDeviceDTO {
   groups?: string[];
   previous_interfaces?: Array<{
     name: string;
-    major: string;
-    minor: string;
+    major: number;
+    minor: number;
     exchanged_msgs?: number;
     exchanged_bytes?: number;
   }>;

--- a/src/react/DeviceInterfaceValues.tsx
+++ b/src/react/DeviceInterfaceValues.tsx
@@ -273,7 +273,7 @@ export default ({ astarte, deviceId, interfaceName }: Props): React.ReactElement
       const device = await astarte.getDeviceInfo(deviceId).catch(() => {
         throw new Error('Device not found.');
       });
-      const interfaceIntrospection = device.introspection[interfaceName];
+      const interfaceIntrospection = device.introspection.get(interfaceName);
       if (!interfaceIntrospection) {
         throw new Error('Interface not found in device introspection.');
       }


### PR DESCRIPTION
This PR reworks the typescript Device model, clearly separating concerns regarding modeling, validation and encoding/decoding.
This way:
- Encoding/decoding happens inside AstarteClient
- A clean Device model is exposed from AstarteClient, which automatically validates data upon class instantiation
- Optionally expose utility functions from AstarteClient to validate data against the Device model