### PR TITLE
Open groups modal when adding device to existing group

### DIFF
--- a/cypress/integration/device_page_test.js
+++ b/cypress/integration/device_page_test.js
@@ -166,5 +166,17 @@ describe('Device page tests', () => {
         cy.contains('Device Live Events');
       });
     });
+
+    it('correctly opens the groups modal when adding to new group', function () {
+      cy.get('.main-content').within(() => {
+        cy.get('.card-header')
+          .contains('Groups')
+          .parents('.card')
+          .within(() => {
+            cy.contains('Add to existing group').click();
+          });
+        cy.get('.modal').contains('Select Existing Group');
+      });
+    });
   });
 });

--- a/src/elm/Page/Device.elm
+++ b/src/elm/Page/Device.elm
@@ -1214,7 +1214,7 @@ deviceGroupsCard device showAddToGroup width =
         [ renderGroups device.groups ]
         [ Button.button
             [ Button.primary
-            , Button.onClick OpenNewMetadataPopup
+            , Button.onClick OpenGroupsPopup
             ]
             [ Html.text "Add to existing group" ]
         ]


### PR DESCRIPTION
This PR fixes a wrong behavior on the Device page where a wrong modal was shown when clicking on the `Add to existing group` button.
A Cypress test is also added to ensure the correct Groups modal is shown instead.