### PR TITLE
Move New Interface page from Elm to React

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Major rework for the Interface Editor.
+
 ## [1.0.0-beta.1] - Unreleased
 ### Added
 - Support device groups in device triggers.

--- a/cypress/fixtures/test.astarte.NoDefaultsInterface.json
+++ b/cypress/fixtures/test.astarte.NoDefaultsInterface.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "interface_name": "test.astarte.NoDefaultsInterface",
+    "version_major": 2,
+    "version_minor": 2,
+    "type": "datastream",
+    "ownership": "device",
+    "aggregation": "object",
+    "description": "Interface description",
+    "doc": "Interface documentation",
+    "mappings": [
+      {
+        "endpoint": "/objects/boolean",
+        "type": "boolean",
+        "reliability": "guaranteed",
+        "retention": "volatile",
+        "expiry": 120,
+        "database_retention_policy": "use_ttl",
+        "database_retention_ttl": 120,
+        "explicit_timestamp": true
+      },
+      {
+        "endpoint": "/objects/string",
+        "type": "string",
+        "reliability": "guaranteed",
+        "retention": "volatile",
+        "expiry": 120,
+        "database_retention_policy": "use_ttl",
+        "database_retention_ttl": 120,
+        "explicit_timestamp": true,
+        "description": "Mapping description",
+        "doc": "Mapping documentation"
+      }
+    ]
+  }
+}

--- a/cypress/fixtures/test.astarte.SpecifiedDefaultsInterface.json
+++ b/cypress/fixtures/test.astarte.SpecifiedDefaultsInterface.json
@@ -1,0 +1,34 @@
+{
+  "data": {
+    "interface_name": "test.astarte.SpecifiedDefaultsInterface",
+    "version_major": 0,
+    "version_minor": 1,
+    "type": "datastream",
+    "ownership": "device",
+    "aggregation": "individual",
+    "description": "Interface description",
+    "doc": "Interface documentation",
+    "mappings": [
+      {
+        "endpoint": "/objects/boolean",
+        "type": "boolean",
+        "reliability": "unreliable",
+        "retention": "discard",
+        "database_retention_policy": "no_ttl",
+        "explicit_timestamp": false
+      },
+      {
+        "endpoint": "/objects/string",
+        "type": "string",
+        "reliability": "unreliable",
+        "retention": "volatile",
+        "expiry": 0,
+        "database_retention_policy": "use_ttl",
+        "database_retention_ttl": 60,
+        "explicit_timestamp": false,
+        "description": "Mapping description",
+        "doc": "Mapping documentation"
+      }
+    ]
+  }
+}

--- a/cypress/integration/interface_builder_test.js
+++ b/cypress/integration/interface_builder_test.js
@@ -563,15 +563,16 @@ describe('Interface builder tests', () => {
         cy.get('#interfaceName').should('not.have.class', 'is-invalid');
         cy.get('#interfaceName')
           .parents('.form-group')
-          .get('i.fa-exclamation-circle')
-          .should('be.visible');
+          .get('.warning-feedback')
+          .should('be.visible')
+          .and('not.empty');
 
         // Valid name
         cy.get('#interfaceName').clear().type('com.sample.Name');
         cy.get('#interfaceName').should('not.have.class', 'is-invalid');
         cy.get('#interfaceName')
           .parents('.form-group')
-          .get('i.fa-exclamation-circle')
+          .get('.warning-feedback')
           .should('not.be.visible');
       });
 

--- a/cypress/integration/interface_builder_test.js
+++ b/cypress/integration/interface_builder_test.js
@@ -1,3 +1,293 @@
+const _ = require('lodash');
+
+const parseMappingOptions = (mapping) => {
+  return {
+    reliability: _.get(mapping, 'reliability', 'unreliable'),
+    explicitTimestamp: _.get(mapping, 'explicit_timestamp', false),
+    retention: _.get(mapping, 'retention', 'discard'),
+    expiry: _.get(mapping, 'expiry', 0),
+    databaseRetention: _.get(mapping, 'database_retention_policy', 'no_ttl'),
+    databaseTTL: _.get(mapping, 'database_retention_ttl'),
+    allowUnset: _.get(mapping, 'allow_unset', false),
+  };
+};
+
+const setupInterfaceEditorFromSource = (iface) => {
+  cy.get('#interfaceSource')
+    .clear()
+    .type(JSON.stringify(iface), { parseSpecialCharSequences: false });
+  cy.wait(500);
+};
+
+const setupInterfaceEditorFromUI = (iface) => {
+  cy.get('#interfaceName').scrollIntoView().clear().type(iface.interface_name);
+  if (iface.version_major > 0) {
+    cy.get('#interfaceMajor').scrollIntoView().type(`{selectall}${iface.version_major}`);
+    cy.get('#interfaceMinor').scrollIntoView().type(`{selectall}${iface.version_minor}`);
+  } else {
+    cy.get('#interfaceMinor').scrollIntoView().type(`{selectall}${iface.version_minor}`);
+    cy.get('#interfaceMajor').scrollIntoView().type(`{selectall}${iface.version_major}`);
+  }
+  if (iface.ownership === 'server') {
+    cy.get('#interfaceOwnershipServer').scrollIntoView().check();
+  } else {
+    cy.get('#interfaceOwnershipDevice').scrollIntoView().check();
+  }
+  if (iface.type === 'properties') {
+    cy.get('#interfaceTypeProperties').scrollIntoView().scrollIntoView().check();
+  } else {
+    cy.get('#interfaceTypeDatastream').scrollIntoView().check();
+    if (iface.aggregation === 'object') {
+      cy.get('#interfaceAggregationObject').scrollIntoView().check();
+    } else {
+      cy.get('#interfaceAggregationIndividual').scrollIntoView().check();
+    }
+  }
+  if (iface.aggregation === 'object') {
+    const {
+      reliability,
+      explicitTimestamp,
+      retention,
+      expiry,
+      databaseRetention,
+      databaseTTL,
+    } = parseMappingOptions(_.get(iface.mappings, '0'));
+    cy.get('#objectMappingReliability').scrollIntoView().select(reliability);
+    if (explicitTimestamp) {
+      cy.get('#objectMappingExplicitTimestamp').scrollIntoView().check();
+    } else {
+      cy.get('#objectMappingExplicitTimestamp').scrollIntoView().uncheck();
+    }
+    cy.get('#objectMappingRetention').scrollIntoView().select(retention);
+    cy.get('#objectMappingDatabaseRetention').scrollIntoView().select(databaseRetention);
+    if (retention !== 'discard') {
+      cy.get('#objectMappingExpiry').scrollIntoView().type(`{selectall}${expiry}`);
+    }
+    if (databaseRetention !== 'no_ttl') {
+      cy.get('#objectMappingTTL').scrollIntoView().type(`{selectall}${databaseTTL}`);
+    }
+  }
+  cy.get('#interfaceDescription').scrollIntoView().clear();
+  if (iface.description) {
+    cy.get('#interfaceDescription')
+      .scrollIntoView()
+      .type(iface.description, { parseSpecialCharSequences: false });
+  }
+  cy.get('#interfaceDocumentation').scrollIntoView().clear();
+  if (iface.doc) {
+    cy.get('#interfaceDocumentation')
+      .scrollIntoView()
+      .type(iface.doc, { parseSpecialCharSequences: false });
+  }
+  (iface.mappings || []).forEach((mapping) => {
+    cy.get('button').contains('Add new mapping...').click();
+    cy.get('.modal.show').within(() => {
+      cy.get('#mappingEndpoint')
+        .scrollIntoView()
+        .clear()
+        .type(mapping.endpoint, { parseSpecialCharSequences: false });
+      cy.get('#mappingType').scrollIntoView().select(mapping.type);
+      cy.get('#mappingDescription').scrollIntoView().clear();
+      if (mapping.description) {
+        cy.get('#mappingDescription').scrollIntoView().type(mapping.description, {
+          parseSpecialCharSequences: false,
+        });
+      }
+      cy.get('#mappingDocumentation').scrollIntoView().clear();
+      if (mapping.doc) {
+        cy.get('#mappingDocumentation')
+          .scrollIntoView()
+          .type(mapping.doc, { parseSpecialCharSequences: false });
+      }
+      const {
+        reliability,
+        explicitTimestamp,
+        retention,
+        expiry,
+        databaseRetention,
+        databaseTTL,
+        allowUnset,
+      } = parseMappingOptions(mapping);
+      if (iface.type === 'properties') {
+        if (allowUnset) {
+          cy.get('#mappingAllowUnset').scrollIntoView().check();
+        } else {
+          cy.get('#mappingAllowUnset').scrollIntoView().uncheck();
+        }
+      } else if (iface.type === 'datastream' && iface.aggregation !== 'object') {
+        cy.get('#mappingReliability').scrollIntoView().select(reliability);
+        cy.get('#mappingRetention').scrollIntoView().select(retention);
+        cy.get('#mappingDatabaseRetention').scrollIntoView().select(databaseRetention);
+        if (explicitTimestamp) {
+          cy.get('#mappingExplicitTimestamp').scrollIntoView().check();
+        } else {
+          cy.get('#mappingExplicitTimestamp').scrollIntoView().uncheck();
+        }
+        if (retention !== 'discard') {
+          cy.get('#mappingExpiry').scrollIntoView().type(`{selectall}${expiry}`);
+        }
+        if (databaseRetention !== 'no_ttl') {
+          cy.get('#mappingTTL').scrollIntoView().type(`{selectall}${databaseTTL}`);
+        }
+      }
+      cy.get('button').contains('Confirm').click();
+    });
+  });
+};
+
+const checkMappingEditorUIValues = ({ mapping, type, aggregation = 'individual' }) => {
+  cy.get('.card button')
+    .contains(mapping.endpoint)
+    .scrollIntoView()
+    .should('be.visible')
+    .parents('.card')
+    .within(() => {
+      cy.get('button').contains('Edit...').click();
+    });
+  cy.get('.modal.show').within(() => {
+    cy.get('#mappingEndpoint')
+      .scrollIntoView()
+      .should('be.visible')
+      .and('have.value', mapping.endpoint);
+    cy.get('#mappingType').scrollIntoView().should('be.visible').and('have.value', mapping.type);
+    cy.get('#mappingDescription')
+      .scrollIntoView()
+      .should('be.visible')
+      .and('have.value', mapping.description || '');
+    cy.get('#mappingDocumentation')
+      .scrollIntoView()
+      .should('be.visible')
+      .and('have.value', mapping.doc || '');
+    const {
+      reliability,
+      explicitTimestamp,
+      retention,
+      expiry,
+      databaseRetention,
+      databaseTTL,
+      allowUnset,
+    } = parseMappingOptions(mapping);
+    if (type === 'properties') {
+      cy.get('#mappingAllowUnset')
+        .scrollIntoView()
+        .should('be.visible')
+        .and(allowUnset ? 'be.checked' : 'not.be.checked');
+    } else if (type === 'datastream' && aggregation !== 'object') {
+      cy.get('#mappingReliability')
+        .scrollIntoView()
+        .should('be.visible')
+        .and('have.value', reliability || 'unreliable');
+      cy.get('#mappingRetention')
+        .scrollIntoView()
+        .should('be.visible')
+        .and('have.value', retention || 'discard');
+      cy.get('#mappingDatabaseRetention')
+        .scrollIntoView()
+        .should('be.visible')
+        .and('have.value', databaseRetention || 'no_ttl');
+      cy.get('#mappingExplicitTimestamp')
+        .scrollIntoView()
+        .should('be.visible')
+        .and(explicitTimestamp ? 'be.checked' : 'not.be.checked');
+      if (retention !== 'discard') {
+        cy.get('#mappingExpiry')
+          .scrollIntoView()
+          .should('be.visible')
+          .and('have.value', expiry || 0);
+      }
+      if (databaseRetention !== 'no_ttl') {
+        cy.get('#mappingTTL')
+          .scrollIntoView()
+          .should('be.visible')
+          .and('have.value', databaseTTL || 60);
+      }
+    }
+    cy.get('button').contains('Cancel').click();
+  });
+};
+
+const checkInterfaceEditorUIValues = (iface) => {
+  cy.get('#interfaceName')
+    .scrollIntoView()
+    .should('be.visible')
+    .and('have.value', iface.interface_name);
+  cy.get('#interfaceMajor')
+    .scrollIntoView()
+    .should('be.visible')
+    .and('have.value', iface.version_major);
+  cy.get('#interfaceMinor')
+    .scrollIntoView()
+    .should('be.visible')
+    .and('have.value', iface.version_minor);
+  cy.get('#interfaceDescription')
+    .scrollIntoView()
+    .should('be.visible')
+    .and('have.value', iface.description || '');
+  cy.get('#interfaceDocumentation')
+    .scrollIntoView()
+    .should('be.visible')
+    .and('have.value', iface.doc || '');
+  if (iface.ownership === 'server') {
+    cy.get('#interfaceOwnershipServer').scrollIntoView().should('be.visible').and('be.checked');
+  } else {
+    cy.get('#interfaceOwnershipDevice').scrollIntoView().should('be.visible').and('be.checked');
+  }
+  if (iface.type === 'properties') {
+    cy.get('#interfaceTypeProperties').scrollIntoView().should('be.visible').and('be.checked');
+  } else {
+    cy.get('#interfaceTypeDatastream').scrollIntoView().should('be.visible').and('be.checked');
+    if (iface.aggregation === 'object') {
+      cy.get('#interfaceAggregationObject').scrollIntoView().should('be.visible').and('be.checked');
+    } else {
+      cy.get('#interfaceAggregationIndividual')
+        .scrollIntoView()
+        .should('be.visible')
+        .and('be.checked');
+    }
+  }
+  if (iface.aggregation === 'object') {
+    const {
+      reliability,
+      explicitTimestamp,
+      retention,
+      expiry,
+      databaseRetention,
+      databaseTTL,
+    } = parseMappingOptions(_.get(iface.mappings, '0'));
+    cy.get('#objectMappingReliability')
+      .scrollIntoView()
+      .should('be.visible')
+      .and('have.value', reliability || 'unreliable');
+    cy.get('#objectMappingExplicitTimestamp')
+      .scrollIntoView()
+      .should('be.visible')
+      .and(explicitTimestamp ? 'be.checked' : 'not.be.checked');
+    cy.get('#objectMappingRetention')
+      .scrollIntoView()
+      .should('be.visible')
+      .and('have.value', retention || 'discard');
+    cy.get('#objectMappingDatabaseRetention')
+      .scrollIntoView()
+      .should('be.visible')
+      .and('have.value', databaseRetention || 'no_ttl');
+    if (retention !== 'discard') {
+      cy.get('#objectMappingExpiry')
+        .scrollIntoView()
+        .should('be.visible')
+        .and('have.value', expiry || 0);
+    }
+    if (databaseRetention !== 'no_ttl') {
+      cy.get('#objectMappingTTL')
+        .scrollIntoView()
+        .should('be.visible')
+        .and('have.value', databaseTTL || 60);
+    }
+  }
+  (iface.mappings || []).forEach((mapping) => {
+    cy.get('.card button').contains(mapping.endpoint).scrollIntoView().should('be.visible');
+  });
+};
+
 describe('Interface builder tests', () => {
   context('no access before login', () => {
     it('redirects to login', () => {
@@ -12,50 +302,626 @@ describe('Interface builder tests', () => {
   context('authenticated', () => {
     beforeEach(() => {
       cy.login();
-
-      cy.fixture('test.astarte.FirstInterface').as('test_interface');
-      cy.server();
-      cy.route('GET', '/realmmanagement/v1/*/interfaces/*/*', '@test_interface');
-      cy.wait(200);
     });
 
-    it('loads empty builder', () => {
-      cy.visit('/interfaces/new');
-      cy.location('pathname').should('eq', '/interfaces/new');
-      cy.get('#interfaceName').should('have.value', '');
+    context('new interface page', () => {
+      beforeEach(() => {
+        cy.visit('/interfaces/new');
+      });
 
-      // default interface version should be 0.1
-      cy.get('#interfaceMajor').should('have.value', '0');
-      cy.get('#interfaceMinor').should('have.value', '1');
+      it('successfully loads New Interface page', function () {
+        cy.location('pathname').should('eq', '/interfaces/new');
+        cy.get('.main-content h2').contains('Interface Editor');
+      });
+
+      it('has a Hide button to toggle Interface Source visibility', () => {
+        cy.get('#interfaceSource').scrollIntoView().should('be.visible');
+        cy.get('button').contains('Hide source').scrollIntoView().click();
+        cy.get('#interfaceSource').should('not.be.visible');
+        cy.get('button').contains('Show source').scrollIntoView().click();
+        cy.get('#interfaceSource').scrollIntoView().should('be.visible');
+      });
+
+      it('correctly displays default and disabled options', () => {
+        cy.get('label[for="interfaceName"]').contains('Name');
+        cy.get('#interfaceName').should('be.enabled').and('be.empty');
+        // default interface version should be 0.1
+        cy.get('label[for="interfaceMajor"]').contains('Major');
+        cy.get('#interfaceMajor').should('be.enabled').and('have.value', '0');
+        cy.get('label[for="interfaceMinor"]').contains('Minor');
+        cy.get('#interfaceMinor').should('be.enabled').and('have.value', '1');
+        cy.get('label[for="interfaceTypeDatastream"]').contains('Datastream');
+        cy.get('#interfaceTypeDatastream').should('be.enabled').and('not.be.checked');
+        cy.get('label[for="interfaceTypeProperties"]').contains('Properties');
+        cy.get('#interfaceTypeProperties').should('be.enabled').and('be.checked');
+        cy.get('label[for="interfaceAggregationIndividual"]').contains('Individual');
+        cy.get('#interfaceAggregationIndividual').should('be.disabled');
+        cy.get('label[for="interfaceAggregationObject"]').contains('Object');
+        cy.get('#interfaceAggregationObject').should('be.disabled');
+        cy.get('label[for="interfaceOwnershipDevice"]').contains('Device');
+        cy.get('#interfaceOwnershipDevice').should('be.enabled').and('be.checked');
+        cy.get('label[for="interfaceOwnershipServer"]').contains('Server');
+        cy.get('#interfaceOwnershipServer').should('be.enabled').and('not.be.checked');
+        cy.get('label[for="interfaceDescription"]').contains('Description');
+        cy.get('#interfaceDescription').should('be.enabled').and('be.empty');
+        cy.get('label[for="interfaceDocumentation"]').contains('Documentation');
+        cy.get('#interfaceDocumentation').should('be.enabled').and('be.empty');
+        cy.get('button').contains('Add new mapping...');
+
+        // Select Datastream type
+        cy.get('label').contains('Datastream').click();
+        cy.get('#interfaceAggregationIndividual').should('be.enabled').and('be.checked');
+        cy.get('#interfaceAggregationObject').should('be.enabled').and('not.be.checked');
+
+        // Select Object type
+        cy.get('label').contains('Object').click();
+
+        cy.get('label[for="objectMappingReliability"]').contains('Reliability');
+        cy.get('#objectMappingReliability').should('be.enabled').and('have.value', 'unreliable');
+        cy.get('label[for="objectMappingExplicitTimestamp"]').contains('Explicit timestamp');
+        cy.get('#objectMappingExplicitTimestamp').should('be.enabled').and('be.checked');
+        cy.get('label[for="objectMappingRetention"]').contains('Retention');
+        cy.get('#objectMappingRetention').should('be.enabled').and('have.value', 'discard');
+        cy.get('label[for="objectMappingDatabaseRetention"]').contains('Database Retention');
+        cy.get('#objectMappingDatabaseRetention').should('be.enabled').and('have.value', 'no_ttl');
+
+        // Select Volatile retention
+        cy.get('#objectMappingRetention').select('volatile');
+
+        cy.get('label[for="objectMappingExpiry"]').contains('Expiry');
+        cy.get('#objectMappingExpiry').should('be.enabled').and('have.value', '0');
+
+        // Select use_ttl database retention
+        cy.get('#objectMappingDatabaseRetention').select('use_ttl');
+
+        cy.get('label[for="objectMappingTTL"]').contains('TTL');
+        cy.get('#objectMappingTTL').should('be.enabled').and('have.value', '60');
+      });
+
+      it('displays correct Mapping editor depending on interface type', () => {
+        // Properties interface
+        cy.get('label').contains('Properties').click();
+        cy.get('button').contains('Add new mapping...').click();
+        cy.get('.modal.show').within(() => {
+          cy.get('.modal-header').contains('Add new mapping');
+          cy.get('label[for="mappingEndpoint"]').contains('Endpoint');
+          cy.get('#mappingEndpoint').should('be.enabled').and('be.empty');
+          cy.get('label[for="mappingType"]').contains('Type');
+          cy.get('#mappingType').should('be.enabled').and('have.value', 'double');
+          cy.get('label[for="mappingAllowUnset"]').contains('Allow unset');
+          cy.get('#mappingAllowUnset').should('be.enabled').and('not.be.checked');
+          cy.get('label[for="mappingDescription"]').contains('Description');
+          cy.get('#mappingDescription').should('be.enabled').and('be.empty');
+          cy.get('label[for="mappingDocumentation"]').contains('Documentation');
+          cy.get('#mappingDocumentation').should('be.enabled').and('be.empty');
+          cy.get('button').contains('Confirm').should('be.disabled');
+          cy.get('button').contains('Cancel').click();
+        });
+
+        // Datastream Object interface
+        cy.get('label').contains('Datastream').click();
+        cy.get('label').contains('Object').click();
+        cy.get('button').contains('Add new mapping...').click();
+        cy.get('.modal.show').within(() => {
+          cy.get('.modal-header').contains('Add new mapping');
+          cy.get('label[for="mappingEndpoint"]').contains('Endpoint');
+          cy.get('#mappingEndpoint').should('be.enabled').and('be.empty');
+          cy.get('label[for="mappingType"]').contains('Type');
+          cy.get('#mappingType').should('be.enabled').and('have.value', 'double');
+          cy.get('label[for="mappingDescription"]').contains('Description');
+          cy.get('#mappingDescription').should('be.enabled').and('be.empty');
+          cy.get('label[for="mappingDocumentation"]').contains('Documentation');
+          cy.get('#mappingDocumentation').should('be.enabled').and('be.empty');
+          cy.get('button').contains('Confirm').should('be.disabled');
+          cy.get('button').contains('Cancel').click();
+        });
+
+        // Datastream Individual interface
+        cy.get('label').contains('Datastream').click();
+        cy.get('label').contains('Individual').click();
+        cy.get('button').contains('Add new mapping...').click();
+        cy.get('.modal.show').within(() => {
+          cy.get('.modal-header').contains('Add new mapping');
+          cy.get('label[for="mappingEndpoint"]').contains('Endpoint');
+          cy.get('#mappingEndpoint').should('be.enabled').and('be.empty');
+          cy.get('label[for="mappingType"]').contains('Type');
+          cy.get('#mappingType').should('be.enabled').and('have.value', 'double');
+          cy.get('label[for="mappingReliability"]').contains('Reliability');
+          cy.get('#mappingReliability').should('be.enabled').and('have.value', 'unreliable');
+          cy.get('label[for="mappingRetention"]').contains('Retention');
+          cy.get('#mappingRetention').should('be.enabled').and('have.value', 'discard');
+          cy.get('label[for="mappingDatabaseRetention"]').contains('Database retention');
+          cy.get('#mappingDatabaseRetention').should('be.enabled').and('have.value', 'no_ttl');
+          cy.get('label[for="mappingExplicitTimestamp"]').contains('Explicit timestamp');
+          cy.get('#mappingExplicitTimestamp').should('be.enabled').and('be.checked');
+          cy.get('label[for="mappingDescription"]').contains('Description');
+          cy.get('#mappingDescription').should('be.enabled').and('be.empty');
+          cy.get('label[for="mappingDocumentation"]').contains('Documentation');
+          cy.get('#mappingDocumentation').should('be.enabled').and('be.empty');
+
+          // Select Volatile retention
+          cy.get('#mappingRetention').select('volatile');
+          cy.get('label[for="mappingExpiry"]').contains('Expiry');
+          cy.get('#mappingExpiry').should('be.enabled').and('have.value', '0');
+
+          // Select use_ttl database retention
+          cy.get('#mappingDatabaseRetention').select('use_ttl');
+          cy.get('label[for="mappingTTL"]').contains('TTL');
+          cy.get('#mappingTTL').should('be.enabled').and('have.value', '60');
+
+          cy.get('button').contains('Confirm').should('be.disabled');
+          cy.get('button').contains('Cancel').click();
+        });
+      });
+
+      it('can add, edit and remove mappings', () => {
+        const mappingEndpoint = '/mapping_endpoint';
+
+        // Add new mapping
+        cy.get('button').contains('Add new mapping...').click();
+        cy.get('.modal.show').within(() => {
+          cy.get('.modal-header').contains('Add new mapping');
+          cy.get('#mappingEndpoint').type(mappingEndpoint);
+          cy.get('#mappingType').select('double');
+          cy.get('button').contains('Confirm').click();
+        });
+        cy.get('button')
+          .contains(mappingEndpoint)
+          .parents('.card')
+          .within(() => {
+            cy.get('.badge').contains('double');
+          });
+
+        // Edit mapping
+        cy.get('button')
+          .contains(mappingEndpoint)
+          .parents('.card')
+          .within(() => {
+            cy.get('button').contains('Edit...').click();
+          });
+        cy.get('.modal.show').within(() => {
+          cy.get('.modal-header').contains('Edit mapping');
+          cy.get('#mappingType').select('string');
+          cy.get('button').contains('Confirm').click();
+        });
+        cy.get('button')
+          .contains(mappingEndpoint)
+          .parents('.card')
+          .within(() => {
+            cy.get('.badge').contains('string');
+          });
+
+        // Remove mapping
+        cy.get('button')
+          .contains(mappingEndpoint)
+          .parents('.card')
+          .within(() => {
+            cy.get('button').contains('Remove').click();
+          });
+        cy.get('button').contains(mappingEndpoint).should('not.exist');
+      });
+
+      it('shows the correct confirmation modal before installing the interface', () => {
+        const interfaceName = 'com.samples.Interface';
+
+        // Set name
+        cy.get('#interfaceName').type(interfaceName);
+
+        // Set draft version
+        cy.get('#interfaceMinor').type('{selectall}1');
+        cy.get('#interfaceMajor').type('{selectall}0');
+
+        // Add mapping
+        cy.get('button').contains('Add new mapping...').click();
+        cy.get('.modal.show').within(() => {
+          cy.get('.modal-header').contains('Add new mapping');
+          cy.get('#mappingEndpoint').type('/enpdoint');
+          cy.get('button').contains('Confirm').click();
+        });
+
+        // Modal confirmation for draft version
+        cy.get('button').contains('Install interface').click();
+        cy.get('.modal.show').within(() => {
+          cy.get('.modal-header').contains('Confirmation Required');
+          cy.contains(`You are about to install the interface ${interfaceName}.`);
+          cy.contains(
+            'As its major version is 0, this is a draft interface, which can be deleted.',
+          );
+          cy.contains('In such a case, any data sent through this interface will be lost.');
+          cy.contains('Draft Interfaces should be used for development and testing purposes only.');
+          cy.contains('Are you sure you want to continue?');
+          cy.get('button').contains('Cancel').click();
+        });
+
+        // Set major version
+        cy.get('#interfaceMajor').type('{selectall}1');
+
+        // Modal confirmation for major version
+        cy.get('button').contains('Install interface').click();
+        cy.get('.modal.show').within(() => {
+          cy.get('.modal-header').contains('Confirmation Required');
+          cy.contains(`You are about to install the interface ${interfaceName}.`);
+          cy.contains(
+            'Interface major is greater than zero, that means you will not be able to change already installed mappings.',
+          );
+          cy.contains('Are you sure you want to continue?');
+          cy.get('button').contains('Cancel').click();
+        });
+      });
+
+      it('correctly reports errors and warning for the interface name property', () => {
+        // Empty name
+        cy.get('#interfaceName').clear();
+        cy.get('#interfaceName').should('have.class', 'is-invalid');
+
+        // Invalid name
+        cy.get('#interfaceName').type('invalid_name!');
+        cy.get('#interfaceName').should('have.class', 'is-invalid');
+
+        // Valid but poor name
+        cy.get('#interfaceName').clear().type('name');
+        cy.get('#interfaceName').should('not.have.class', 'is-invalid');
+        cy.get('#interfaceName')
+          .parents('.form-group')
+          .get('i.fa-exclamation-circle')
+          .should('be.visible');
+
+        // Valid name
+        cy.get('#interfaceName').clear().type('com.sample.Name');
+        cy.get('#interfaceName').should('not.have.class', 'is-invalid');
+        cy.get('#interfaceName')
+          .parents('.form-group')
+          .get('i.fa-exclamation-circle')
+          .should('not.be.visible');
+      });
+
+      it('correctly reports errors in mapping editor for the endpoint field', () => {
+        cy.get('button').contains('Add new mapping...').click();
+        cy.get('.modal.show').within(() => {
+          cy.get('#mappingEndpoint').clear();
+          cy.get('#mappingEndpoint').should('have.class', 'is-invalid');
+          cy.get('#mappingEndpoint').type('invalid_endpoint!');
+          cy.get('#mappingEndpoint').should('have.class', 'is-invalid');
+          cy.get('#mappingEndpoint').clear().type('/valid_endpoint');
+          cy.get('#mappingEndpoint').should('not.have.class', 'is-invalid');
+        });
+      });
+
+      it('correctly loads interface from its source', () => {
+        const interfaceFixtures = [
+          'test.astarte.NoDefaultsInterface',
+          'test.astarte.PropertiesInterface',
+          'test.astarte.IndividualObjectInterface',
+          'test.astarte.AggregatedObjectInterface',
+        ];
+        interfaceFixtures.forEach((interfaceFixture) => {
+          cy.fixture(interfaceFixture).then(({ data: iface }) => {
+            setupInterfaceEditorFromSource(iface);
+            checkInterfaceEditorUIValues(iface);
+          });
+        });
+      });
+
+      it('can correctly build an interface with the UI', () => {
+        const interfaceFixtures = [
+          'test.astarte.NoDefaultsInterface',
+          'test.astarte.PropertiesInterface',
+          'test.astarte.IndividualObjectInterface',
+          'test.astarte.AggregatedObjectInterface',
+        ];
+        interfaceFixtures.forEach((interfaceFixture) => {
+          cy.fixture(interfaceFixture).then(({ data: iface }) => {
+            setupInterfaceEditorFromUI(iface);
+            checkInterfaceEditorUIValues(iface);
+            (iface.mappings || []).forEach((mapping) => {
+              checkMappingEditorUIValues({
+                mapping,
+                type: iface.type,
+                aggregation: iface.aggregation,
+              });
+            });
+          });
+        });
+      });
+
+      it('redirects to list of interfaces after a new interface installation', () => {
+        cy.fixture('test.astarte.PropertiesInterface').then((interfaceFixture) => {
+          cy.route({
+            method: 'POST',
+            url: '/realmmanagement/v1/*/interfaces',
+            status: 201,
+            response: interfaceFixture,
+          }).as('installInterfaceRequest');
+          setupInterfaceEditorFromUI(interfaceFixture.data);
+          cy.get('button').contains('Install interface').click();
+          cy.get('.modal.show button').contains('Confirm').click();
+          cy.wait('@installInterfaceRequest')
+            .its('requestBody.data')
+            .should('deep.eq', interfaceFixture.data);
+          cy.location('pathname').should('eq', '/interfaces');
+        });
+      });
     });
 
-    it('shows selected interface', function() {
-      const testInterfaceName = this.test_interface.data.interface_name;
-      const testInterfaceMajor = this.test_interface.data.version_major;
-      const testInterfaceMinor = this.test_interface.data.version_minor;
-      cy.visit(`/interfaces/${testInterfaceName}/${testInterfaceMajor}`);
-      cy.location('pathname').should('eq', `/interfaces/${testInterfaceName}/${testInterfaceMajor}`);
+    context('edit interface page', () => {
+      it('correctly loads interface data into the Editor UI', () => {
+        const interfaceFixtures = [
+          'test.astarte.NoDefaultsInterface',
+          'test.astarte.PropertiesInterface',
+          'test.astarte.IndividualObjectInterface',
+          'test.astarte.AggregatedObjectInterface',
+        ];
+        interfaceFixtures.forEach((interfaceFixture) => {
+          cy.fixture(interfaceFixture).then(({ data: iface }) => {
+            cy.route(
+              'GET',
+              `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+              { data: iface },
+            );
+            cy.visit(`/interfaces/${iface.interface_name}/${iface.version_major}`);
+            cy.location('pathname').should(
+              'eq',
+              `/interfaces/${iface.interface_name}/${iface.version_major}`,
+            );
+            checkInterfaceEditorUIValues(iface);
+          });
+        });
+      });
 
-      cy.get('#interfaceName').should('have.value', testInterfaceName);
-      cy.get('#interfaceMajor').should('have.value', testInterfaceMajor).and('have.attr', 'readonly');
-      cy.get('#interfaceMinor').should('have.value', testInterfaceMinor);
-    });
+      it('correctly displays fields as disabled to prevent breaking changes from being made', function () {
+        cy.fixture('test.astarte.NoDefaultsInterface').then(({ data: iface }) => {
+          cy.route(
+            'GET',
+            `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+            { data: iface },
+          );
+          cy.visit(`/interfaces/${iface.interface_name}/${iface.version_major}`);
+          cy.get('#interfaceName').should('have.attr', 'readonly');
+          cy.get('#interfaceMajor').should('have.attr', 'readonly');
+          cy.get('#interfaceTypeDatastream').should('be.disabled');
+          cy.get('#interfaceTypeProperties').should('be.disabled');
+          cy.get('#interfaceAggregationIndividual').should('be.disabled');
+          cy.get('#interfaceAggregationObject').should('be.disabled');
+          cy.get('#interfaceOwnershipDevice').should('be.disabled');
+          cy.get('#interfaceOwnershipServer').should('be.disabled');
+          cy.get('#objectMappingReliability').should('be.disabled');
+          cy.get('#objectMappingExplicitTimestamp').should('be.disabled');
+          cy.get('#objectMappingRetention').should('be.disabled');
+          cy.get('#objectMappingExpiry').should('be.disabled');
+          cy.get('#objectMappingDatabaseRetention').should('be.disabled');
+          cy.get('#objectMappingTTL').should('be.disabled');
+          cy.get('.card button')
+            .contains(iface.mappings[0].endpoint)
+            .should('exist')
+            .parents('.card')
+            .within(() => {
+              cy.get('button').contains('Edit...').should('not.exist');
+              cy.get('button').contains('Remove').should('not.exist');
+            });
+        });
+      });
 
-    it('redirects to list of interfaces after a new interface installation', function () {
-      cy.route({
-        method: 'POST',
-        url: '/realmmanagement/v1/*/interfaces',
-        status: 201,
-        response: '@test_interface',
-      }).as('installInterfaceRequest');
-      cy.visit('/interfaces/new');
-      cy.get('#interfaceSource')
-        .clear()
-        .type(JSON.stringify(this.test_interface.data), { parseSpecialCharSequences: false });
-      cy.get('button').contains('Install interface').click();
-      cy.get('.modal.show button').contains('Confirm').click();
-      cy.location('pathname').should('eq', '/interfaces');
-      cy.get('h2').contains('Interfaces');
+      it('can add, edit and remove new mappings', function () {
+        cy.fixture('test.astarte.NoDefaultsInterface').then(({ data: iface }) => {
+          cy.route(
+            'GET',
+            `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+            { data: iface },
+          );
+          cy.visit(`/interfaces/${iface.interface_name}/${iface.version_major}`);
+
+          const mappingEndpoint = '/new_mapping_endpoint';
+
+          // Add new mapping
+          cy.get('button').contains('Add new mapping...').click();
+          cy.get('.modal.show').within(() => {
+            cy.get('.modal-header').contains('Add new mapping');
+            cy.get('#mappingEndpoint').type(mappingEndpoint);
+            cy.get('#mappingType').select('double');
+            cy.get('button').contains('Confirm').click();
+          });
+          cy.get('button')
+            .contains(mappingEndpoint)
+            .parents('.card')
+            .within(() => {
+              cy.get('.badge').contains('double');
+            });
+
+          // Edit mapping
+          cy.get('button')
+            .contains(mappingEndpoint)
+            .parents('.card')
+            .within(() => {
+              cy.get('button').contains('Edit...').click();
+            });
+          cy.get('.modal.show').within(() => {
+            cy.get('.modal-header').contains('Edit mapping');
+            cy.get('#mappingType').select('string');
+            cy.get('button').contains('Confirm').click();
+          });
+          cy.get('button')
+            .contains(mappingEndpoint)
+            .parents('.card')
+            .within(() => {
+              cy.get('.badge').contains('string');
+            });
+
+          // Remove mapping
+          cy.get('button')
+            .contains(mappingEndpoint)
+            .parents('.card')
+            .within(() => {
+              cy.get('button').contains('Remove').click();
+            });
+          cy.get('button').contains(mappingEndpoint).should('not.exist');
+        });
+      });
+
+      it('can only delete a draft Interface', function () {
+        const draftInterface = {
+          interface_name: 'test.astarte.DraftInterface',
+          version_major: 0,
+          version_minor: 1,
+          type: 'datastream',
+          ownership: 'device',
+          mappings: [
+            {
+              endpoint: '/test',
+              type: 'double',
+            },
+          ],
+        };
+        const majorInterface = _.merge({}, draftInterface, { version_major: 1 });
+
+        cy.route(
+          'GET',
+          `/realmmanagement/v1/*/interfaces/${majorInterface.interface_name}/${majorInterface.version_major}`,
+          { data: majorInterface },
+        );
+        cy.visit(`/interfaces/${majorInterface.interface_name}/${majorInterface.version_major}`);
+        cy.get('button').contains('Delete interface').scrollIntoView().should('not.be.visible');
+
+        cy.route(
+          'GET',
+          `/realmmanagement/v1/*/interfaces/${draftInterface.interface_name}/${draftInterface.version_major}`,
+          { data: draftInterface },
+        );
+        cy.route({
+          method: 'DELETE',
+          url: `/realmmanagement/v1/*/interfaces/${draftInterface.interface_name}/${draftInterface.version_major}`,
+          status: 204,
+          response: '',
+        }).as('deleteInterfaceRequest');
+        cy.visit(`/interfaces/${draftInterface.interface_name}/${draftInterface.version_major}`);
+        cy.get('button').contains('Delete interface').scrollIntoView().click();
+        cy.get('.modal.show').within(() => {
+          cy.contains(
+            `You are going to remove ${draftInterface.interface_name} v${draftInterface.version_major}. This might cause data loss, removed interfaces cannot be restored. Are you sure?`,
+          );
+          cy.contains(`Please type ${draftInterface.interface_name} to proceed.`);
+          cy.get('button').contains('Confirm').should('be.disabled');
+          cy.get('#confirmInterfaceName').type(draftInterface.interface_name);
+          cy.get('button').contains('Confirm').should('be.enabled').click();
+        });
+        cy.wait('@deleteInterfaceRequest');
+        cy.location('pathname').should('eq', '/interfaces');
+      });
+
+      it('asks to confirm before correctly applying changes', function () {
+        cy.fixture('test.astarte.NoDefaultsInterface').then(({ data: iface }) => {
+          cy.route(
+            'GET',
+            `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+            { data: iface },
+          );
+          cy.route({
+            method: 'PUT',
+            url: `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+            status: 204,
+            response: '',
+          }).as('saveInterfaceRequest');
+          cy.visit(`/interfaces/${iface.interface_name}/${iface.version_major}`);
+          const newIface = _.merge({}, iface, {
+            version_minor: iface.version_minor + 1,
+            doc: 'New documentation',
+          });
+          cy.get('#interfaceMinor').type(`{selectall}${newIface.version_minor}`);
+          cy.get('#interfaceDocumentation').clear().type(newIface.doc);
+          cy.get('button').contains('Apply changes').scrollIntoView().click();
+          cy.get('.modal.show').within(() => {
+            cy.get('.modal-header').contains('Confirmation Required');
+            cy.get('.modal-body').contains(`Update the interface ${newIface.interface_name}?`);
+            cy.get('button').contains('Confirm').click();
+          });
+          cy.wait('@saveInterfaceRequest').its('requestBody.data').should('deep.eq', newIface);
+        });
+      });
+
+      it('displays and save an interface source with default values stripped out', function () {
+        // Case with no default values to strip out
+        cy.fixture('test.astarte.NoDefaultsInterface').then(({ data: iface }) => {
+          cy.route(
+            'GET',
+            `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+            { data: iface },
+          );
+          cy.route({
+            method: 'PUT',
+            url: `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+            status: 204,
+            response: '',
+          }).as('saveInterfaceRequest');
+          cy.visit(`/interfaces/${iface.interface_name}/${iface.version_major}`);
+          const newIface = _.merge({}, iface, {
+            version_minor: iface.version_minor + 1,
+            doc: 'New documentation',
+          });
+
+          // Source should be displayed equal, without adding default values
+          cy.get('#interfaceSource')
+            .invoke('val')
+            .should((ifaceSource) => {
+              expect(JSON.parse(ifaceSource)).to.deep.eq(iface);
+            });
+
+          cy.get('#interfaceMinor').type(`{selectall}${newIface.version_minor}`);
+          cy.get('#interfaceDocumentation').clear().type(newIface.doc);
+
+          // Source should be displayed equal, without adding default values
+          cy.get('#interfaceSource')
+            .invoke('val')
+            .should((ifaceSource) => {
+              expect(JSON.parse(ifaceSource)).to.deep.eq(newIface);
+            });
+
+          // Interface should be saved without adding default values
+          cy.get('button').contains('Apply changes').scrollIntoView().click();
+          cy.get('.modal.show button').contains('Confirm').click();
+          cy.wait('@saveInterfaceRequest').its('requestBody.data').should('deep.eq', newIface);
+        });
+
+        // Case with default values to strip out
+        cy.fixture('test.astarte.SpecifiedDefaultsInterface').then(({ data: iface }) => {
+          cy.route(
+            'GET',
+            `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+            { data: iface },
+          );
+          cy.route({
+            method: 'PUT',
+            url: `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+            status: 204,
+            response: '',
+          }).as('saveInterfaceRequest');
+          cy.visit(`/interfaces/${iface.interface_name}/${iface.version_major}`);
+          const newIface = _.merge({}, iface, {
+            version_minor: iface.version_minor + 1,
+            doc: 'New documentation',
+          });
+
+          // Source should not be displayed equal, since default values are stripped out
+          cy.get('#interfaceSource')
+            .invoke('val')
+            .should((ifaceSource) => {
+              expect(JSON.parse(ifaceSource)).not.to.deep.eq(iface);
+            });
+
+          cy.get('#interfaceMinor').type(`{selectall}${newIface.version_minor}`);
+          cy.get('#interfaceDocumentation').clear().type(newIface.doc);
+
+          // Source should not be displayed equal, since default values are stripped out
+          cy.get('#interfaceSource')
+            .invoke('val')
+            .should((ifaceSource) => {
+              expect(JSON.parse(ifaceSource)).not.to.deep.eq(newIface);
+            });
+
+          // Interface should be saved with default values stripped out
+          cy.get('button').contains('Apply changes').scrollIntoView().click();
+          cy.get('.modal.show button').contains('Confirm').click();
+          cy.wait('@saveInterfaceRequest').its('requestBody.data').should('not.deep.eq', newIface);
+        });
+      });
     });
   });
 });

--- a/elm.json
+++ b/elm.json
@@ -23,7 +23,7 @@
             "folkertdev/one-true-path-experiment": "4.0.3",
             "gampleman/elm-visualization": "2.0.1",
             "rtfeldman/elm-iso8601-date-strings": "1.1.3",
-            "rundis/elm-bootstrap": "5.1.0"
+            "rundis/elm-bootstrap": "5.2.0"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/src/astarte-client/client.ts
+++ b/src/astarte-client/client.ts
@@ -24,6 +24,7 @@ import {
   AstarteDataTreeNode,
   fromAstarteDeviceDTO,
   fromAstarteInterfaceDTO,
+  toAstarteInterfaceDTO,
   fromAstartePipelineDTO,
   toAstartePipelineDTO,
   toAstarteDataTree,
@@ -285,6 +286,10 @@ class AstarteClient {
       }),
     );
     return fromAstarteInterfaceDTO(response.data);
+  }
+
+  async installInterface(iface: AstarteInterface): Promise<void> {
+    await this.$post(this.apiConfig.interfaces(this.config), toAstarteInterfaceDTO(iface));
   }
 
   async getTriggerNames(): Promise<string[]> {

--- a/src/astarte-client/types/dto/interface.d.ts
+++ b/src/astarte-client/types/dto/interface.d.ts
@@ -36,7 +36,7 @@ interface AstarteDatastreamInterfaceDTO {
   version_minor: number;
   type: 'datastream';
   ownership: 'device' | 'server';
-  aggregation: 'individual' | 'object';
+  aggregation?: 'individual' | 'object';
   description?: string;
   doc?: string;
   mappings: AstarteMappingDTO[];

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -489,7 +489,7 @@ pageInit realmRoute config session =
             initReactPage session Interfaces "interfaces" realmRoute
 
         Route.NewInterface ->
-            initInterfaceBuilderPage Nothing session session.apiConfig.realm
+            initReactPage session Interfaces "interface-new" realmRoute
 
         Route.ShowInterface name major ->
             initInterfaceBuilderPage (Just ( name, major )) session session.apiConfig.realm

--- a/src/elm/Modal/MappingBuilder.elm
+++ b/src/elm/Modal/MappingBuilder.elm
@@ -504,7 +504,7 @@ renderMappingEndpointInput endpoint isObject editMode endpointWarningPopup =
     Form.group []
         [ Form.label [ for "mappingEndpoint" ] [ text "Endpoint" ]
         , Input.text
-            [ Input.id "Endpoint"
+            [ Input.id "mappingEndpoint"
             , Input.value endpoint
             , Input.disabled editMode
             , Input.onInput UpdateMappingEndpoint

--- a/src/elm/Modal/MappingBuilder.elm
+++ b/src/elm/Modal/MappingBuilder.elm
@@ -236,6 +236,7 @@ view : Model -> Html Msg
 view model =
     Modal.config (Close ModalCancel)
         |> Modal.large
+        |> Modal.scrollableBody True
         |> Modal.h5 []
             [ if model.editMode then
                 text "Edit mapping"

--- a/src/elm/Modal/MappingBuilder.elm
+++ b/src/elm/Modal/MappingBuilder.elm
@@ -284,9 +284,9 @@ renderBody mapping isProperties isObject editMode endpointWarningPopup =
                     Col.sm12
                 ]
                 [ Form.group []
-                    [ Form.label [ for "mappingTypes" ] [ text "Type" ]
+                    [ Form.label [ for "mappingType" ] [ text "Type" ]
                     , Select.select
-                        [ Select.id "mappingTypes"
+                        [ Select.id "mappingType"
                         , Select.onChange UpdateMappingType
                         ]
                         (List.map (\t -> renderMappingTypeItem (t == mapping.mType) t) InterfaceMapping.mappingTypeList)
@@ -442,7 +442,7 @@ renderBody mapping isProperties isObject editMode endpointWarningPopup =
             , Form.col [ Col.sm3 ]
                 [ Form.group []
                     [ Checkbox.checkbox
-                        [ Checkbox.id "mappingExpTimestamp"
+                        [ Checkbox.id "mappingExplicitTimestamp"
                         , Checkbox.checked mapping.explicitTimestamp
                         , Checkbox.onCheck UpdateMappingTimestamp
                         ]
@@ -466,9 +466,9 @@ renderBody mapping isProperties isObject editMode endpointWarningPopup =
         , Form.row []
             [ Form.col [ Col.sm12 ]
                 [ Form.group []
-                    [ Form.label [ for "mappingDoc" ] [ text "Documentation" ]
+                    [ Form.label [ for "mappingDocumentation" ] [ text "Documentation" ]
                     , Textarea.textarea
-                        [ Textarea.id "mappingDoc"
+                        [ Textarea.id "mappingDocumentation"
                         , Textarea.rows 1
                         , Textarea.value <| mapping.doc
                         , Textarea.onInput UpdateMappingDoc

--- a/src/elm/Page/InterfaceBuilder.elm
+++ b/src/elm/Page/InterfaceBuilder.elm
@@ -62,6 +62,7 @@ import Types.InterfaceMapping as InterfaceMapping
         , mappingTypeToEnglishString
         , reliabilityToEnglishString
         , retentionToEnglishString
+        , databaseRetentionToEnglishString
         )
 import Types.Session exposing (Session)
 import Types.SuggestionPopup as SuggestionPopup exposing (SuggestionPopup)
@@ -259,6 +260,8 @@ update session msg model =
                             { reliability = mapping.reliability
                             , retention = mapping.retention
                             , expiry = mapping.expiry
+                            , databaseRetention = mapping.databaseRetention
+                            , ttl = mapping.ttl
                             , explicitTimestamp = mapping.explicitTimestamp
                             }
 
@@ -266,6 +269,8 @@ update session msg model =
                             { reliability = InterfaceMapping.Unreliable
                             , retention = InterfaceMapping.Discard
                             , expiry = 0
+                            , databaseRetention = InterfaceMapping.NoTTL
+                            , ttl = 60
                             , explicitTimestamp = True
                             }
             in
@@ -278,6 +283,8 @@ update session msg model =
                 , objectReliability = commonObjectParams.reliability
                 , objectRetention = commonObjectParams.retention
                 , objectExpiry = commonObjectParams.expiry
+                , objectDatabaseRetention = commonObjectParams.databaseRetention
+                , objectTTL = commonObjectParams.ttl
                 , objectExplicitTimestamp = commonObjectParams.explicitTimestamp
                 , showSpinner = False
               }
@@ -420,6 +427,8 @@ update session msg model =
                                         { reliability = mapping.reliability
                                         , retention = mapping.retention
                                         , expiry = mapping.expiry
+                                        , databaseRetention = mapping.databaseRetention
+                                        , ttl = mapping.ttl
                                         , explicitTimestamp = mapping.explicitTimestamp
                                         }
 
@@ -427,6 +436,8 @@ update session msg model =
                                         { reliability = InterfaceMapping.Unreliable
                                         , retention = InterfaceMapping.Discard
                                         , expiry = 0
+                                        , databaseRetention = InterfaceMapping.NoTTL
+                                        , ttl = 60
                                         , explicitTimestamp = False
                                         }
                         in
@@ -437,6 +448,8 @@ update session msg model =
                             , objectReliability = commonObjectParams.reliability
                             , objectRetention = commonObjectParams.retention
                             , objectExpiry = commonObjectParams.expiry
+                            , objectDatabaseRetention = commonObjectParams.databaseRetention
+                            , objectTTL = commonObjectParams.ttl
                             , objectExplicitTimestamp = commonObjectParams.explicitTimestamp
                           }
                         , Cmd.none
@@ -1483,11 +1496,17 @@ renderMapping mapping =
         , options = [ Card.attrs [ Spacing.mb2 ] ]
         , header = renderMappingHeader mapping
         , blocks =
-            [ ( textBlock "Allow Unset" ""
+            [ ( textBlock "Description" mapping.description
+              , String.isEmpty mapping.description
+              )
+            , ( textBlock "Documentation" mapping.doc
+              , String.isEmpty mapping.doc
+              )
+            , ( textBlock "Allow Unset" <| boolToString mapping.allowUnset
               , not mapping.allowUnset
               )
-            , ( textBlock "Description" mapping.description
-              , String.isEmpty mapping.description
+            , ( textBlock "Explicit Timestamp" <| boolToString mapping.explicitTimestamp
+              , not mapping.explicitTimestamp
               )
             , ( textBlock "Reliability" <| reliabilityToEnglishString mapping.reliability
               , mapping.reliability == InterfaceMapping.Unreliable
@@ -1495,14 +1514,14 @@ renderMapping mapping =
             , ( textBlock "Retention" <| retentionToEnglishString mapping.retention
               , mapping.retention == InterfaceMapping.Discard
               )
-            , ( textBlock "Expiry" <| String.fromInt mapping.expiry
+            , ( textBlock "Expiry" <| String.fromInt mapping.expiry ++ " seconds"
               , mapping.retention == InterfaceMapping.Discard || mapping.expiry == 0
               )
-            , ( textBlock "Explicit Timestamp" <| boolToString mapping.explicitTimestamp
-              , not mapping.explicitTimestamp
+            , ( textBlock "Database Retention" <| databaseRetentionToEnglishString mapping.databaseRetention
+              , mapping.databaseRetention == InterfaceMapping.NoTTL
               )
-            , ( textBlock "Doc" mapping.doc
-              , String.isEmpty mapping.doc
+            , ( textBlock "Database Retention TTL" <| String.fromInt mapping.ttl ++ " seconds"
+              , mapping.databaseRetention == InterfaceMapping.NoTTL
               )
             ]
                 |> List.filterMap
@@ -1710,7 +1729,7 @@ subscriptions model =
 boolToString : Bool -> String
 boolToString b =
     if b then
-        "true"
+        "True"
 
     else
-        "false"
+        "False"

--- a/src/elm/Page/InterfaceBuilder.elm
+++ b/src/elm/Page/InterfaceBuilder.elm
@@ -1103,14 +1103,14 @@ renderContent model interface interfaceEditMode accordionState =
                             |> Fieldset.children
                                 (Radio.radioList "interfaceType"
                                     [ Radio.create
-                                        [ Radio.id "itrb1"
+                                        [ Radio.id "interfaceTypeDatastream"
                                         , Radio.disabled interfaceEditMode
                                         , Radio.checked <| interface.iType == Interface.Datastream
                                         , Radio.onClick <| UpdateInterfaceType Interface.Datastream
                                         ]
                                         "Datastream"
                                     , Radio.create
-                                        [ Radio.id "itrb2"
+                                        [ Radio.id "interfaceTypeProperties"
                                         , Radio.disabled interfaceEditMode
                                         , Radio.checked <| interface.iType == Interface.Properties
                                         , Radio.onClick <| UpdateInterfaceType Interface.Properties
@@ -1129,14 +1129,14 @@ renderContent model interface interfaceEditMode accordionState =
                             |> Fieldset.children
                                 (Radio.radioList "interfaceAggregation"
                                     [ Radio.create
-                                        [ Radio.id "iarb1"
+                                        [ Radio.id "interfaceAggregationIndividual"
                                         , Radio.disabled <| interfaceEditMode || interface.iType == Interface.Properties
                                         , Radio.checked <| interface.aggregation == Interface.Individual
                                         , Radio.onClick <| UpdateInterfaceAggregation Interface.Individual
                                         ]
                                         "Individual"
                                     , Radio.create
-                                        [ Radio.id "iarb2"
+                                        [ Radio.id "interfaceAggregationObject"
                                         , Radio.disabled <| interfaceEditMode || interface.iType == Interface.Properties
                                         , Radio.checked <| interface.aggregation == Interface.Object
                                         , Radio.onClick <| UpdateInterfaceAggregation Interface.Object
@@ -1155,14 +1155,14 @@ renderContent model interface interfaceEditMode accordionState =
                             |> Fieldset.children
                                 (Radio.radioList "interfaceOwnership"
                                     [ Radio.create
-                                        [ Radio.id "iorb1"
+                                        [ Radio.id "interfaceOwnershipDevice"
                                         , Radio.disabled <| interfaceEditMode
                                         , Radio.checked <| interface.ownership == Interface.Device
                                         , Radio.onClick <| UpdateInterfaceOwnership Interface.Device
                                         ]
                                         "Device"
                                     , Radio.create
-                                        [ Radio.id "iorb2"
+                                        [ Radio.id "interfaceOwnershipServer"
                                         , Radio.disabled <| interfaceEditMode
                                         , Radio.checked <| interface.ownership == Interface.Server
                                         , Radio.onClick <| UpdateInterfaceOwnership Interface.Server
@@ -1191,9 +1191,9 @@ renderContent model interface interfaceEditMode accordionState =
             , Form.row []
                 [ Form.col [ Col.sm12 ]
                     [ Form.group []
-                        [ Form.label [ for "interfaceDoc" ] [ text "Documentation" ]
+                        [ Form.label [ for "interfaceDocumentation" ] [ text "Documentation" ]
                         , Textarea.textarea
-                            [ Textarea.id "interfaceDoc"
+                            [ Textarea.id "interfaceDocumentation"
                             , Textarea.rows 3
                             , Textarea.value interface.doc
                             , Textarea.onInput UpdateInterfaceDoc
@@ -1305,7 +1305,7 @@ renderCommonMappingSettings model =
             ]
             [ Form.group []
                 [ Checkbox.checkbox
-                    [ Checkbox.id "objectMappingExpTimestamp"
+                    [ Checkbox.id "objectMappingExplicitTimestamp"
                     , Checkbox.disabled model.interfaceEditMode
                     , Checkbox.checked model.objectExplicitTimestamp
                     , Checkbox.onCheck UpdateObjectMappingExplicitTimestamp
@@ -1374,9 +1374,9 @@ renderCommonMappingSettings model =
                 Col.sm6
             ]
             [ Form.group []
-                [ Form.label [ for "objectDatabaseRetention" ] [ text "Database Retention" ]
+                [ Form.label [ for "objectMappingDatabaseRetention" ] [ text "Database Retention" ]
                 , Select.select
-                    [ Select.id "objectDatabaseRetention"
+                    [ Select.id "objectMappingDatabaseRetention"
                     , Select.disabled model.interfaceEditMode
                     , Select.onChange UpdateObjectMappingDatabaseRetention
                     ]
@@ -1401,9 +1401,9 @@ renderCommonMappingSettings model =
                 Col.sm6
             ]
             [ Form.group []
-                [ Form.label [ for "objectTTL" ] [ text "TTL" ]
+                [ Form.label [ for "objectMappingTTL" ] [ text "TTL" ]
                 , InputGroup.number
-                    [ Input.id "objectTTL"
+                    [ Input.id "objectMappingTTL"
                     , Input.disabled model.interfaceEditMode
                     , Input.value <| String.fromInt model.objectTTL
                     , Input.onInput UpdateObjectMappingTTL

--- a/src/elm/Types/InterfaceMapping.elm
+++ b/src/elm/Types/InterfaceMapping.elm
@@ -36,6 +36,7 @@ module Types.InterfaceMapping exposing
     , mappingTypeToString
     , reliabilityToEnglishString
     , retentionToEnglishString
+    , databaseRetentionToEnglishString
     , setAllowUnset
     , setDatabaseRetention
     , setDescription
@@ -641,3 +642,12 @@ retentionToEnglishString retention =
 
         Stored ->
             "Stored"
+
+databaseRetentionToEnglishString : DatabaseRetention -> String
+databaseRetentionToEnglishString databaseRetention =
+    case databaseRetention of
+        NoTTL ->
+            "No TTL"
+
+        UseTTL ->
+            "Use TTL"

--- a/src/react/NewInterfacePage.tsx
+++ b/src/react/NewInterfacePage.tsx
@@ -1,0 +1,167 @@
+/*
+   This file is part of Astarte.
+
+   Copyright 2020 Ispirata Srl
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import React, { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button, Container, Row, Spinner } from 'react-bootstrap';
+import AstarteClient, { AstarteInterface } from 'astarte-client';
+import _ from 'lodash';
+
+import { useAlerts } from './AlertManager';
+import InterfaceEditor from './components/InterfaceEditor';
+import ConfirmModal from './components/modals/Confirm';
+import BackButton from './ui/BackButton';
+
+interface InstallModalProps {
+  interfaceName: string;
+  isDraft: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  isInstallingInterface: boolean;
+}
+
+const InstallModal = ({
+  interfaceName,
+  isDraft,
+  onCancel,
+  onConfirm,
+  isInstallingInterface,
+}: InstallModalProps) => {
+  return (
+    <ConfirmModal
+      title="Confirmation Required"
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+      isConfirming={isInstallingInterface}
+    >
+      <p>
+        You are about to install the interface <b>{interfaceName}</b>.
+      </p>
+      {isDraft ? (
+        <p>
+          As its major version is 0, this is a draft interface, which can be deleted.
+          <br />
+          In such a case, any data sent through this interface will be lost.
+          <br />
+          Draft Interfaces should be used for development and testing purposes only.
+        </p>
+      ) : (
+        <p>
+          Interface major is greater than zero, that means you will not be able to change already
+          installed mappings.
+        </p>
+      )}
+      <p>Are you sure you want to continue?</p>
+    </ConfirmModal>
+  );
+};
+
+interface Props {
+  astarte: AstarteClient;
+}
+
+export default ({ astarte }: Props): React.ReactElement => {
+  const [interfaceDraft, setInterfaceDraft] = useState<AstarteInterface | null>(null);
+  const [isValidInterface, setIsValidInterface] = useState(false);
+  const [isInstallingInterface, setIsInstallingInterface] = useState(false);
+  const [showInstallModal, setShowInstallModal] = useState(false);
+  const [isSourceVisible, setIsSourceVisible] = useState(true);
+  const installationAlerts = useAlerts();
+  const navigate = useNavigate();
+
+  const handleToggleSourceVisibility = useCallback(() => {
+    setIsSourceVisible((isVisible) => !isVisible);
+  }, []);
+
+  const handleInterfaceChange = useCallback(
+    (updatedInterface: AstarteInterface, isValid: boolean) => {
+      setInterfaceDraft(updatedInterface);
+      setIsValidInterface(isValid);
+    },
+    [],
+  );
+
+  const showConfirmInstallModal = useCallback(() => {
+    setShowInstallModal(true);
+  }, []);
+
+  const hideConfirmInstallModal = useCallback(() => {
+    setShowInstallModal(false);
+  }, []);
+
+  const handleConfirmInstallInterface = useCallback(() => {
+    if (interfaceDraft == null || isInstallingInterface) {
+      return;
+    }
+    setIsInstallingInterface(true);
+    astarte
+      .installInterface(new AstarteInterface(interfaceDraft))
+      .then(() => {
+        navigate({ pathname: '/interfaces' });
+      })
+      .catch((err) => {
+        installationAlerts.showError(`Could not install interface: ${err.message}`);
+        setIsInstallingInterface(false);
+        hideConfirmInstallModal();
+      });
+  }, [
+    astarte,
+    interfaceDraft,
+    isInstallingInterface,
+    navigate,
+    hideConfirmInstallModal,
+    installationAlerts.showError,
+  ]);
+
+  return (
+    <Container fluid className="p-3">
+      <h2>
+        <BackButton href="/interfaces" />
+        Interface Editor
+      </h2>
+      <div className="mt-4">
+        <installationAlerts.Alerts />
+        <InterfaceEditor onChange={handleInterfaceChange} isSourceVisible={isSourceVisible} />
+        <Row className="justify-content-end m-0 mt-3">
+          <Button variant="secondary" className="mr-2" onClick={handleToggleSourceVisibility}>
+            {isSourceVisible ? 'Hide' : 'Show'} source
+          </Button>
+          <Button
+            variant="primary"
+            onClick={showConfirmInstallModal}
+            disabled={isInstallingInterface || !isValidInterface}
+          >
+            {isInstallingInterface && (
+              <Spinner as="span" size="sm" animation="border" role="status" className="mr-2" />
+            )}
+            Install interface
+          </Button>
+        </Row>
+        {showInstallModal && (
+          <InstallModal
+            onCancel={hideConfirmInstallModal}
+            onConfirm={handleConfirmInstallInterface}
+            isInstallingInterface={isInstallingInterface}
+            interfaceName={_.get(interfaceDraft, 'name', '')}
+            isDraft={_.get(interfaceDraft, 'major', 0) === 0}
+          />
+        )}
+      </div>
+    </Container>
+  );
+};

--- a/src/react/Router.jsx
+++ b/src/react/Router.jsx
@@ -26,6 +26,7 @@ import GroupDevicesPage from './GroupDevicesPage';
 import NewGroupPage from './NewGroupPage';
 import TriggersPage from './TriggersPage';
 import InterfacesPage from './InterfacesPage';
+import NewInterfacePage from './NewInterfacePage';
 import DevicesPage from './DevicesPage';
 import RegisterDevicePage from './RegisterDevicePage';
 import FlowInstancesPage from './FlowInstancesPage';
@@ -71,6 +72,7 @@ export default ({ reactHistory: history, astarteClient, sessionManager, config, 
         />
         <Route path="triggers" element={<TriggersPage {...pageProps} />} />
         <Route path="interfaces" element={<InterfacesPage {...pageProps} />} />
+        <Route path="interfaces/new" element={<NewInterfacePage {...pageProps} />} />
         <Route path="devices" element={<DevicesPage {...pageProps} />} />
         <Route path="devices/register" element={<RegisterDevicePage {...pageProps} />} />
         <Route

--- a/src/react/components/InterfaceEditor.tsx
+++ b/src/react/components/InterfaceEditor.tsx
@@ -1,0 +1,934 @@
+/*
+   This file is part of Astarte.
+
+   Copyright 2020 Ispirata Srl
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Accordion,
+  Badge,
+  Button,
+  Card,
+  Col,
+  Container,
+  Form,
+  InputGroup,
+  Modal,
+  Row,
+} from 'react-bootstrap';
+import { AstarteInterface, AstarteMapping } from 'astarte-client';
+import _ from 'lodash';
+
+import MappingEditor from './MappingEditor';
+
+interface FormControlWarningProps {
+  message?: string;
+}
+
+const FormControlWarning = ({ message }: FormControlWarningProps): React.ReactElement | null => {
+  if (!message) {
+    return null;
+  }
+  return <div className="warning-feedback">{message}</div>;
+};
+
+interface MappingRowProps {
+  className?: string;
+  mapping: AstarteMapping;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+const reliabilityToLabel = {
+  unreliable: 'Unreliable',
+  guaranteed: 'Guaranteed',
+  unique: 'Unique',
+};
+
+const retentionToLabel = {
+  discard: 'Discard',
+  volatile: 'Volatile',
+  stored: 'Stored',
+};
+
+const databaseRetentionToLabel = {
+  no_ttl: 'No TTL',
+  use_ttl: 'Use TTL',
+};
+
+const MappingRow = ({ className, mapping, onEdit, onDelete }: MappingRowProps) => {
+  return (
+    <Accordion>
+      <Card className={className}>
+        <Accordion.Toggle
+          eventKey={mapping.endpoint}
+          as={Card.Header}
+          className="d-flex align-items-center flex-wrap"
+        >
+          <span className="flex-grow-1">
+            <Badge variant="secondary">{mapping.type}</Badge>
+            <Button className="text-left text-truncate" variant="link">
+              {mapping.endpoint}
+            </Button>
+          </span>
+          <Button className="mr-2" variant="outline-primary" onClick={onEdit}>
+            Edit...
+          </Button>
+          <Button variant="outline-primary" onClick={onDelete}>
+            Remove
+          </Button>
+        </Accordion.Toggle>
+        <Accordion.Collapse eventKey={mapping.endpoint}>
+          <Card.Body>
+            {mapping.description && (
+              <>
+                <h5>Description</h5>
+                <p>{mapping.description}</p>
+              </>
+            )}
+            {mapping.documentation && (
+              <>
+                <h5>Documentation</h5>
+                <p>{mapping.documentation}</p>
+              </>
+            )}
+            {mapping.allowUnset && (
+              <>
+                <h5>Allow Unset</h5>
+                <p>True</p>
+              </>
+            )}
+            {mapping.explicitTimestamp && (
+              <>
+                <h5>Explicit Timestamp</h5>
+                <p>True</p>
+              </>
+            )}
+            {mapping.reliability && (
+              <>
+                <h5>Reliability</h5>
+                <p>{reliabilityToLabel[mapping.reliability]}</p>
+              </>
+            )}
+            {mapping.retention && (
+              <>
+                <h5>Retention</h5>
+                <p>{retentionToLabel[mapping.retention]}</p>
+              </>
+            )}
+            {mapping.expiry && (
+              <>
+                <h5>Expiry</h5>
+                <p>{mapping.expiry} seconds</p>
+              </>
+            )}
+            {mapping.databaseRetentionPolicy && (
+              <>
+                <h5>Database Retention</h5>
+                <p>{databaseRetentionToLabel[mapping.databaseRetentionPolicy]}</p>
+              </>
+            )}
+            {mapping.databaseRetentionTtl != null && (
+              <>
+                <h5>Database Retention TTL</h5>
+                <p>{mapping.databaseRetentionTtl} seconds</p>
+              </>
+            )}
+          </Card.Body>
+        </Accordion.Collapse>
+      </Card>
+    </Accordion>
+  );
+};
+
+const getDefaultMapping = (params: {
+  interfaceType: AstarteInterface['type'];
+  interfaceAggregation: AstarteInterface['aggregation'];
+}): AstarteMapping => {
+  if (params.interfaceType === 'datastream' && params.interfaceAggregation === 'individual') {
+    return {
+      endpoint: '',
+      type: 'double',
+      explicitTimestamp: true,
+    };
+  }
+  return {
+    endpoint: '',
+    type: 'double',
+  };
+};
+
+interface MappingModalProps {
+  interfaceType: AstarteInterface['type'];
+  interfaceAggregation?: AstarteInterface['aggregation'];
+  mapping?: AstarteMapping;
+  onCancel: () => void;
+  onConfirm: (newMapping: AstarteMapping) => void;
+}
+
+const MappingModal = ({
+  interfaceType,
+  interfaceAggregation = 'individual',
+  mapping,
+  onCancel,
+  onConfirm,
+}: MappingModalProps): React.ReactElement => {
+  const [mappingDraft, setMappingDraft] = useState(
+    mapping || getDefaultMapping({ interfaceType, interfaceAggregation }),
+  );
+
+  const handleChange = useCallback((newMapping: AstarteMapping) => {
+    setMappingDraft(newMapping);
+  }, []);
+
+  const isValidMapping = AstarteMapping.validation.isValidSync(mappingDraft);
+
+  return (
+    <Modal show size="lg" centered onHide={onCancel}>
+      <Modal.Header closeButton>
+        <Modal.Title>{mapping != null ? 'Edit mapping' : 'Add new mapping'}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <MappingEditor
+          interfaceType={interfaceType}
+          interfaceAggregation={interfaceAggregation}
+          mapping={mappingDraft}
+          onChange={handleChange}
+        />
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          onClick={() => onConfirm(mappingDraft)}
+          disabled={!isValidMapping}
+        >
+          Confirm
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+const computeInterfaceWarnings = (iface: AstarteInterface): { [key: string]: string } => {
+  const warnings: { [key: string]: string } = {};
+
+  if (iface.type === 'datastream' && iface.aggregation === 'object') {
+    const endpoints = iface.mappings.map((mapping) => mapping.endpoint);
+    const endpointDepths = endpoints.map((endpoint) => endpoint.split('/').length - 1);
+    if (endpointDepths.some((depth) => depth < 2)) {
+      warnings.mappings =
+        'Interface mappings endpoints of depth 1 in Object aggregate interfaces are deprecated. The endpoint should have depth level of 2 or more (e.g. /my/endpoint).';
+    }
+  }
+
+  const interfaceNameRegex = /^([a-z][a-z0-9]*\.([a-z0-9][a-z0-9-]*\.)*)+[A-Z][a-zA-Z0-9]*$/;
+  if (!interfaceNameRegex.test(iface.name)) {
+    warnings.name =
+      'Interface name should be prefixed with a reverse domain name, and should use PascalCase (e.g. com.example.MyInterface)';
+  }
+
+  return warnings;
+};
+
+const formatJSON = (json: unknown): string => {
+  return JSON.stringify(json, null, 4);
+};
+
+const formatJSONText = (text: string): string => {
+  try {
+    return formatJSON(JSON.parse(text));
+  } catch {
+    return text;
+  }
+};
+
+const checkValidJSONText = (text: string): boolean => {
+  try {
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const parseAstarteInterfaceJSON = (json: any): AstarteInterface | null => {
+  let parsedInterface: AstarteInterface;
+  try {
+    parsedInterface = AstarteInterface.fromJSON(json);
+  } catch {
+    throw new Error('Invalid interface');
+  }
+  return parsedInterface;
+};
+
+const defaultInterface: AstarteInterface = {
+  name: '',
+  major: 0,
+  minor: 1,
+  type: 'properties',
+  ownership: 'device',
+  mappings: [],
+};
+
+interface DatastreamOptions {
+  reliability?: AstarteMapping['reliability'];
+  retention?: AstarteMapping['retention'];
+  expiry?: AstarteMapping['expiry'];
+  databaseRetentionPolicy?: AstarteMapping['databaseRetentionPolicy'];
+  databaseRetentionTtl?: AstarteMapping['databaseRetentionTtl'];
+  explicitTimestamp?: AstarteMapping['explicitTimestamp'];
+}
+
+const defaultDatastreamOptions = {
+  explicitTimestamp: true,
+};
+
+const getInitialDatastreamOptions = (iface: AstarteInterface): DatastreamOptions => {
+  if (iface.mappings.length === 0) {
+    return defaultDatastreamOptions;
+  }
+  const mapping = iface.mappings[0];
+  const options: DatastreamOptions = {};
+  options.reliability = mapping.reliability;
+  options.retention = mapping.retention;
+  options.expiry = options.retention !== 'discard' ? mapping.expiry : undefined;
+  options.databaseRetentionPolicy = mapping.databaseRetentionPolicy;
+  options.databaseRetentionTtl =
+    options.databaseRetentionPolicy === 'use_ttl' ? mapping.databaseRetentionTtl : undefined;
+  options.explicitTimestamp = mapping.explicitTimestamp != null ? mapping.explicitTimestamp : true;
+  return options;
+};
+
+interface Props {
+  initialData?: AstarteInterface;
+  isSourceVisible?: boolean;
+  onChange: (updatedInterface: AstarteInterface, isValid: boolean) => unknown;
+}
+
+export default ({ initialData, isSourceVisible = false, onChange }: Props): React.ReactElement => {
+  const [interfaceDraft, setInterfaceDraft] = useState<AstarteInterface>(
+    initialData || defaultInterface,
+  );
+  const [interfaceSource, setInterfaceSource] = useState(
+    formatJSON(AstarteInterface.toJSON(interfaceDraft)),
+  );
+  const [datastreamOptions, setDatastreamOptions] = useState<DatastreamOptions>(
+    getInitialDatastreamOptions(interfaceDraft),
+  );
+  const [isMappingModalVisible, setIsMappingModalVisible] = useState(false);
+  const [mappingToEditIndex, setMappingToEditIndex] = useState(0);
+
+  const handleInterfaceNameChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setInterfaceDraft((draft) => ({ ...draft, name: value.trim() }));
+  }, []);
+
+  const handleInterfaceMajorChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setInterfaceDraft((draft) => ({ ...draft, major: parseInt(value, 10) }));
+  }, []);
+
+  const handleInterfaceMinorChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setInterfaceDraft((draft) => ({ ...draft, minor: parseInt(value, 10) }));
+  }, []);
+
+  const clearMappingsOptions = useCallback(
+    (params: { type: AstarteInterface['type']; aggregation: AstarteInterface['aggregation'] }) => {
+      setInterfaceDraft((draft) => {
+        const mappings = draft.mappings.map((mapping) =>
+          _.omit(mapping, [
+            'allowUnset',
+            'reliability',
+            'retention',
+            'expiry',
+            'databaseRetentionPolicy',
+            'databaseRetentionTtl',
+            'explicitTimestamp',
+          ]),
+        );
+        return { ...draft, mappings };
+      });
+      if (params.type === 'datastream' && params.aggregation === 'object') {
+        setDatastreamOptions(defaultDatastreamOptions);
+      } else {
+        setDatastreamOptions({});
+      }
+    },
+    [],
+  );
+
+  const handleInterfaceTypeChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.currentTarget;
+    const type = value as AstarteInterface['type'];
+    const aggregation = type === 'datastream' ? 'individual' : undefined;
+    clearMappingsOptions({ type, aggregation });
+    setInterfaceDraft((draft) => ({ ...draft, type, aggregation }));
+  }, []);
+
+  const handleInterfaceAggregationChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.currentTarget;
+    const aggregation = value as AstarteInterface['aggregation'];
+    clearMappingsOptions({ type: 'datastream', aggregation });
+    setInterfaceDraft((draft) => ({
+      ...draft,
+      aggregation,
+    }));
+  }, []);
+
+  const handleInterfaceOwnershipChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.currentTarget;
+    const ownership = value as AstarteInterface['ownership'];
+    setInterfaceDraft((draft) => ({
+      ...draft,
+      ownership,
+    }));
+  }, []);
+
+  const handleInterfaceDescriptionChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setInterfaceDraft((draft) => ({ ...draft, description: value || undefined }));
+  }, []);
+
+  const handleInterfaceDocumentationChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const { value } = e.target;
+      setInterfaceDraft((draft) => ({ ...draft, documentation: value || undefined }));
+    },
+    [],
+  );
+
+  const handleInterfaceReliabilityChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.currentTarget;
+    let reliability = value as AstarteMapping['reliability'];
+    reliability = reliability === 'unreliable' ? undefined : reliability;
+    setDatastreamOptions((options) => ({ ...options, reliability }));
+  }, []);
+
+  const handleInterfaceExplicitTimestampChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      let explicitTimestamp = !!e.target.checked as AstarteMapping['explicitTimestamp'];
+      explicitTimestamp = explicitTimestamp || undefined;
+      setDatastreamOptions((options) => ({ ...options, explicitTimestamp }));
+    },
+    [],
+  );
+
+  const handleInterfaceRetentionChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.currentTarget;
+    const retention = value as AstarteMapping['retention'];
+    setDatastreamOptions((options) => ({
+      ...options,
+      retention: retention === 'discard' ? undefined : retention,
+      expiry: retention === 'discard' ? undefined : options.expiry,
+    }));
+  }, []);
+
+  const handleInterfaceExpiryChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const expiry = parseInt(e.currentTarget.value, 10) || undefined;
+    setDatastreamOptions((options) => ({ ...options, expiry }));
+  }, []);
+
+  const handleInterfaceDatabaseRetentionPolicyChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const { value } = e.currentTarget;
+      const databaseRetentionPolicy = value as AstarteMapping['databaseRetentionPolicy'];
+      setDatastreamOptions((options) => ({
+        ...options,
+        databaseRetentionPolicy:
+          databaseRetentionPolicy === 'no_ttl' ? undefined : databaseRetentionPolicy,
+        databaseRetentionTtl:
+          databaseRetentionPolicy === 'no_ttl' ? undefined : options.databaseRetentionTtl || 60,
+      }));
+    },
+    [],
+  );
+
+  const handleInterfaceDatabaseRetentionTtlChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const databaseRetentionTtl = parseInt(e.currentTarget.value, 10);
+      setDatastreamOptions((options) => ({ ...options, databaseRetentionTtl }));
+    },
+    [],
+  );
+
+  const handleAddMapping = useCallback(() => {
+    setMappingToEditIndex(interfaceDraft.mappings.length);
+    setIsMappingModalVisible(true);
+  }, [interfaceDraft.mappings]);
+
+  const handleEditMapping = useCallback((mappingIndex: number) => {
+    setMappingToEditIndex(mappingIndex);
+    setIsMappingModalVisible(true);
+  }, []);
+
+  const handleDeleteMapping = useCallback((mappingIndex: number) => {
+    setInterfaceDraft((draft) => {
+      const updatedMappings = draft.mappings.filter((m, index) => index !== mappingIndex);
+      return { ...draft, mappings: updatedMappings };
+    });
+  }, []);
+
+  const handleConfirmEditMapping = useCallback(
+    (mapping: AstarteMapping) => {
+      setInterfaceDraft((draft) => {
+        let newMapping = { ...mapping };
+        if (interfaceDraft.type === 'datastream' && interfaceDraft.aggregation === 'object') {
+          newMapping = { ...mapping, ...datastreamOptions };
+        }
+        const isNewMapping = mappingToEditIndex >= draft.mappings.length;
+        const updatedMappings = isNewMapping
+          ? draft.mappings.concat(newMapping)
+          : draft.mappings.map((m, index) => (index === mappingToEditIndex ? newMapping : m));
+        return { ...draft, mappings: updatedMappings };
+      });
+      setIsMappingModalVisible(false);
+    },
+    [mappingToEditIndex, datastreamOptions, interfaceDraft.type, interfaceDraft.aggregation],
+  );
+
+  const handleInterfaceSourceChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setInterfaceSource(value);
+    if (!checkValidJSONText(value)) {
+      return;
+    }
+    let parsedInterface: AstarteInterface | null;
+    try {
+      parsedInterface = parseAstarteInterfaceJSON(JSON.parse(value));
+    } catch {
+      parsedInterface = null;
+    }
+    if (!parsedInterface) {
+      return;
+    }
+    setInterfaceDraft(parsedInterface);
+    const mapping: AstarteMapping | undefined = _.get(parsedInterface, 'mappings.0');
+    if (parsedInterface.type === 'datastream' && parsedInterface.aggregation === 'object') {
+      setDatastreamOptions({
+        reliability: mapping?.reliability,
+        retention: mapping?.retention,
+        expiry: mapping?.expiry,
+        databaseRetentionPolicy: mapping?.databaseRetentionPolicy,
+        databaseRetentionTtl: mapping?.databaseRetentionTtl,
+        explicitTimestamp: mapping?.explicitTimestamp,
+      });
+    } else {
+      setDatastreamOptions({});
+    }
+  }, []);
+
+  useEffect(() => {
+    setInterfaceDraft((draft) => {
+      if (draft.aggregation !== 'object' || draft.mappings.length === 0) {
+        return draft;
+      }
+      const mappings = draft.mappings.map((mapping) => ({
+        ...mapping,
+        reliability: datastreamOptions.reliability,
+        retention: datastreamOptions.retention,
+        expiry: datastreamOptions.expiry,
+        databaseRetentionPolicy: datastreamOptions.databaseRetentionPolicy,
+        databaseRetentionTtl: datastreamOptions.databaseRetentionTtl,
+        explicitTimestamp: datastreamOptions.explicitTimestamp,
+      }));
+      return { ...draft, mappings };
+    });
+  }, [datastreamOptions]);
+
+  let interfaceValidationErrors: { [key: string]: string } = {};
+  try {
+    AstarteInterface.validation.validateSync(interfaceDraft, { abortEarly: false });
+  } catch (err) {
+    interfaceValidationErrors = _.mapValues(
+      _.keyBy(_.uniqBy(err.inner, 'path'), 'path'),
+      'message',
+    );
+  }
+  const isValidInterface = _.isEmpty(interfaceValidationErrors);
+
+  useEffect(() => {
+    const formattedInterfaceSource = formatJSON(AstarteInterface.toJSON(interfaceDraft));
+    setInterfaceSource((source) =>
+      formatJSONText(source) !== formattedInterfaceSource ? formattedInterfaceSource : source,
+    );
+    onChange(interfaceDraft, isValidInterface);
+  }, [interfaceDraft, isValidInterface]);
+
+  const interfaceValidationWarnings = computeInterfaceWarnings(interfaceDraft);
+
+  let isValidInterfaceSource = true;
+  let interfaceSourceError = '';
+  if (!checkValidJSONText(interfaceSource)) {
+    isValidInterfaceSource = false;
+    interfaceSourceError = 'Invalid JSON';
+  } else {
+    try {
+      parseAstarteInterfaceJSON(JSON.parse(interfaceSource));
+    } catch (err) {
+      isValidInterfaceSource = false;
+      interfaceSourceError = err.message;
+    }
+  }
+
+  const mappingToEdit = _.nth(interfaceDraft.mappings, mappingToEditIndex);
+
+  const showInterfaceExpiry =
+    datastreamOptions.retention === 'volatile' || datastreamOptions.retention === 'stored';
+
+  const showInterfaceDatabaseRetentionTtl = datastreamOptions.databaseRetentionPolicy === 'use_ttl';
+
+  return (
+    <Row>
+      <Col md={isSourceVisible ? 6 : 12}>
+        <Container fluid className="bg-white rounded p-3">
+          <Form>
+            <Form.Row className="mb-2">
+              <Col md={6}>
+                <Form.Group controlId="interfaceName">
+                  <Form.Label>Name</Form.Label>
+                  <Form.Control
+                    type="text"
+                    placeholder="Interface name"
+                    value={interfaceDraft.name}
+                    onChange={handleInterfaceNameChange}
+                    autoComplete="off"
+                    required
+                    isInvalid={interfaceValidationErrors.name != null}
+                  />
+                  <Form.Control.Feedback type="invalid">
+                    {interfaceValidationErrors.name}
+                  </Form.Control.Feedback>
+                  {interfaceValidationErrors.name == null && (
+                    <FormControlWarning message={interfaceValidationWarnings.name} />
+                  )}
+                </Form.Group>
+              </Col>
+              <Col md={3}>
+                <Form.Group controlId="interfaceMajor">
+                  <Form.Label>Major</Form.Label>
+                  <Form.Control
+                    type="number"
+                    min={0}
+                    value={interfaceDraft.major}
+                    onChange={handleInterfaceMajorChange}
+                    required
+                    isInvalid={interfaceValidationErrors.major != null}
+                  />
+                  <Form.Control.Feedback type="invalid">
+                    {interfaceValidationErrors.major}
+                  </Form.Control.Feedback>
+                </Form.Group>
+              </Col>
+              <Col md={3}>
+                <Form.Group controlId="interfaceMinor">
+                  <Form.Label>Minor</Form.Label>
+                  <Form.Control
+                    type="number"
+                    min={0}
+                    value={interfaceDraft.minor}
+                    onChange={handleInterfaceMinorChange}
+                    required
+                    isInvalid={interfaceValidationErrors.minor != null}
+                  />
+                  <Form.Control.Feedback type="invalid">
+                    {interfaceValidationErrors.minor}
+                  </Form.Control.Feedback>
+                </Form.Group>
+              </Col>
+            </Form.Row>
+            <Form.Row className="mb-2">
+              <Col md={4}>
+                <Form.Group>
+                  <Form.Label>Type</Form.Label>
+                  <Form.Check
+                    type="radio"
+                    name="interfaceType"
+                    id="interfaceTypeDatastream"
+                    label="Datastream"
+                    value="datastream"
+                    checked={interfaceDraft.type === 'datastream'}
+                    onChange={handleInterfaceTypeChange}
+                  />
+                  <Form.Check
+                    type="radio"
+                    name="interfaceType"
+                    id="interfaceTypeProperties"
+                    label="Properties"
+                    value="properties"
+                    checked={interfaceDraft.type === 'properties'}
+                    onChange={handleInterfaceTypeChange}
+                  />
+                </Form.Group>
+              </Col>
+              <Col md={4}>
+                <Form.Group>
+                  <Form.Label>Aggregation</Form.Label>
+                  <Form.Check
+                    type="radio"
+                    name="interfaceAggregation"
+                    id="interfaceAggregationIndividual"
+                    label="Individual"
+                    value="individual"
+                    checked={
+                      interfaceDraft.aggregation === 'individual' || !interfaceDraft.aggregation
+                    }
+                    onChange={handleInterfaceAggregationChange}
+                    disabled={interfaceDraft.type === 'properties'}
+                  />
+                  <Form.Check
+                    type="radio"
+                    name="interfaceAggregation"
+                    id="interfaceAggregationObject"
+                    label="Object"
+                    value="object"
+                    checked={interfaceDraft.aggregation === 'object'}
+                    onChange={handleInterfaceAggregationChange}
+                    disabled={interfaceDraft.type === 'properties'}
+                  />
+                </Form.Group>
+              </Col>
+              <Col md={4}>
+                <Form.Group>
+                  <Form.Label>Ownership</Form.Label>
+                  <Form.Check
+                    type="radio"
+                    name="interfaceOwnership"
+                    id="interfaceOwnershipDevice"
+                    label="Device"
+                    value="device"
+                    checked={interfaceDraft.ownership === 'device'}
+                    onChange={handleInterfaceOwnershipChange}
+                  />
+                  <Form.Check
+                    type="radio"
+                    name="interfaceOwnership"
+                    id="interfaceOwnershipServer"
+                    label="Server"
+                    value="server"
+                    checked={interfaceDraft.ownership === 'server'}
+                    onChange={handleInterfaceOwnershipChange}
+                  />
+                </Form.Group>
+              </Col>
+            </Form.Row>
+            {interfaceDraft.type === 'datastream' && interfaceDraft.aggregation === 'object' && (
+              <Form.Row className="mb-2">
+                <Col md={6}>
+                  <Form.Group controlId="objectMappingReliability">
+                    <Form.Label>Reliability</Form.Label>
+                    <Form.Control
+                      as="select"
+                      name="mappingReliability"
+                      value={datastreamOptions.reliability || 'unreliable'}
+                      onChange={handleInterfaceReliabilityChange}
+                    >
+                      <option value="unreliable">{reliabilityToLabel.unreliable}</option>
+                      <option value="guaranteed">{reliabilityToLabel.guaranteed}</option>
+                      <option value="unique">{reliabilityToLabel.unique}</option>
+                    </Form.Control>
+                  </Form.Group>
+                </Col>
+                <Col md={6}>
+                  <Form.Group controlId="objectMappingExplicitTimestamp">
+                    <Form.Label>Timestamp</Form.Label>
+                    <Form.Check
+                      type="checkbox"
+                      name="mappingExplicitTimestamp"
+                      label="Explicit timestamp"
+                      checked={!!datastreamOptions.explicitTimestamp}
+                      onChange={handleInterfaceExplicitTimestampChange}
+                    />
+                  </Form.Group>
+                </Col>
+              </Form.Row>
+            )}
+            {interfaceDraft.type === 'datastream' && interfaceDraft.aggregation === 'object' && (
+              <Form.Row className="mb-2">
+                <Col md={showInterfaceExpiry ? 6 : 12}>
+                  <Form.Group controlId="objectMappingRetention">
+                    <Form.Label>Retention</Form.Label>
+                    <Form.Control
+                      as="select"
+                      name="mappingRetention"
+                      value={datastreamOptions.retention || 'discard'}
+                      onChange={handleInterfaceRetentionChange}
+                    >
+                      <option value="discard">{retentionToLabel.discard}</option>
+                      <option value="volatile">{retentionToLabel.volatile}</option>
+                      <option value="stored">{retentionToLabel.stored}</option>
+                    </Form.Control>
+                  </Form.Group>
+                </Col>
+                {showInterfaceExpiry && (
+                  <Col md={6}>
+                    <Form.Group controlId="objectMappingExpiry">
+                      <Form.Label>Expiry</Form.Label>
+                      <InputGroup>
+                        <Form.Control
+                          type="number"
+                          min={0}
+                          value={datastreamOptions.expiry || 0}
+                          onChange={handleInterfaceExpiryChange}
+                          isInvalid={(datastreamOptions.expiry || 0) < 0}
+                        />
+                        <InputGroup.Append>
+                          <InputGroup.Text>seconds</InputGroup.Text>
+                        </InputGroup.Append>
+                      </InputGroup>
+                    </Form.Group>
+                  </Col>
+                )}
+              </Form.Row>
+            )}
+            {interfaceDraft.type === 'datastream' && interfaceDraft.aggregation === 'object' && (
+              <Form.Row className="mb-2">
+                <Col md={showInterfaceDatabaseRetentionTtl ? 6 : 12}>
+                  <Form.Group controlId="objectMappingDatabaseRetention">
+                    <Form.Label>Database Retention</Form.Label>
+                    <Form.Control
+                      as="select"
+                      name="mappingDatabaseRetention"
+                      value={datastreamOptions.databaseRetentionPolicy || 'no_ttl'}
+                      onChange={handleInterfaceDatabaseRetentionPolicyChange}
+                    >
+                      <option value="no_ttl">{databaseRetentionToLabel.no_ttl}</option>
+                      <option value="use_ttl">{databaseRetentionToLabel.use_ttl}</option>
+                    </Form.Control>
+                  </Form.Group>
+                </Col>
+                {showInterfaceDatabaseRetentionTtl && (
+                  <Col md={6}>
+                    <Form.Group controlId="objectMappingTTL">
+                      <Form.Label>TTL</Form.Label>
+                      <InputGroup>
+                        <Form.Control
+                          type="number"
+                          min={60}
+                          value={datastreamOptions.databaseRetentionTtl || 60}
+                          onChange={handleInterfaceDatabaseRetentionTtlChange}
+                          isInvalid={(datastreamOptions.databaseRetentionTtl || 60) < 60}
+                        />
+                        <InputGroup.Append>
+                          <InputGroup.Text>seconds</InputGroup.Text>
+                        </InputGroup.Append>
+                      </InputGroup>
+                    </Form.Group>
+                  </Col>
+                )}
+              </Form.Row>
+            )}
+            <Form.Row className="mb-2">
+              <Col sm={12}>
+                <Form.Group controlId="interfaceDescription">
+                  <Form.Label>Description</Form.Label>
+                  <Form.Control
+                    as="textarea"
+                    value={interfaceDraft.description || ''}
+                    onChange={handleInterfaceDescriptionChange}
+                    autoComplete="off"
+                    rows={3}
+                    isInvalid={interfaceValidationErrors.description != null}
+                  />
+                  <Form.Control.Feedback type="invalid">
+                    {interfaceValidationErrors.description}
+                  </Form.Control.Feedback>
+                </Form.Group>
+              </Col>
+            </Form.Row>
+            <Form.Row className="mb-2">
+              <Col sm={12}>
+                <Form.Group controlId="interfaceDocumentation">
+                  <Form.Label>Documentation</Form.Label>
+                  <Form.Control
+                    as="textarea"
+                    value={interfaceDraft.documentation || ''}
+                    onChange={handleInterfaceDocumentationChange}
+                    autoComplete="off"
+                    rows={3}
+                    isInvalid={interfaceValidationErrors.documentation != null}
+                  />
+                  <Form.Control.Feedback type="invalid">
+                    {interfaceValidationErrors.documentation}
+                  </Form.Control.Feedback>
+                </Form.Group>
+              </Col>
+            </Form.Row>
+            <Form.Row className="mb-2">
+              <Col sm={12}>
+                <Form.Group controlId="interfaceMappings">
+                  <button
+                    type="button"
+                    className="btn accordion-button w-100 mb-2"
+                    onClick={handleAddMapping}
+                  >
+                    <i className="fas fa-plus mr-2" /> Add new mapping...
+                  </button>
+                  {interfaceDraft.mappings.map((mapping, index) => (
+                    <MappingRow
+                      key={mapping.endpoint}
+                      className="mb-2"
+                      mapping={mapping}
+                      onEdit={() => handleEditMapping(index)}
+                      onDelete={() => handleDeleteMapping(index)}
+                    />
+                  ))}
+                  <Form.Control
+                    className="d-none"
+                    isInvalid={interfaceValidationErrors.mappings != null}
+                  />
+                  <Form.Control.Feedback type="invalid">
+                    {interfaceValidationErrors.mappings}
+                  </Form.Control.Feedback>
+                  <FormControlWarning message={interfaceValidationWarnings.mappings} />
+                </Form.Group>
+              </Col>
+            </Form.Row>
+          </Form>
+        </Container>
+      </Col>
+      {isSourceVisible && (
+        <Col md={6}>
+          <Form.Group controlId="interfaceSource" className="h-100 d-flex flex-column">
+            <Form.Control
+              as="textarea"
+              className="flex-grow-1 text-monospace"
+              value={interfaceSource}
+              onChange={handleInterfaceSourceChange}
+              autoComplete="off"
+              required
+              isValid={isValidInterfaceSource}
+              isInvalid={!isValidInterfaceSource}
+            />
+            <Form.Control.Feedback type="invalid">{interfaceSourceError}</Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      )}
+      {isMappingModalVisible && (
+        <MappingModal
+          interfaceType={interfaceDraft.type}
+          interfaceAggregation={interfaceDraft.aggregation}
+          mapping={mappingToEdit}
+          onCancel={() => setIsMappingModalVisible(false)}
+          onConfirm={handleConfirmEditMapping}
+        />
+      )}
+    </Row>
+  );
+};

--- a/src/react/components/MappingEditor.tsx
+++ b/src/react/components/MappingEditor.tsx
@@ -1,0 +1,333 @@
+/*
+   This file is part of Astarte.
+
+   Copyright 2020 Ispirata Srl
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import React from 'react';
+import { Col, Form, InputGroup } from 'react-bootstrap';
+import { AstarteMapping } from 'astarte-client';
+import type { AstarteInterface } from 'astarte-client';
+import _ from 'lodash';
+
+const astarteDataTypes: AstarteMapping['type'][] = [
+  'string',
+  'boolean',
+  'double',
+  'integer',
+  'longinteger',
+  'binaryblob',
+  'datetime',
+  'doublearray',
+  'integerarray',
+  'booleanarray',
+  'longintegerarray',
+  'stringarray',
+  'binaryblobarray',
+  'datetimearray',
+];
+
+const defaultMapping: AstarteMapping = {
+  endpoint: '',
+  type: 'double',
+};
+
+interface Props {
+  interfaceType: AstarteInterface['type'];
+  interfaceAggregation?: AstarteInterface['aggregation'];
+  mapping?: AstarteMapping;
+  onChange: (updatedMapping: AstarteMapping) => unknown;
+}
+
+export default ({
+  interfaceType,
+  interfaceAggregation = 'individual',
+  mapping = defaultMapping,
+  onChange,
+}: Props): React.ReactElement => {
+  const isPropertiesInterface = interfaceType === 'properties';
+  const isDatastreamIndividualInterface =
+    interfaceType === 'datastream' && interfaceAggregation === 'individual';
+  const showMappingExpiry = mapping.retention === 'volatile' || mapping.retention === 'stored';
+  const showInterfaceDatabaseRetentionTtl = mapping.databaseRetentionPolicy === 'use_ttl';
+
+  let mappingValidationErrors: { [property: string]: string } = {};
+  try {
+    AstarteMapping.validation.validateSync(mapping, { abortEarly: false });
+  } catch (err) {
+    mappingValidationErrors = _.mapValues(_.keyBy(_.uniqBy(err.inner, 'path'), 'path'), 'message');
+  }
+
+  return (
+    <Form>
+      <Form.Row className="mb-2">
+        <Col sm={12}>
+          <Form.Group controlId="mappingEndpoint">
+            <Form.Label>Endpoint</Form.Label>
+            <Form.Control
+              type="text"
+              value={mapping.endpoint}
+              onChange={({ target: { value } }) => onChange({ ...mapping, endpoint: value })}
+              autoComplete="off"
+              required
+              isInvalid={mappingValidationErrors.endpoint != null}
+            />
+            <Form.Control.Feedback type="invalid">
+              {mappingValidationErrors.endpoint}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Form.Row>
+      <Form.Row className="mb-2">
+        <Col sm={isPropertiesInterface ? 8 : 12}>
+          <Form.Group controlId="mappingType">
+            <Form.Label>Type</Form.Label>
+            <Form.Control
+              as="select"
+              value={mapping.type}
+              onChange={({ target: { value } }) =>
+                onChange({ ...mapping, type: value as AstarteMapping['type'] })
+              }
+              isInvalid={mappingValidationErrors.type != null}
+            >
+              {astarteDataTypes.map((t) => (
+                <option key={t}>{t}</option>
+              ))}
+            </Form.Control>
+            <Form.Control.Feedback type="invalid">
+              {mappingValidationErrors.type}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+        {isPropertiesInterface && (
+          <Col sm={4}>
+            <Form.Group controlId="mappingAllowUnset">
+              <Form.Label>Property options</Form.Label>
+              <Form.Check
+                type="checkbox"
+                label="Allow unset"
+                checked={!!mapping.allowUnset}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  const allowUnset = !!e.target.checked;
+                  onChange({ ...mapping, allowUnset: allowUnset || undefined });
+                }}
+                isInvalid={mappingValidationErrors.allowUnset != null}
+              />
+              <Form.Control.Feedback type="invalid">
+                {mappingValidationErrors.allowUnset}
+              </Form.Control.Feedback>
+            </Form.Group>
+          </Col>
+        )}
+      </Form.Row>
+      {isDatastreamIndividualInterface && (
+        <Form.Row className="mb-2">
+          <Col md={6}>
+            <Form.Group controlId="mappingReliability">
+              <Form.Label>Reliability</Form.Label>
+              <Form.Control
+                as="select"
+                name="reliability"
+                value={mapping.reliability || 'unreliable'}
+                onChange={({ currentTarget: { value } }) => {
+                  let reliability = value as AstarteMapping['reliability'];
+                  reliability = reliability === 'unreliable' ? undefined : reliability;
+                  onChange({ ...mapping, reliability });
+                }}
+                isInvalid={mappingValidationErrors.reliability != null}
+              >
+                <option value="unreliable">Unreliable</option>
+                <option value="guaranteed">Guaranteed</option>
+                <option value="unique">Unique</option>
+              </Form.Control>
+              <Form.Control.Feedback type="invalid">
+                {mappingValidationErrors.reliability}
+              </Form.Control.Feedback>
+            </Form.Group>
+          </Col>
+          <Col sm={6}>
+            <Form.Group controlId="mappingExplicitTimestamp">
+              <Form.Label>Timestamp</Form.Label>
+              <Form.Check
+                type="checkbox"
+                label="Explicit timestamp"
+                checked={!!mapping.explicitTimestamp}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  const explicitTimestamp = !!e.target.checked;
+                  onChange({ ...mapping, explicitTimestamp: explicitTimestamp || undefined });
+                }}
+                isInvalid={mappingValidationErrors.explicitTimestamp != null}
+              />
+              <Form.Control.Feedback type="invalid">
+                {mappingValidationErrors.explicitTimestamp}
+              </Form.Control.Feedback>
+            </Form.Group>
+          </Col>
+        </Form.Row>
+      )}
+      {isDatastreamIndividualInterface && (
+        <Form.Row className="mb-2">
+          <Col md={showMappingExpiry ? 6 : 12}>
+            <Form.Group controlId="mappingRetention">
+              <Form.Label>Retention</Form.Label>
+              <Form.Control
+                as="select"
+                name="retention"
+                value={mapping.retention || 'discard'}
+                onChange={({ currentTarget: { value } }) => {
+                  const retention = value as AstarteMapping['retention'];
+                  onChange({
+                    ...mapping,
+                    retention: retention === 'discard' ? undefined : retention,
+                    expiry: retention === 'discard' ? undefined : mapping.expiry,
+                  });
+                }}
+                isInvalid={mappingValidationErrors.retention != null}
+              >
+                <option value="discard">Discard</option>
+                <option value="volatile">Volatile</option>
+                <option value="stored">Stored</option>
+              </Form.Control>
+              <Form.Control.Feedback type="invalid">
+                {mappingValidationErrors.retention}
+              </Form.Control.Feedback>
+            </Form.Group>
+          </Col>
+          {showMappingExpiry && (
+            <Col md={6}>
+              <Form.Group controlId="mappingExpiry">
+                <Form.Label>Expiry</Form.Label>
+                <InputGroup>
+                  <Form.Control
+                    type="number"
+                    min={0}
+                    value={mapping.expiry || 0}
+                    onChange={({ currentTarget: { value } }) => {
+                      const expiry = parseInt(value, 10) || undefined;
+                      onChange({ ...mapping, expiry });
+                    }}
+                    isInvalid={mappingValidationErrors.expiry != null}
+                  />
+                  <InputGroup.Append>
+                    <InputGroup.Text>seconds</InputGroup.Text>
+                  </InputGroup.Append>
+                  <Form.Control.Feedback type="invalid">
+                    {mappingValidationErrors.expiry}
+                  </Form.Control.Feedback>
+                </InputGroup>
+              </Form.Group>
+            </Col>
+          )}
+        </Form.Row>
+      )}
+      {isDatastreamIndividualInterface && (
+        <Form.Row className="mb-2">
+          <Col md={showInterfaceDatabaseRetentionTtl ? 6 : 12}>
+            <Form.Group controlId="mappingDatabaseRetention">
+              <Form.Label>Database retention</Form.Label>
+              <Form.Control
+                as="select"
+                name="mappingDatabaseRetention"
+                value={mapping.databaseRetentionPolicy || 'no_ttl'}
+                onChange={({ currentTarget: { value } }) => {
+                  const databaseRetentionPolicy = value as AstarteMapping['databaseRetentionPolicy'];
+                  onChange({
+                    ...mapping,
+                    databaseRetentionPolicy:
+                      databaseRetentionPolicy === 'no_ttl' ? undefined : databaseRetentionPolicy,
+                    databaseRetentionTtl:
+                      databaseRetentionPolicy === 'no_ttl'
+                        ? undefined
+                        : mapping.databaseRetentionTtl || 60,
+                  });
+                }}
+                isInvalid={mappingValidationErrors.databaseRetentionPolicy != null}
+              >
+                <option value="no_ttl">No TTL</option>
+                <option value="use_ttl">Use TTL</option>
+              </Form.Control>
+              <Form.Control.Feedback type="invalid">
+                {mappingValidationErrors.databaseRetentionPolicy}
+              </Form.Control.Feedback>
+            </Form.Group>
+          </Col>
+          {showInterfaceDatabaseRetentionTtl && (
+            <Col md={6}>
+              <Form.Group controlId="mappingTTL">
+                <Form.Label>TTL</Form.Label>
+                <InputGroup>
+                  <Form.Control
+                    type="number"
+                    min={60}
+                    value={mapping.databaseRetentionTtl || 60}
+                    onChange={({ currentTarget: { value } }) => {
+                      const databaseRetentionTtl = parseInt(value, 10);
+                      onChange({ ...mapping, databaseRetentionTtl });
+                    }}
+                    isInvalid={mappingValidationErrors.databaseRetentionTtl != null}
+                  />
+                  <InputGroup.Append>
+                    <InputGroup.Text>seconds</InputGroup.Text>
+                  </InputGroup.Append>
+                  <Form.Control.Feedback type="invalid">
+                    {mappingValidationErrors.databaseRetentionTtl}
+                  </Form.Control.Feedback>
+                </InputGroup>
+              </Form.Group>
+            </Col>
+          )}
+        </Form.Row>
+      )}
+      <Form.Row className="mb-2">
+        <Col sm={12}>
+          <Form.Group controlId="mappingDescription">
+            <Form.Label>Description</Form.Label>
+            <Form.Control
+              as="textarea"
+              value={mapping.description || ''}
+              onChange={({ target: { value } }) =>
+                onChange({ ...mapping, description: value || undefined })
+              }
+              autoComplete="off"
+              isInvalid={mappingValidationErrors.description != null}
+            />
+            <Form.Control.Feedback type="invalid">
+              {mappingValidationErrors.description}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Form.Row>
+      <Form.Row className="mb-2">
+        <Col sm={12}>
+          <Form.Group controlId="mappingDocumentation">
+            <Form.Label>Documentation</Form.Label>
+            <Form.Control
+              as="textarea"
+              value={mapping.documentation || ''}
+              onChange={({ target: { value } }) =>
+                onChange({ ...mapping, documentation: value || undefined })
+              }
+              autoComplete="off"
+              isInvalid={mappingValidationErrors.documentation != null}
+            />
+            <Form.Control.Feedback type="invalid">
+              {mappingValidationErrors.documentation}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Form.Row>
+    </Form>
+  );
+};

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -204,6 +204,14 @@ h6,
   z-index: 2;
 }
 
+.warning-feedback {
+  display: block;
+  width: 100%;
+  margin-top: 0.25rem;
+  font-size: 70%;
+  color: $warning;
+}
+
 .suggestion {
   position: absolute;
   top: 2.4rem;


### PR DESCRIPTION
This PR implements the New Interface page in React. In doing so, two form components are also introduced, InterfaceEditor and MappingEditor, providing validation and visual feedback for errors and warnings.