### PR TITLE
Add Confirm and Form modal components

### DIFF
--- a/cypress/integration/block_page_test.js
+++ b/cypress/integration/block_page_test.js
@@ -20,6 +20,12 @@ describe('Block page tests', () => {
           .then((customBlock) => {
             cy.server();
             cy.route('GET', '/flow/v1/*/blocks/*', '@customBlock');
+            cy.route({
+              method: 'DELETE',
+              url: `/flow/v1/*/blocks/${customBlock.data.name}`,
+              status: 204,
+              response: '',
+            }).as('deleteBlockRequest');
             cy.login();
             cy.visit(`/blocks/${customBlock.data.name}`);
           });
@@ -37,6 +43,19 @@ describe('Block page tests', () => {
           cy.contains('Source');
           cy.contains('Schema');
         });
+      });
+
+      it('can delete a custom block', function () {
+        cy.get('.main-content').within(() => {
+          cy.contains('Delete block').click();
+        });
+        cy.get('.modal')
+          .contains(`Delete block ${this.customBlock.data.name}?`)
+          .parents('.modal')
+          .as('deleteModal');
+        cy.get('@deleteModal').get('button').contains('Remove').click();
+        cy.wait('@deleteBlockRequest');
+        cy.location('pathname').should('eq', '/blocks');
       });
     });
 
@@ -63,6 +82,12 @@ describe('Block page tests', () => {
           cy.contains('Type').next().contains(blockTypeToLabel[this.nativeBlock.data.type]);
           cy.contains('Source').should('not.exist');
           cy.contains('Schema');
+        });
+      });
+
+      it('cannot delete a native block', function () {
+        cy.get('.main-content').within(() => {
+          cy.contains('Delete block').should('not.exist');
         });
       });
     });

--- a/cypress/integration/pipeline_page_test.js
+++ b/cypress/integration/pipeline_page_test.js
@@ -20,7 +20,7 @@ describe('Pipeline page tests', () => {
             url: `/flow/v1/*/pipelines/${pipeline.data.name}`,
             status: 204,
             response: '',
-          }).as('deletePipeline');
+          }).as('deletePipelineRequest');
           cy.login();
           cy.visit(`/pipelines/${pipeline.data.name}`);
           cy.wait('@getPipeline');
@@ -42,12 +42,17 @@ describe('Pipeline page tests', () => {
       });
     });
 
-    it('can delete the pipeline', () => {
+    it('can delete the pipeline', function () {
       cy.get('.main-content').within(() => {
         cy.contains('Delete pipeline').click();
-        cy.wait('@deletePipeline');
-        cy.location('pathname').should('eq', '/pipelines');
       });
+      cy.get('.modal')
+        .contains(`Delete pipeline ${this.pipeline.data.name}?`)
+        .parents('.modal')
+        .as('deleteModal');
+      cy.get('@deleteModal').get('button').contains('Remove').click();
+      cy.wait('@deletePipelineRequest');
+      cy.location('pathname').should('eq', '/pipelines');
     });
   });
 });

--- a/cypress/integration/register_device_page_test.js
+++ b/cypress/integration/register_device_page_test.js
@@ -40,8 +40,8 @@ describe('Register device page tests', () => {
 
       cy.get('.btn').contains('Generate from name').click();
 
-      cy.get('#userNamespace').type(namespace);
-      cy.get('#userString').type(customString);
+      cy.get('[id$="userNamespace"]').type(namespace);
+      cy.get('[id$="userString"]').type(customString);
 
       cy.get('.btn').contains('Generate ID').click();
 

--- a/src/react/BlockSourcePage.tsx
+++ b/src/react/BlockSourcePage.tsx
@@ -23,6 +23,7 @@ import AstarteClient, { AstarteCustomBlock } from 'astarte-client';
 import type { AstarteBlock } from 'astarte-client';
 
 import { useAlerts } from './AlertManager';
+import ConfirmModal from './components/modals/Confirm';
 import SingleCardPage from './ui/SingleCardPage';
 
 const blockTypeToLabel = {
@@ -40,6 +41,7 @@ interface Props {
 export default ({ astarte, history, blockId }: Props): React.ReactElement => {
   const [phase, setPhase] = useState('loading');
   const [block, setBlock] = useState<AstarteBlock | null>(null);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isDeletingBlock, setIsDeletingBlock] = useState(false);
   const deletionAlerts = useAlerts();
 
@@ -51,6 +53,7 @@ export default ({ astarte, history, blockId }: Props): React.ReactElement => {
       .catch((err: Error) => {
         setIsDeletingBlock(false);
         deletionAlerts.showError(`Couldn't delete block: ${err.message}`);
+        setShowDeleteModal(false);
       });
   }, [astarte, history, setIsDeletingBlock, blockId, deletionAlerts.showError]);
 
@@ -102,7 +105,7 @@ export default ({ astarte, history, blockId }: Props): React.ReactElement => {
             {blockObj instanceof AstarteCustomBlock && (
               <Button
                 variant="danger"
-                onClick={isDeletingBlock ? undefined : deleteBlock}
+                onClick={() => setShowDeleteModal(true)}
                 disabled={isDeletingBlock}
               >
                 {isDeletingBlock && (
@@ -112,6 +115,20 @@ export default ({ astarte, history, blockId }: Props): React.ReactElement => {
               </Button>
             )}
           </Row>
+          {showDeleteModal && (
+            <ConfirmModal
+              title="Warning"
+              confirmLabel="Remove"
+              confirmVariant="danger"
+              onCancel={() => setShowDeleteModal(false)}
+              onConfirm={deleteBlock}
+              isConfirming={isDeletingBlock}
+            >
+              <p>
+                Delete block <b>{blockId}</b>?
+              </p>
+            </ConfirmModal>
+          )}
         </>
       );
 

--- a/src/react/FlowInstancesPage.tsx
+++ b/src/react/FlowInstancesPage.tsx
@@ -18,11 +18,12 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Button, Modal, OverlayTrigger, Spinner, Table, Tooltip } from 'react-bootstrap';
+import { Button, OverlayTrigger, Spinner, Table, Tooltip } from 'react-bootstrap';
 import AstarteClient from 'astarte-client';
 import type { AstarteFlow } from 'astarte-client';
 
 import { useAlerts } from './AlertManager';
+import ConfirmModal from './components/modals/Confirm';
 import SingleCardPage from './ui/SingleCardPage';
 
 const CircleIcon = React.forwardRef<HTMLElement, React.HTMLProps<HTMLElement>>((props, ref) => (
@@ -96,52 +97,6 @@ const InstancesTable = ({ instances, onDelete }: InstancesTableProps): React.Rea
   );
 };
 
-interface ConfirmDeletionModalProps {
-  show: boolean;
-  flowName: string;
-  isDeleting: boolean;
-  onCancel: () => void;
-  onDelete: () => void;
-}
-
-const ConfirmDeletionModal = ({
-  show,
-  flowName,
-  isDeleting,
-  onCancel,
-  onDelete,
-}: ConfirmDeletionModalProps): React.ReactElement => (
-  <div
-    onKeyDown={(e) => {
-      if (e.key === 'Enter' && !isDeleting) {
-        onDelete();
-      }
-    }}
-  >
-    <Modal size="sm" show={show} onHide={onCancel}>
-      <Modal.Header closeButton>
-        <Modal.Title>Warning</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        <p>
-          Delete flow <b>{flowName}</b>?
-        </p>
-      </Modal.Body>
-      <Modal.Footer>
-        <Button variant="secondary" onClick={onCancel}>
-          Cancel
-        </Button>
-        <Button variant="danger" onClick={onDelete} disabled={isDeleting}>
-          <>
-            {isDeleting && <Spinner className="mr-2" size="sm" animation="border" role="status" />}
-            Remove
-          </>
-        </Button>
-      </Modal.Footer>
-    </Modal>
-  </div>
-);
-
 interface Props {
   astarte: AstarteClient;
   history: any;
@@ -150,8 +105,7 @@ interface Props {
 export default ({ astarte, history }: Props): React.ReactElement => {
   const [phase, setPhase] = useState<'loading' | 'ok' | 'err'>('loading');
   const [instances, setInstances] = useState<AstarteFlow[] | null>(null);
-  const [isModalVisible, setIsModalVisible] = useState(false);
-  const [selectedFlow, setSelectedFlow] = useState<AstarteFlow['name'] | null>(null);
+  const [flowToConfirmDelete, setFlowToConfirmDelete] = useState<AstarteFlow['name'] | null>(null);
   const [isDeletingFlow, setIsDeletingFlow] = useState(false);
   const deletionAlerts = useAlerts();
 
@@ -179,22 +133,20 @@ export default ({ astarte, history }: Props): React.ReactElement => {
     astarte.getFlowInstances().then(handleFlowResponse).catch(handleFlowError);
   }, [astarte, setInstances, setPhase]);
 
-  const confirmDeleteFlow = useCallback(
+  const handleDeleteFlow = useCallback(
     (instance: AstarteFlow) => {
-      setSelectedFlow(instance.name);
-      setIsModalVisible(true);
+      setFlowToConfirmDelete(instance.name);
     },
-    [setSelectedFlow, setIsModalVisible],
+    [setFlowToConfirmDelete],
   );
 
   const deleteFlow = useCallback(() => {
-    const flowName = selectedFlow as AstarteFlow['name'];
+    const flowName = flowToConfirmDelete as AstarteFlow['name'];
     setIsDeletingFlow(true);
     astarte
       .deleteFlowInstance(flowName)
       .then(() => {
-        setIsModalVisible(false);
-        setSelectedFlow(null);
+        setFlowToConfirmDelete(null);
         setIsDeletingFlow(false);
         setInstances((oldInstances) =>
           (oldInstances || []).filter((instance) => instance.name !== flowName),
@@ -206,9 +158,8 @@ export default ({ astarte, history }: Props): React.ReactElement => {
         deletionAlerts.showError(`Could not delete flow instance: ${err.message}`);
       });
   }, [
-    selectedFlow,
-    setIsModalVisible,
-    setSelectedFlow,
+    flowToConfirmDelete,
+    setFlowToConfirmDelete,
     setIsDeletingFlow,
     setInstances,
     setPhase,
@@ -216,9 +167,8 @@ export default ({ astarte, history }: Props): React.ReactElement => {
   ]);
 
   const handleModalCancel = useCallback(() => {
-    setIsModalVisible(false);
-    setSelectedFlow(null);
-  }, [setIsModalVisible, setSelectedFlow]);
+    setFlowToConfirmDelete(null);
+  }, [setFlowToConfirmDelete]);
 
   let innerHTML;
 
@@ -227,7 +177,7 @@ export default ({ astarte, history }: Props): React.ReactElement => {
       innerHTML = (
         <>
           <deletionAlerts.Alerts />
-          <InstancesTable instances={instances as AstarteFlow[]} onDelete={confirmDeleteFlow} />
+          <InstancesTable instances={instances as AstarteFlow[]} onDelete={handleDeleteFlow} />
         </>
       );
       break;
@@ -251,13 +201,20 @@ export default ({ astarte, history }: Props): React.ReactElement => {
       <Button variant="primary" onClick={() => history.push('/pipelines')}>
         New flow
       </Button>
-      <ConfirmDeletionModal
-        show={isModalVisible}
-        flowName={selectedFlow || ''}
-        isDeleting={isDeletingFlow}
-        onCancel={handleModalCancel}
-        onDelete={deleteFlow}
-      />
+      {flowToConfirmDelete != null && (
+        <ConfirmModal
+          title="Warning"
+          confirmLabel="Remove"
+          confirmVariant="danger"
+          onCancel={handleModalCancel}
+          onConfirm={deleteFlow}
+          isConfirming={isDeletingFlow}
+        >
+          <p>
+            Delete flow <b>{flowToConfirmDelete}</b>?
+          </p>
+        </ConfirmModal>
+      )}
     </SingleCardPage>
   );
 };

--- a/src/react/GroupDevicesPage.tsx
+++ b/src/react/GroupDevicesPage.tsx
@@ -17,10 +17,11 @@
 */
 
 import React, { useEffect, useState, useCallback } from 'react';
-import { Button, Modal, OverlayTrigger, Spinner, Table, Tooltip } from 'react-bootstrap';
+import { Button, OverlayTrigger, Spinner, Table, Tooltip } from 'react-bootstrap';
 import AstarteClient, { AstarteDevice } from 'astarte-client';
-
 import { Link } from 'react-router-dom';
+
+import ConfirmModal from './components/modals/Confirm';
 import SingleCardPage from './ui/SingleCardPage';
 
 const CircleIcon = React.forwardRef<HTMLElement, React.HTMLProps<HTMLElement>>((props, ref) => (
@@ -28,55 +29,6 @@ const CircleIcon = React.forwardRef<HTMLElement, React.HTMLProps<HTMLElement>>((
     {props.children}
   </i>
 ));
-
-interface ConfirmDeviceRemovalModal {
-  deviceName: string;
-  groupName: string;
-  isLastDevice: boolean;
-  isRemoving: boolean;
-  show: boolean;
-  onCancel: () => void;
-  onRemove: () => void;
-}
-
-const ConfirmDeviceRemovalModal = ({
-  deviceName,
-  groupName,
-  isLastDevice,
-  isRemoving,
-  show,
-  onCancel,
-  onRemove,
-}: ConfirmDeviceRemovalModal): React.ReactElement => (
-  <div
-    onKeyDown={(e) => {
-      if (e.key === 'Enter' && !isRemoving) {
-        onRemove();
-      }
-    }}
-  >
-    <Modal size="lg" show={show} onHide={onCancel}>
-      <Modal.Header closeButton>
-        <Modal.Title>Warning</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        {isLastDevice && (
-          <p>This is the last device in the group. Removing this device will delete the group</p>
-        )}
-        <p>{`Remove device "${deviceName}" from group "${groupName}"?`}</p>
-      </Modal.Body>
-      <Modal.Footer>
-        <Button variant="secondary" onClick={onCancel}>
-          Cancel
-        </Button>
-        <Button variant="danger" disabled={isRemoving} onClick={onRemove}>
-          {isRemoving && <Spinner className="mr-2" size="sm" animation="border" role="status" />}
-          Remove
-        </Button>
-      </Modal.Footer>
-    </Modal>
-  </div>
-);
 
 const deviceTableRow = (
   device: AstarteDevice,
@@ -253,15 +205,23 @@ const GroupDevicesPage = ({ astarte, history, groupName }: Props): React.ReactEl
   return (
     <SingleCardPage title="Group Devices" backLink="/groups">
       {innerHTML}
-      <ConfirmDeviceRemovalModal
-        deviceName={selectedDeviceName}
-        groupName={groupName}
-        isLastDevice={devices?.length === 1}
-        isRemoving={isRemovingDevice}
-        show={isModalVisible}
-        onCancel={closeModal}
-        onRemove={removeDevice}
-      />
+      {isModalVisible && (
+        <ConfirmModal
+          title="Warning"
+          confirmLabel="Remove"
+          confirmVariant="danger"
+          onCancel={closeModal}
+          onConfirm={removeDevice}
+          isConfirming={isRemovingDevice}
+        >
+          {devices?.length === 1 && (
+            <p>This is the last device in the group. Removing this device will delete the group</p>
+          )}
+          <p>
+            Remove device <b>{selectedDeviceName}</b> from group <b>{groupName}</b>?
+          </p>
+        </ConfirmModal>
+      )}
     </SingleCardPage>
   );
 };

--- a/src/react/NewPipelinePage.tsx
+++ b/src/react/NewPipelinePage.tsx
@@ -18,59 +18,20 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { Button, Form, Modal, Spinner } from 'react-bootstrap';
+import { Button, Form, Spinner } from 'react-bootstrap';
 import Ajv from 'ajv';
 import metaSchemaDraft04 from 'ajv/lib/refs/json-schema-draft-04.json';
-import JsonSchemaForm from '@rjsf/bootstrap-4';
 import AstarteClient, { AstartePipeline } from 'astarte-client';
 import type { AstarteBlock } from 'astarte-client';
 
 import { useAlerts } from './AlertManager';
+import FormModal from './components/modals/Form';
 import VisualFlowEditor, { getNewModel, nodeModelToSource } from './components/VisualFlowEditor';
 import type NativeBlockModel from './models/NativeBlockModel';
 import SingleCardPage from './ui/SingleCardPage';
 
 const ajv = new Ajv({ schemaId: 'id' });
 ajv.addMetaSchema(metaSchemaDraft04);
-
-interface NodeSettingsModalProps {
-  node: NativeBlockModel;
-  schema: AstarteBlock['schema'];
-  initialData: { [key: string]: any };
-  onCancel: () => void;
-  onConfirm: (formData: { [key: string]: any }) => void;
-}
-
-const NodeSettingsModal = ({
-  node,
-  schema,
-  initialData,
-  onCancel,
-  onConfirm,
-}: NodeSettingsModalProps): React.ReactElement => (
-  <Modal size="lg" show onHide={onCancel}>
-    <Modal.Header closeButton>
-      <Modal.Title>Settings for {node.name}</Modal.Title>
-    </Modal.Header>
-    <Modal.Body>
-      <JsonSchemaForm
-        schema={schema}
-        additionalMetaSchemas={[metaSchemaDraft04]}
-        formData={initialData}
-        onSubmit={(params) => onConfirm(params.formData)}
-      >
-        <div className="form-footer">
-          <Button type="submit" variant="primary">
-            Apply settings
-          </Button>
-          <Button variant="secondary mr-2" onClick={onCancel}>
-            Cancel
-          </Button>
-        </div>
-      </JsonSchemaForm>
-    </Modal.Body>
-  </Modal>
-);
 
 interface CommandRowProps {
   className?: string;
@@ -162,10 +123,11 @@ export default ({ astarte, history }: Props): React.ReactElement => {
       editorModel.setLocked(true);
 
       setActiveModal(
-        <NodeSettingsModal
-          node={node}
+        <FormModal
+          title={`Settings for ${node.name}`}
           schema={blockDefinition.schema}
           initialData={node.getProperties()}
+          confirmLabel="Apply settings"
           onCancel={() => {
             setActiveModal(null);
             editorModel.setLocked(false);

--- a/src/react/PipelineSourcePage.tsx
+++ b/src/react/PipelineSourcePage.tsx
@@ -24,6 +24,7 @@ import _ from 'lodash';
 
 import { useAlerts } from './AlertManager';
 import SingleCardPage from './ui/SingleCardPage';
+import ConfirmModal from './components/modals/Confirm';
 import WaitForData from './components/WaitForData';
 import useFetch from './hooks/useFetch';
 
@@ -35,6 +36,7 @@ interface Props {
 
 export default ({ astarte, history, pipelineId }: Props): React.ReactElement => {
   const pipelineFetcher = useFetch(() => astarte.getPipeline(pipelineId));
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isDeletingPipeline, setIsDeletingPipeline] = useState(false);
   const deletionAlerts = useAlerts();
 
@@ -46,6 +48,7 @@ export default ({ astarte, history, pipelineId }: Props): React.ReactElement => 
       .catch((err) => {
         deletionAlerts.showError(`Couldn't delete pipeline: ${err.message}`);
         setIsDeletingPipeline(false);
+        setShowDeleteModal(false);
       });
   }, [astarte, pipelineId, history, deletionAlerts.showError]);
 
@@ -84,7 +87,11 @@ export default ({ astarte, history, pipelineId }: Props): React.ReactElement => 
                 )}
               </Col>
             </Row>
-            <Button variant="danger" onClick={deletePipeline} disabled={isDeletingPipeline}>
+            <Button
+              variant="danger"
+              onClick={() => setShowDeleteModal(true)}
+              disabled={isDeletingPipeline}
+            >
               {isDeletingPipeline && (
                 <Spinner as="span" size="sm" animation="border" role="status" className="mr-2" />
               )}
@@ -93,6 +100,20 @@ export default ({ astarte, history, pipelineId }: Props): React.ReactElement => 
           </>
         )}
       </WaitForData>
+      {showDeleteModal && (
+        <ConfirmModal
+          title="Warning"
+          confirmLabel="Remove"
+          confirmVariant="danger"
+          onCancel={() => setShowDeleteModal(false)}
+          onConfirm={deletePipeline}
+          isConfirming={isDeletingPipeline}
+        >
+          <p>
+            Delete pipeline <b>{pipelineId}</b>?
+          </p>
+        </ConfirmModal>
+      )}
     </SingleCardPage>
   );
 };

--- a/src/react/RealmSettingsPage.tsx
+++ b/src/react/RealmSettingsPage.tsx
@@ -17,54 +17,12 @@
 */
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { Button, Form, Modal, Spinner } from 'react-bootstrap';
+import { Button, Form, Spinner } from 'react-bootstrap';
 import AstarteClient from 'astarte-client';
 
+import ConfirmModal from './components/modals/Confirm';
 import SingleCardPage from './ui/SingleCardPage';
 import { useAlerts } from './AlertManager';
-
-interface ConfirmKeyChangesProps {
-  show: boolean;
-  isUpdating: boolean;
-  onCancel: () => void;
-  onConfirm: () => void;
-}
-
-const ConfirmKeyChanges = ({
-  show,
-  isUpdating,
-  onCancel,
-  onConfirm,
-}: ConfirmKeyChangesProps): React.ReactElement => (
-  <div
-    onKeyDown={(e) => {
-      if (e.key === 'Enter' && !isUpdating) {
-        onConfirm();
-      }
-    }}
-  >
-    <Modal size="lg" show={show} onHide={onCancel}>
-      <Modal.Header closeButton>
-        <Modal.Title>Confirm Public Key Update</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        <p>
-          Realm public key will be changed, users will not be able to make further API calls using
-          their current auth token. Confirm?
-        </p>
-      </Modal.Body>
-      <Modal.Footer>
-        <Button variant="secondary" onClick={onCancel}>
-          Cancel
-        </Button>
-        <Button variant="primary" onClick={onConfirm} disabled={isUpdating}>
-          {isUpdating && <Spinner className="mr-2" size="sm" animation="border" role="status" />}
-          Update settings
-        </Button>
-      </Modal.Footer>
-    </Modal>
-  </div>
-);
 
 interface Props {
   astarte: AstarteClient;
@@ -127,8 +85,14 @@ export default ({ astarte, history }: Props): React.ReactElement => {
                 onChange={(e) => setDraftPublicKey(e.target.value)}
               />
             </Form.Group>
-            {/* TODO: this action is destructive, maybe we should use danger/warning variants */}
-            <Button variant="primary" disabled={!canUpdatePublicKey} onClick={showModal}>
+            <Button
+              variant="danger"
+              disabled={!canUpdatePublicKey || isUpdatingSettings}
+              onClick={showModal}
+            >
+              {isUpdatingSettings && (
+                <Spinner as="span" size="sm" animation="border" role="status" className="mr-2" />
+              )}
               Apply
             </Button>
           </Form>
@@ -152,12 +116,21 @@ export default ({ astarte, history }: Props): React.ReactElement => {
   return (
     <SingleCardPage title="Realm Settings">
       {innerHTML}
-      <ConfirmKeyChanges
-        isUpdating={isUpdatingSettings}
-        show={isModalVisible}
-        onCancel={dismissModal}
-        onConfirm={applyNewSettings}
-      />
+      {isModalVisible && (
+        <ConfirmModal
+          title="Confirm Public Key Update"
+          confirmLabel="Update settings"
+          confirmVariant="danger"
+          onCancel={dismissModal}
+          onConfirm={applyNewSettings}
+          isConfirming={isUpdatingSettings}
+        >
+          <p>
+            Realm public key will be changed, users will not be able to make further API calls using
+            their current auth token. Confirm?
+          </p>
+        </ConfirmModal>
+      )}
     </SingleCardPage>
   );
 };

--- a/src/react/components/modals/Confirm.tsx
+++ b/src/react/components/modals/Confirm.tsx
@@ -1,0 +1,95 @@
+/*
+   This file is part of Astarte.
+
+   Copyright 2020 Ispirata Srl
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import React, { useCallback } from 'react';
+import { Button, Modal, Spinner } from 'react-bootstrap';
+import type { ModalProps } from 'react-bootstrap';
+
+type BoostrapVariant =
+  | 'primary'
+  | 'secondary'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'info'
+  | 'light'
+  | 'dark'
+  | 'link';
+
+interface Props {
+  cancelLabel?: string;
+  children: React.ReactNode;
+  confirmLabel?: string;
+  confirmOnEnter?: boolean;
+  confirmVariant?: BoostrapVariant;
+  isConfirming?: boolean;
+  onCancel?: () => void;
+  onConfirm: () => void;
+  size?: ModalProps['size'];
+  title: React.ReactNode;
+}
+
+const ConfirmModal = ({
+  cancelLabel = 'Cancel',
+  children,
+  confirmLabel = 'Confirm',
+  confirmOnEnter = true,
+  confirmVariant = 'primary',
+  isConfirming = false,
+  onCancel,
+  onConfirm,
+  size = 'lg',
+  title,
+}: Props): React.ReactElement => {
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' && confirmOnEnter && !isConfirming) {
+      onConfirm();
+    }
+  }, []);
+
+  return (
+    <div onKeyDown={handleKeyDown}>
+      <Modal show centered size={size} onHide={onCancel || onConfirm}>
+        <Modal.Header closeButton>
+          <Modal.Title>{title}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>{children}</Modal.Body>
+        <Modal.Footer>
+          {onCancel && (
+            <Button variant="secondary" onClick={onCancel} style={{ minWidth: '5em' }}>
+              {cancelLabel}
+            </Button>
+          )}
+          <Button
+            variant={confirmVariant}
+            disabled={isConfirming}
+            onClick={onConfirm}
+            style={{ minWidth: '5em' }}
+          >
+            {isConfirming && (
+              <Spinner className="mr-2" size="sm" animation="border" role="status" />
+            )}
+            {confirmLabel}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </div>
+  );
+};
+
+export default ConfirmModal;

--- a/src/react/components/modals/Form.tsx
+++ b/src/react/components/modals/Form.tsx
@@ -1,0 +1,191 @@
+/*
+   This file is part of Astarte.
+
+   Copyright 2020 Ispirata Srl
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import React, { useState } from 'react';
+import { Button, Form, Modal, Spinner } from 'react-bootstrap';
+import type { ModalProps } from 'react-bootstrap';
+import metaSchemaDraft04 from 'ajv/lib/refs/json-schema-draft-04.json';
+import JsonSchemaForm from '@rjsf/bootstrap-4';
+import type { WidgetProps } from '@rjsf/core';
+import type { ComponentProps } from 'react';
+
+const additionalMetaSchemas = [metaSchemaDraft04];
+
+export interface TextWidgetProps extends WidgetProps {
+  type?: string;
+}
+
+const TextWidget = ({
+  id,
+  required,
+  readonly,
+  disabled,
+  placeholder,
+  type,
+  label,
+  value,
+  onChange,
+  onBlur,
+  onFocus,
+  autofocus,
+  options,
+  schema,
+  rawErrors = [],
+}: TextWidgetProps) => {
+  const handleChange = ({ target: { value: v } }: React.ChangeEvent<HTMLInputElement>) =>
+    onChange(v === '' ? options.emptyValue : v);
+  const handleBlur = ({ target: { value: v } }: React.FocusEvent<HTMLInputElement>) =>
+    onBlur(id, v);
+  const handleFocus = ({ target: { value: v } }: React.FocusEvent<HTMLInputElement>) =>
+    onFocus(id, v);
+
+  return (
+    <Form.Group className="mb-0">
+      <Form.Label className={rawErrors.length > 0 ? 'text-danger' : ''}>
+        {label || schema.title}
+        {(label || schema.title) && required ? '*' : null}
+      </Form.Label>
+      <Form.Control
+        id={id}
+        autoFocus={autofocus}
+        required={required}
+        disabled={disabled}
+        readOnly={readonly}
+        placeholder={placeholder}
+        className={rawErrors.length > 0 ? 'is-invalid' : ''}
+        list={schema.examples ? `examples_${id}` : undefined}
+        type={type || (schema.type as string)}
+        value={value || value === 0 ? value : ''}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onFocus={handleFocus}
+      />
+      {schema.examples ? (
+        <datalist id={`examples_${id}`}>
+          {(schema.examples as string[])
+            .concat(schema.default ? ([schema.default] as string[]) : [])
+            .map((example: any) => {
+              // eslint-disable-next-line jsx-a11y/control-has-associated-label
+              return <option key={example} value={example} />;
+            })}
+        </datalist>
+      ) : null}
+    </Form.Group>
+  );
+};
+
+// Delete custom widgets when this is issue is solved and 'placeholder' is supported
+// https://github.com/rjsf-team/react-jsonschema-form/issues/1998
+const widgets = {
+  TextWidget,
+};
+
+type JsonSchemaFormProps = ComponentProps<typeof JsonSchemaForm>;
+
+type BoostrapVariant =
+  | 'primary'
+  | 'secondary'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'info'
+  | 'light'
+  | 'dark'
+  | 'link';
+
+interface Props {
+  cancelLabel?: string;
+  confirmLabel?: string;
+  confirmVariant?: BoostrapVariant;
+  initialData?: JsonSchemaFormProps['formData'];
+  isConfirming?: boolean;
+  liveValidate?: boolean;
+  onCancel: () => void;
+  onConfirm: (formData: any) => void;
+  schema: JsonSchemaFormProps['schema'];
+  size?: ModalProps['size'];
+  title: React.ReactNode;
+  transformErrors?: JsonSchemaFormProps['transformErrors'];
+  uiSchema?: JsonSchemaFormProps['uiSchema'];
+}
+
+const FormModal = ({
+  cancelLabel = 'Cancel',
+  confirmLabel = 'Confirm',
+  confirmVariant = 'primary',
+  initialData,
+  isConfirming = false,
+  liveValidate = false,
+  onCancel,
+  onConfirm,
+  schema,
+  size = 'lg',
+  title,
+  transformErrors,
+  uiSchema,
+}: Props): React.ReactElement => {
+  const [formData, setFormData] = React.useState(initialData || null);
+  const [hasSubmit, setHasSubmit] = useState(false);
+
+  return (
+    <Modal show centered size={size} onHide={onCancel}>
+      <Modal.Header closeButton>
+        <Modal.Title>{title}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div>
+          <JsonSchemaForm
+            schema={schema}
+            additionalMetaSchemas={additionalMetaSchemas}
+            uiSchema={uiSchema}
+            widgets={widgets}
+            formData={formData}
+            liveValidate={liveValidate || hasSubmit}
+            onChange={(event) => {
+              setFormData(event.formData);
+            }}
+            onSubmit={(event) => onConfirm(event.formData)}
+            showErrorList={false}
+            transformErrors={transformErrors}
+          >
+            <hr style={{ display: 'block', marginLeft: '-1em', marginRight: '-1em' }} />
+            <div className="d-flex justify-content-end">
+              <Button variant="secondary mr-2" onClick={onCancel} style={{ minWidth: '5em' }}>
+                {cancelLabel}
+              </Button>
+              <Button
+                type="submit"
+                variant={confirmVariant}
+                disabled={isConfirming}
+                onClick={() => setHasSubmit(true)}
+                style={{ minWidth: '5em' }}
+              >
+                {isConfirming && (
+                  <Spinner className="mr-2" size="sm" animation="border" role="status" />
+                )}
+                {confirmLabel}
+              </Button>
+            </div>
+          </JsonSchemaForm>
+        </div>
+      </Modal.Body>
+    </Modal>
+  );
+};
+
+export default FormModal;

--- a/src/react/components/modals/Form.tsx
+++ b/src/react/components/modals/Form.tsx
@@ -58,7 +58,6 @@ const TextWidget = ({
     <Form.Group className="mb-0">
       <Form.Label className={rawErrors.length > 0 ? 'text-danger' : ''}>
         {label || schema.title}
-        {(label || schema.title) && required ? '*' : null}
       </Form.Label>
       <Form.Control
         id={id}


### PR DESCRIPTION
This PR adds two Modal components useful to standardize and model two situations:
- the case where a *simple confirmation* should be asked to the user before taking some further action (ConfirmModal)
- the case where some *contextual data* should be asked to the user before taking some further action (FormModal)

The FormModal component supports auto-generating forms from a JSON schema definition.

The ConfirmModal is used to ask the user to confirm deletion of a block or pipeline before proceeding with a destructive action:

https://user-images.githubusercontent.com/60540759/101225610-2d6a5300-3692-11eb-8b77-f40c92ba7156.png

https://user-images.githubusercontent.com/60540759/101225614-30fdda00-3692-11eb-846f-ce8cecc25ce5.png

The two modal components are also reused throughout the app to standardize the modals behavior and style, including size, centered positioning and danger color for destructive actions.

Device deletion before:

https://user-images.githubusercontent.com/60540759/101225640-44a94080-3692-11eb-9eda-a244e56a8c05.png

Device deletion after:

https://user-images.githubusercontent.com/60540759/101226367-8509be00-3694-11eb-8dc5-198c54b1373b.png

Flow deletion before:

https://user-images.githubusercontent.com/60540759/101225673-5559b680-3692-11eb-819e-a3560312fd92.png

Flow deletion after:

https://user-images.githubusercontent.com/60540759/101225684-5db1f180-3692-11eb-9909-5f0a60c8df53.png

Device ID generation before:

https://user-images.githubusercontent.com/60540759/101225700-699db380-3692-11eb-88dd-5d7220a56848.png

Device ID generation after:

https://user-images.githubusercontent.com/60540759/101628616-5dae4a80-3a20-11eb-9c79-1cacff121791.png

Device registered before:

https://user-images.githubusercontent.com/60540759/101225741-876b1880-3692-11eb-9d72-ba03910eeeff.png

Device registered after:

https://user-images.githubusercontent.com/60540759/101225748-8d60f980-3692-11eb-9f03-d78aa1fd98bf.png

Realm settings before:

https://user-images.githubusercontent.com/60540759/101225766-9782f800-3692-11eb-9ca8-ee3abfe96c80.png

Realm settings after:

https://user-images.githubusercontent.com/60540759/101225772-9e116f80-3692-11eb-8676-ddea0ad2d4e2.png

Pipeline builder before:

https://user-images.githubusercontent.com/60540759/101225803-bbded480-3692-11eb-8bd7-522cfd058995.png

Pipeline builder after:

https://user-images.githubusercontent.com/60540759/101628781-9e0dc880-3a20-11eb-8dc3-72acee63f857.png
