### PR TITLE
Use tree structure to format interfaces data

### DIFF
--- a/cypress/integration/interface_value_page_test.js
+++ b/cypress/integration/interface_value_page_test.js
@@ -45,7 +45,7 @@ describe('Interface values page tests', () => {
               });
               cy.visit(`/devices/${deviceId}/interfaces/${interfaceName}`);
               cy.get('.main-content .card-body [role="alert"]').contains(
-                'Could not retrieve interface properties.',
+                'Could not retrieve interface data.',
               );
             });
         });
@@ -75,7 +75,9 @@ describe('Interface values page tests', () => {
                 response: '',
               });
               cy.visit(`/devices/${deviceId}/interfaces/${interfaceName}`);
-              cy.get('.main-content .card-body [role="alert"]').contains('Device not found.');
+              cy.get('.main-content .card-body [role="alert"]').contains(
+                'Could not retrieve interface data.',
+              );
             });
         });
     });

--- a/src/astarte-client/index.ts
+++ b/src/astarte-client/index.ts
@@ -34,10 +34,17 @@ export {
 
 export type { AstarteBlock } from './models';
 
+export type { AstarteDataTreeNode, AstarteDataTreeKind } from './transforms';
+
 export type {
   AstarteDataType,
+  AstarteDataTuple,
+  AstarteDataValue,
   AstarteDeviceEvent,
-  AstartePropertiesInterfaceValue,
+  AstartePropertyData,
+  AstarteDatastreamData,
+  AstarteDatastreamIndividualData,
+  AstarteDatastreamObjectData,
   AstartePropertiesInterfaceValues,
   AstarteIndividualDatastreamInterfaceValue,
   AstarteIndividualDatastreamInterfaceValues,

--- a/src/astarte-client/models/Interface/index.ts
+++ b/src/astarte-client/models/Interface/index.ts
@@ -191,6 +191,10 @@ export class AstarteInterface {
     );
   }
 
+  static findEndpointMapping(iface: AstarteInterface, endpoint: string): AstarteMapping | null {
+    return iface.mappings.find((m) => AstarteMapping.matchEndpoint(m.endpoint, endpoint)) || null;
+  }
+
   static validation = astarteInterfaceObjectSchema;
 
   static fromJSON(json: AstarteInterfaceJSON): AstarteInterface {

--- a/src/astarte-client/transforms/dataTree.ts
+++ b/src/astarte-client/transforms/dataTree.ts
@@ -1,0 +1,472 @@
+/* eslint-disable max-classes-per-file */
+/*
+   This file is part of Astarte.
+   Copyright 2020 Ispirata Srl
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import _ from 'lodash';
+
+import { AstarteInterface } from '../models';
+import type {
+  AstarteDataType,
+  AstarteDataValue,
+  AstarteDataTuple,
+  AstartePropertyData,
+  AstarteDatastreamData,
+  AstarteDatastreamIndividualData,
+  AstarteDatastreamObjectData,
+  AstarteInterfaceValues,
+  AstarteIndividualDatastreamInterfaceValue,
+  AstarteAggregatedDatastreamInterfaceValue,
+} from '../types';
+
+const getEndpointDataType = (iface: AstarteInterface, endpoint: string): AstarteDataType => {
+  const matchedMapping = AstarteInterface.findEndpointMapping(iface, endpoint);
+  if (matchedMapping == null) {
+    throw new Error(`Could not find an interface mapping for the endpoint ${endpoint}`);
+  }
+  return matchedMapping.type;
+};
+
+const isAstarteDataValue = (value: unknown): value is AstarteDataValue =>
+  !_.isUndefined(value) && (!_.isPlainObject(value) || _.isNull(value));
+
+const isPropertiesInterfaceValue = (value: unknown): value is AstarteDataValue =>
+  isAstarteDataValue(value);
+
+const isIndividualDatastreamInterfaceValue = (
+  value: unknown,
+): value is AstarteIndividualDatastreamInterfaceValue => isAstarteDataValue(_.get(value, 'value'));
+
+const isAggregatedDatastreamInterfaceValue = (
+  value: unknown,
+): value is AstarteAggregatedDatastreamInterfaceValue => Array.isArray(value);
+
+type AstarteDataTreeKind = 'properties' | 'datastream_object' | 'datastream_individual';
+
+const getDataTreeKind = (iface: AstarteInterface): AstarteDataTreeKind => {
+  if (iface.type === 'properties') {
+    return 'properties';
+  }
+  if (iface.aggregation === 'object') {
+    return 'datastream_object';
+  }
+  return 'datastream_individual';
+};
+
+type JSON<Value> = Value | { [prop: string]: JSON<Value> };
+
+type Equals<T, S> = [T] extends [S] ? ([S] extends [T] ? true : false) : false;
+
+interface AstarteDataTreeNode<
+  Data extends AstartePropertyData | AstarteDatastreamIndividualData | AstarteDatastreamObjectData
+> {
+  dataKind: AstarteDataTreeKind;
+  name: string;
+  endpoint: string;
+  getParentNode: () => AstarteDataTreeNode<Data> | null;
+  getNode: (endpoint: string) => AstarteDataTreeNode<Data> | null;
+  getLeaves: () => AstarteDataTreeNode<Data>[];
+  toData: () => Equals<Data, AstarteDatastreamObjectData> extends true
+    ? AstarteDatastreamObjectData[]
+    : Equals<Data, AstarteDatastreamIndividualData> extends true
+    ? AstarteDatastreamIndividualData[]
+    : AstartePropertyData[];
+  toLinearizedData: () => Equals<Data, AstarteDatastreamObjectData> extends true
+    ? AstarteDatastreamData[]
+    : Equals<Data, AstarteDatastreamIndividualData> extends true
+    ? AstarteDatastreamData[]
+    : AstartePropertyData[];
+  toLastValue: () => JSON<AstarteDataValue>;
+}
+
+interface AstarteDataTreeLeafNodeParams<
+  Data extends AstartePropertyData | AstarteDatastreamIndividualData | AstarteDatastreamObjectData
+> {
+  interface: AstarteInterface;
+  data: Equals<Data, AstarteDatastreamObjectData> extends true
+    ? AstarteDatastreamObjectData[]
+    : Equals<Data, AstarteDatastreamIndividualData> extends true
+    ? AstarteDatastreamIndividualData[]
+    : AstartePropertyData;
+  endpoint?: string;
+  parentNode?: AstarteDataTreeBranchNode<Data> | null;
+}
+
+class AstarteDataTreeLeafNode<
+  Data extends AstartePropertyData | AstarteDatastreamIndividualData | AstarteDatastreamObjectData
+> implements AstarteDataTreeNode<Data> {
+  readonly dataKind: AstarteDataTreeKind;
+
+  readonly endpoint: string;
+
+  private readonly parent: AstarteDataTreeBranchNode<Data> | null;
+
+  private readonly data: Equals<Data, AstarteDatastreamObjectData> extends true
+    ? AstarteDatastreamObjectData[]
+    : Equals<Data, AstarteDatastreamIndividualData> extends true
+    ? AstarteDatastreamIndividualData[]
+    : AstartePropertyData;
+
+  private readonly linearizedData: Equals<Data, AstarteDatastreamObjectData> extends true
+    ? AstarteDatastreamData[]
+    : Equals<Data, AstarteDatastreamIndividualData> extends true
+    ? AstarteDatastreamData[]
+    : AstartePropertyData;
+
+  constructor({
+    interface: iface,
+    data,
+    endpoint = '',
+    parentNode = null,
+  }: AstarteDataTreeLeafNodeParams<Data>) {
+    this.endpoint = endpoint;
+    this.parent = parentNode;
+    this.dataKind = getDataTreeKind(iface);
+    this.data = data;
+    if (iface.type === 'properties') {
+      // @ts-expect-error cannot correctly infer from generics
+      this.linearizedData = data as AstartePropertyData;
+    } else if (iface.type === 'datastream' && iface.aggregation === 'individual') {
+      const interfaceData = data as AstarteDatastreamIndividualData[];
+      // @ts-expect-error cannot correctly infer from generics
+      this.linearizedData = interfaceData.map((obj) => ({
+        endpoint: obj.endpoint,
+        timestamp: obj.timestamp,
+        ...({ type: obj.type, value: obj.value } as AstarteDataTuple),
+      })) as AstarteDatastreamData[];
+    } else {
+      const interfaceData = data as AstarteDatastreamObjectData[];
+      // @ts-expect-error cannot correctly infer from generics
+      this.linearizedData = interfaceData
+        .map((obj) =>
+          Object.entries(obj.value).map(([prop, propValue]) => ({
+            endpoint: `${obj.endpoint}/${prop}`,
+            timestamp: obj.timestamp,
+            ...propValue,
+          })),
+        )
+        .flat() as AstarteDatastreamData[];
+    }
+  }
+
+  getParentNode(): AstarteDataTreeBranchNode<Data> | null {
+    return this.parent;
+  }
+
+  getNode(endpoint: string): AstarteDataTreeLeafNode<Data> | null {
+    const sanitizedEndpoint = endpoint.replace(/\/$/, '');
+    if (sanitizedEndpoint === this.endpoint) {
+      return this;
+    }
+    return null;
+  }
+
+  getLeaves(): AstarteDataTreeLeafNode<Data>[] {
+    return [this];
+  }
+
+  toData(): Equals<Data, AstarteDatastreamObjectData> extends true
+    ? AstarteDatastreamObjectData[]
+    : Equals<Data, AstarteDatastreamIndividualData> extends true
+    ? AstarteDatastreamIndividualData[]
+    : [AstartePropertyData] {
+    // @ts-expect-error cannot correctly infer from generics
+    return _.isArray(this.data) ? this.data : [this.data];
+  }
+
+  toLinearizedData(): Equals<Data, AstarteDatastreamObjectData> extends true
+    ? AstarteDatastreamData[]
+    : Equals<Data, AstarteDatastreamIndividualData> extends true
+    ? AstarteDatastreamData[]
+    : [AstartePropertyData] {
+    // @ts-expect-error cannot correctly infer from generics
+    return _.isArray(this.linearizedData) ? this.linearizedData : [this.linearizedData];
+  }
+
+  toLastValue(): JSON<AstarteDataValue> {
+    if (this.dataKind === 'properties') {
+      const data = this.data as AstartePropertyData;
+      return data.value;
+    }
+    if (this.dataKind === 'datastream_individual') {
+      const data = this.data as AstarteDatastreamIndividualData[];
+      const lastData: AstarteDatastreamIndividualData | undefined = _.last(
+        _.orderBy(data, ['timestamp'], ['asc']),
+      );
+      return lastData ? lastData.value : null;
+    }
+    const data = this.data as AstarteDatastreamObjectData[];
+    const lastData: AstarteDatastreamObjectData | undefined = _.last(
+      _.orderBy(data, ['timestamp'], ['asc']),
+    );
+    return lastData ? _.mapValues(lastData.value, (valueTuple) => valueTuple.value) : null;
+  }
+
+  get name(): string {
+    return this.parent != null ? this.endpoint.replace(`${this.parent.endpoint}/`, '') : '';
+  }
+}
+
+interface AstarteDataTreeBranchNodeParams<
+  Data extends AstartePropertyData | AstarteDatastreamIndividualData | AstarteDatastreamObjectData
+> {
+  interface: AstarteInterface;
+  data: AstarteInterfaceValues;
+  endpoint?: string;
+  parentNode?: AstarteDataTreeBranchNode<Data> | null;
+}
+class AstarteDataTreeBranchNode<
+  Data extends AstartePropertyData | AstarteDatastreamIndividualData | AstarteDatastreamObjectData
+> implements AstarteDataTreeNode<Data> {
+  readonly dataKind: AstarteDataTreeKind;
+
+  readonly endpoint: string;
+
+  private readonly parent: AstarteDataTreeBranchNode<Data> | null;
+
+  private readonly children: Array<AstarteDataTreeBranchNode<Data> | AstarteDataTreeLeafNode<Data>>;
+
+  constructor({
+    interface: iface,
+    data,
+    endpoint = '',
+    parentNode = null,
+  }: AstarteDataTreeBranchNodeParams<Data>) {
+    this.endpoint = endpoint;
+    this.parent = parentNode;
+    this.dataKind = getDataTreeKind(iface);
+    if (iface.type === 'properties') {
+      // @ts-expect-error cannot correctly infer from generics
+      this.children = Object.entries(data).map(([prop, propValue]) =>
+        toPropertiesTreeNode({
+          interface: iface,
+          data: propValue,
+          endpoint: `${endpoint}/${prop}`,
+          // @ts-expect-error cannot correctly infer from generics
+          parentNode: this as AstarteDataTreeBranchNode<AstartePropertyData>,
+        }),
+      ) as Array<AstarteDataTreeBranchNode<Data> | AstarteDataTreeLeafNode<Data>>;
+    } else if (iface.type === 'datastream' && iface.aggregation === 'individual') {
+      // @ts-expect-error cannot correctly infer from generics
+      this.children = Object.entries(data).map(([prop, propValue]) =>
+        toDatastreamIndividualTreeNode({
+          interface: iface,
+          data: propValue,
+          endpoint: `${endpoint}/${prop}`,
+          // @ts-expect-error cannot correctly infer from generics
+          parentNode: this as AstarteDataTreeBranchNode<AstarteDatastreamIndividualData>,
+        }),
+      ) as Array<AstarteDataTreeBranchNode<Data> | AstarteDataTreeLeafNode<Data>>;
+    } else {
+      // @ts-expect-error cannot correctly infer from generics
+      this.children = Object.entries(data).map(([prop, propValue]) =>
+        toDatastreamObjectTreeNode({
+          interface: iface,
+          data: propValue,
+          endpoint: `${endpoint}/${prop}`,
+          // @ts-expect-error cannot correctly infer from generics
+          parentNode: this as AstarteDataTreeBranchNode<AstarteDatastreamObjectData>,
+        }),
+      ) as Array<AstarteDataTreeBranchNode<Data> | AstarteDataTreeLeafNode<Data>>;
+    }
+  }
+
+  getParentNode(): AstarteDataTreeBranchNode<Data> | null {
+    return this.parent;
+  }
+
+  getNode(
+    endpoint: string,
+  ): AstarteDataTreeBranchNode<Data> | AstarteDataTreeLeafNode<Data> | null {
+    const sanitizedEndpoint = endpoint.replace(/\/$/, '');
+    if (sanitizedEndpoint === this.endpoint) {
+      return this;
+    }
+    if (this.children.length === 0) {
+      return null;
+    }
+    let foundNode: AstarteDataTreeBranchNode<Data> | AstarteDataTreeLeafNode<Data> | null = null;
+    this.children.forEach((child) => {
+      const node = child.getNode(sanitizedEndpoint);
+      if (node != null) {
+        foundNode = node;
+      }
+    });
+    return foundNode;
+  }
+
+  getLeaves(): AstarteDataTreeLeafNode<Data>[] {
+    return this.children.map((child) => child.getLeaves()).flat();
+  }
+
+  toData(): Equals<Data, AstarteDatastreamObjectData> extends true
+    ? AstarteDatastreamObjectData[]
+    : Equals<Data, AstarteDatastreamIndividualData> extends true
+    ? AstarteDatastreamIndividualData[]
+    : AstartePropertyData[] {
+    // @ts-expect-error cannot correctly infer from generics
+    return this.getLeaves()
+      .map((leaf) => leaf.toData())
+      .flat();
+  }
+
+  toLinearizedData(): Equals<Data, AstarteDatastreamObjectData> extends true
+    ? AstarteDatastreamData[]
+    : Equals<Data, AstarteDatastreamIndividualData> extends true
+    ? AstarteDatastreamData[]
+    : AstartePropertyData[] {
+    // @ts-expect-error cannot correctly infer from generics
+    return this.getLeaves()
+      .map((leaf) => leaf.toLinearizedData())
+      .flat();
+  }
+
+  toLastValue(): JSON<AstarteDataValue> {
+    return this.children.reduce(
+      (acc, child) => ({
+        ...acc,
+        [child.name]: child.toLastValue(),
+      }),
+      {},
+    );
+  }
+
+  get name(): string {
+    return this.parent != null ? this.endpoint.replace(`${this.parent.endpoint}/`, '') : '';
+  }
+}
+
+function toAstarteDataTree(params: {
+  interface: AstarteInterface;
+  data: AstarteInterfaceValues;
+}):
+  | AstarteDataTreeNode<AstartePropertyData>
+  | AstarteDataTreeNode<AstarteDatastreamIndividualData>
+  | AstarteDataTreeNode<AstarteDatastreamObjectData> {
+  if (params.interface.type === 'properties') {
+    return new AstarteDataTreeBranchNode<AstartePropertyData>(params);
+  }
+  if (params.interface.type === 'datastream' && params.interface.aggregation === 'individual') {
+    return new AstarteDataTreeBranchNode<AstarteDatastreamIndividualData>(params);
+  }
+  return toDatastreamObjectTreeNode({
+    interface: params.interface,
+    data: params.data,
+    endpoint: '',
+    parentNode: null,
+  });
+}
+
+function toPropertiesTreeNode(params: {
+  interface: AstarteInterface;
+  data: AstarteInterfaceValues;
+  endpoint: string;
+  parentNode: AstarteDataTreeBranchNode<AstartePropertyData> | null;
+}): AstarteDataTreeBranchNode<AstartePropertyData> | AstarteDataTreeLeafNode<AstartePropertyData> {
+  if (isPropertiesInterfaceValue(params.data)) {
+    return new AstarteDataTreeLeafNode<AstartePropertyData>({
+      interface: params.interface,
+      data: {
+        endpoint: params.endpoint,
+        ...({
+          value: params.data,
+          type: getEndpointDataType(params.interface, params.endpoint),
+        } as AstarteDataTuple),
+      },
+      endpoint: params.endpoint,
+      parentNode: params.parentNode,
+    });
+  }
+  return new AstarteDataTreeBranchNode<AstartePropertyData>({
+    interface: params.interface,
+    data: params.data,
+    endpoint: params.endpoint,
+    parentNode: params.parentNode,
+  });
+}
+
+function toDatastreamIndividualTreeNode(params: {
+  interface: AstarteInterface;
+  data: AstarteInterfaceValues;
+  endpoint: string;
+  parentNode: AstarteDataTreeBranchNode<AstarteDatastreamIndividualData> | null;
+}):
+  | AstarteDataTreeBranchNode<AstarteDatastreamIndividualData>
+  | AstarteDataTreeLeafNode<AstarteDatastreamIndividualData> {
+  if (isIndividualDatastreamInterfaceValue(params.data)) {
+    const leafData: AstarteDatastreamIndividualData[] = [
+      {
+        endpoint: params.endpoint,
+        timestamp: params.data.timestamp,
+        ...({
+          value: params.data.value,
+          type: getEndpointDataType(params.interface, params.endpoint),
+        } as AstarteDataTuple),
+      },
+    ];
+    return new AstarteDataTreeLeafNode<AstarteDatastreamIndividualData>({
+      interface: params.interface,
+      data: leafData,
+      endpoint: params.endpoint,
+      parentNode: params.parentNode,
+    });
+  }
+  return new AstarteDataTreeBranchNode<AstarteDatastreamIndividualData>({
+    interface: params.interface,
+    data: params.data,
+    endpoint: params.endpoint,
+    parentNode: params.parentNode,
+  });
+}
+
+function toDatastreamObjectTreeNode(params: {
+  interface: AstarteInterface;
+  data: AstarteInterfaceValues;
+  endpoint: string;
+  parentNode: AstarteDataTreeBranchNode<AstarteDatastreamObjectData> | null;
+}):
+  | AstarteDataTreeBranchNode<AstarteDatastreamObjectData>
+  | AstarteDataTreeLeafNode<AstarteDatastreamObjectData> {
+  if (isAggregatedDatastreamInterfaceValue(params.data)) {
+    const leafData: AstarteDatastreamObjectData[] = params.data.map((obj) => ({
+      endpoint: params.endpoint,
+      timestamp: obj.timestamp,
+      value: Object.entries(_.omit(obj, 'timestamp')).reduce(
+        (acc, [objProp, objPropValue]) => ({
+          ...acc,
+          [objProp]: {
+            value: objPropValue,
+            type: getEndpointDataType(params.interface, `${params.endpoint}/${objProp}`),
+          } as AstarteDataTuple,
+        }),
+        {},
+      ),
+    }));
+    return new AstarteDataTreeLeafNode<AstarteDatastreamObjectData>({
+      interface: params.interface,
+      data: leafData,
+      endpoint: params.endpoint,
+      parentNode: params.parentNode,
+    });
+  }
+  return new AstarteDataTreeBranchNode<AstarteDatastreamObjectData>({
+    interface: params.interface,
+    data: params.data,
+    endpoint: params.endpoint,
+    parentNode: params.parentNode,
+  });
+}
+
+export { toAstarteDataTree };
+
+export type { AstarteDataTreeNode, AstarteDataTreeKind };

--- a/src/astarte-client/transforms/index.ts
+++ b/src/astarte-client/transforms/index.ts
@@ -16,6 +16,7 @@
    limitations under the License.
 */
 
+export * from './dataTree';
 export * from './device';
 export * from './pipeline';
 export * from './interface';

--- a/src/astarte-client/types/dataType.ts
+++ b/src/astarte-client/types/dataType.ts
@@ -16,4 +16,59 @@
    limitations under the License.
 */
 
-export type AstarteDataType = number | boolean | string | number[] | boolean[] | string[];
+export type AstarteDataValue = number | boolean | string | number[] | boolean[] | string[] | null;
+
+export type AstarteDataType =
+  | 'double'
+  | 'integer'
+  | 'boolean'
+  | 'longinteger'
+  | 'string'
+  | 'binaryblob'
+  | 'datetime'
+  | 'doublearray'
+  | 'integerarray'
+  | 'booleanarray'
+  | 'longintegerarray'
+  | 'stringarray'
+  | 'binaryblobarray'
+  | 'datetimearray';
+
+export type AstarteDataTuple =
+  | { type: 'double'; value: number }
+  | { type: 'integer'; value: number }
+  | { type: 'boolean'; value: boolean }
+  | { type: 'longinteger'; value: string }
+  | { type: 'string'; value: string }
+  | { type: 'binaryblob'; value: string }
+  | { type: 'datetime'; value: string }
+  | { type: 'doublearray'; value: number[] }
+  | { type: 'integerarray'; value: number[] }
+  | { type: 'booleanarray'; value: boolean[] }
+  | { type: 'longintegerarray'; value: string[] }
+  | { type: 'stringarray'; value: string[] }
+  | { type: 'binaryblobarray'; value: string[] }
+  | { type: 'datetimearray'; value: string[] }
+  | { type: AstarteDataType; value: null };
+
+export type AstartePropertyData = {
+  endpoint: string;
+} & AstarteDataTuple;
+
+export type AstarteDatastreamData = {
+  endpoint: string;
+  timestamp: string;
+} & AstarteDataTuple;
+
+export type AstarteDatastreamIndividualData = {
+  endpoint: string;
+  timestamp: string;
+} & AstarteDataTuple;
+
+export type AstarteDatastreamObjectData = {
+  endpoint: string;
+  timestamp: string;
+  value: {
+    [path: string]: AstarteDataTuple;
+  };
+};

--- a/src/astarte-client/types/interfaceValues.ts
+++ b/src/astarte-client/types/interfaceValues.ts
@@ -16,17 +16,14 @@
    limitations under the License.
 */
 
-import type { AstarteDataType } from './dataType';
+import type { AstarteDataValue } from './dataType';
 
-export interface AstartePropertiesInterfaceValue {
-  value: AstarteDataType;
-}
 export interface AstartePropertiesInterfaceValues {
-  [subPath: string]: AstartePropertiesInterfaceValues | AstartePropertiesInterfaceValue;
+  [subPath: string]: AstartePropertiesInterfaceValues | AstarteDataValue;
 }
 
 export interface AstarteIndividualDatastreamInterfaceValue {
-  value: AstarteDataType;
+  value: AstarteDataValue;
   timestamp: string;
 }
 export interface AstarteIndividualDatastreamInterfaceValues {
@@ -36,14 +33,12 @@ export interface AstarteIndividualDatastreamInterfaceValues {
 }
 
 export type AstarteAggregatedDatastreamInterfaceValue = Array<{
-  [key: string]: AstarteDataType;
+  [key: string]: AstarteDataValue;
   timestamp: string;
 }>;
-export interface AstarteAggregatedDatastreamInterfaceValues {
-  [subPath: string]:
-    | AstarteAggregatedDatastreamInterfaceValues
-    | AstarteAggregatedDatastreamInterfaceValue;
-}
+export type AstarteAggregatedDatastreamInterfaceValues =
+  | AstarteAggregatedDatastreamInterfaceValue
+  | { [subPath: string]: AstarteAggregatedDatastreamInterfaceValues };
 
 export type AstarteInterfaceValues =
   | AstartePropertiesInterfaceValues


### PR DESCRIPTION
This PR implements an AstarteDataTree data structure to encapsulate interfaces data and provide defined ways to export values from it: in an object or linearized fashion.
This way, returned data values are also preprocessed and labeled with metadata (to highlight data type for instance).
A dedicated API is added to `astarte-client`: `getDeviceDataTree`. The gotcha is that, unless the user provides a completed AstarteDevice and a AstarteDevice, this API needs the client credentials to include a RealmManagement token in addition to the AppEngine token already required by the raw `getDeviceData` API.