### PR TITLE
Add a Cypress test for active devices filter in Devices page

### DIFF
--- a/cypress/integration/devices_page_test.js
+++ b/cypress/integration/devices_page_test.js
@@ -101,5 +101,22 @@ describe('Devices page tests', () => {
       cy.get('table tbody tr').should('have.length', 1);
       cy.get('table tbody tr td:nth-child(2)').should('contain', value);
     });
+
+    it('correctly filters by last device activity', function () {
+      const disconnectedDevice = this.devices.data.find((device) => device.last_connection != null);
+      const activeSinceDate = new Date(disconnectedDevice.last_connection);
+      const activeDevices = this.devices.data.filter(
+        (device) =>
+          !!device.connected ||
+          (device.lastDisconnection != null && device.lastDisconnection >= activeSinceDate),
+      );
+      cy.get('table tbody tr').should('have.length', this.devices.data.length);
+      cy.get('#filterActiveSince').type(activeSinceDate.toISOString().slice(0, 10));
+      cy.get('#filterActiveSince').type('{enter}');
+      cy.get('table tbody tr').should('have.length', activeDevices.length);
+      activeDevices.forEach((activeDevice) => {
+        cy.get('table tbody').should('contain', activeDevice?.aliases?.name || activeDevice.id);
+      });
+    });
   });
 });

--- a/src/react/DevicesPage.tsx
+++ b/src/react/DevicesPage.tsx
@@ -346,20 +346,27 @@ const FilterForm = ({ filters, onUpdateFilters }: FilterFormProps): React.ReactE
             onUpdateFilters({ ...filters, showNeverConnected: e.target.checked })
           }
         />
-        <p className="mt-3">Active since:</p>
-        <DatePicker
-          selected={activeSinceDate}
-          onChange={(date: Date) =>
-            onUpdateFilters({
-              ...filters,
-              activeSinceDate: date,
-              showConnected: true,
-              showDisconnected: true,
-              showNeverConnected: true,
-            })
-          }
-          customInput={<Form.Control type="search" />}
-        />
+      </Form.Group>
+      <Form.Group controlId="filterActiveSince" className="mb-4">
+        <Form.Label>
+          <b>Active since</b>
+        </Form.Label>
+        <div className="d-block">
+          <DatePicker
+            maxDate={new Date()}
+            selected={activeSinceDate}
+            onChange={(date: Date) =>
+              onUpdateFilters({
+                ...filters,
+                activeSinceDate: date,
+                showConnected: true,
+                showDisconnected: true,
+                showNeverConnected: true,
+              })
+            }
+            customInput={<Form.Control type="search" />}
+          />
+        </div>
       </Form.Group>
       <div className="mb-2">
         <b>Metadata</b>


### PR DESCRIPTION
This PR ensures that the ActiveSince filter in Devices page works correctly when entering a date to search for.
A small fix is added to the filter itself, along with a Cypress test that check its functionality.