### PR TITLE
Fix tables responsiveness

### DIFF
--- a/cypress/integration/interface_value_page_test.js
+++ b/cypress/integration/interface_value_page_test.js
@@ -129,12 +129,12 @@ describe('Interface values page tests', () => {
             const sensorData = this.interface_data.data.sensors[sensorId].value;
             cy.get('.card-body p')
               .contains(`/sensors/${sensorId}/value`)
-              .next('table')
+              .next()
               .within(() => {
-                cy.get('tbody tr').should('have.length', sensorData.length);
-                cy.get('thead th').should('have.length', Object.keys(sensorData[0]).length);
+                cy.get('table tbody tr').should('have.length', sensorData.length);
+                cy.get('table thead th').should('have.length', Object.keys(sensorData[0]).length);
                 Object.keys(sensorData[0]).forEach((valueLabel) => {
-                  cy.get('thead th').contains(
+                  cy.get('table thead th').contains(
                     valueLabel === 'timestamp' ? 'Timestamp' : valueLabel,
                   );
                 });

--- a/src/elm/Page/Device.elm
+++ b/src/elm/Page/Device.elm
@@ -1006,17 +1006,18 @@ deviceStatsCard device width =
         [ Grid.row
             [ Row.attrs [ Spacing.mt3 ] ]
             [ Grid.col []
-                [ Table.simpleTable
-                    ( Table.simpleThead
+                [ Table.table
+                    { options = [ Table.responsive ]
+                    , thead =  Table.simpleThead
                         [ Table.th [] [ Html.text "Interface" ]
                         , tableHeaderRight "Bytes"
                         , tableHeaderRightXl "Bytes (%)"
                         , tableHeaderRight "Messages"
                         , tableHeaderRightXl "Messages (%)"
                         ]
-                    , Table.tbody []
+                    , tbody = Table.tbody []
                         (List.map renderInterfaceStats <| introspectionStats ++ [ others, total ])
-                    )
+                    }
                 ]
             , Grid.col
                 [ Col.sm12
@@ -1550,12 +1551,13 @@ renderGroups groups =
         Card.simpleText "Device does not belong to any group"
 
     else
-        Table.simpleTable
-            ( Table.simpleThead
+        Table.table
+            { options = [ Table.responsive ]
+            , thead = Table.simpleThead
                 [ Table.th [] [ Html.text "Name" ] ]
-            , Table.tbody []
+            , tbody = Table.tbody []
                 (List.map renderGroupValue groups)
-            )
+            }
 
 
 renderGroupValue : String -> Table.Row Msg
@@ -1575,8 +1577,9 @@ renderAliases aliases =
         Card.simpleText "Device has no aliases"
 
     else
-        Table.simpleTable
-            ( Table.simpleThead
+        Table.table
+            { options = [ Table.responsive ]
+            , thead = Table.simpleThead
                 [ Table.th []
                     [ Html.text "Tag" ]
                 , Table.th []
@@ -1584,12 +1587,12 @@ renderAliases aliases =
                 , Table.th [ Table.cellAttr <| class "action-column" ]
                     [ Html.text "Actions" ]
                 ]
-            , Table.tbody []
+            , tbody = Table.tbody []
                 (aliases
                     |> Dict.toList
                     |> List.map (fieldValueTableRow EditAlias DeleteAlias)
                 )
-            )
+            }
 
 
 renderMetadata : Dict String String -> Html Msg
@@ -1598,8 +1601,9 @@ renderMetadata metadata =
         Card.simpleText "Device has no metadata"
 
     else
-        Table.simpleTable
-            ( Table.simpleThead
+        Table.table
+            { options = [ Table.responsive ]
+            , thead = Table.simpleThead
                 [ Table.th []
                     [ Html.text "Field" ]
                 , Table.th []
@@ -1607,12 +1611,12 @@ renderMetadata metadata =
                 , Table.th [ Table.cellAttr <| class "action-column" ]
                     [ Html.text "Actions" ]
                 ]
-            , Table.tbody []
+            , tbody = Table.tbody []
                 (metadata
                     |> Dict.toList
                     |> List.map (fieldValueTableRow EditMetadata RemoveMetadata)
                 )
-            )
+            }
 
 
 fieldValueTableRow : (String -> Msg) -> (String -> String -> Msg) -> ( String, String ) -> Table.Row Msg
@@ -1649,15 +1653,16 @@ renderIntrospectionInfo deviceId introspectionValues =
         Html.text "No introspection info"
 
     else
-        Table.simpleTable
-            ( Table.simpleThead
+        Table.table
+            { options = [ Table.responsive ]
+            , thead = Table.simpleThead
                 [ Table.th [] [ Html.text "Name" ]
                 , Table.th [] [ Html.text "Major" ]
                 , Table.th [] [ Html.text "Minor" ]
                 ]
-            , Table.tbody []
+            , tbody = Table.tbody []
                 (List.map (renderIntrospectionValue deviceId) introspectionValues)
-            )
+            }
 
 
 renderPreviousInterfacesInfo : List Device.IntrospectionValue -> Html Msg
@@ -1666,15 +1671,16 @@ renderPreviousInterfacesInfo previousInterfaces =
         Html.text "No previous interfaces info"
 
     else
-        Table.simpleTable
-            ( Table.simpleThead
+        Table.table
+            { options = [ Table.responsive ]
+            , thead = Table.simpleThead
                 [ Table.th [] [ Html.text "Name" ]
                 , Table.th [] [ Html.text "Major" ]
                 , Table.th [] [ Html.text "Minor" ]
                 ]
-            , Table.tbody []
+            , tbody = Table.tbody []
                 (List.map renderPreviousIntrospectionValue previousInterfaces)
-            )
+            }
 
 
 renderIntrospectionValue : String -> Device.IntrospectionValue -> Table.Row Msg

--- a/src/elm/Ui/TriggerActionEditor.elm
+++ b/src/elm/Ui/TriggerActionEditor.elm
@@ -731,19 +731,20 @@ customHttpHeaders customHeaders editMode newCustomHeader editCustomHeader delete
 
 headersTable : Dict String String -> Html msg
 headersTable headers =
-    Table.simpleTable
-        ( Table.simpleThead
+    Table.table
+        { options = [ Table.responsive ]
+        , thead = Table.simpleThead
             [ Table.th []
                 [ Html.text "Header" ]
             , Table.th []
                 [ Html.text "Value" ]
             ]
-        , Table.tbody []
+        , tbody = Table.tbody []
             (headers
                 |> Dict.toList
                 |> List.map keyValueTableRow
             )
-        )
+        }
 
 
 editableheadersTable : Dict String String -> (String -> msg) -> (String -> msg) -> Html msg
@@ -752,8 +753,9 @@ editableheadersTable headers editHeader deleteHeader =
         Html.text ""
 
     else
-        Table.simpleTable
-            ( Table.simpleThead
+        Table.table
+            { options = [ Table.responsive ]
+            , thead = Table.simpleThead
                 [ Table.th []
                     [ Html.text "Header" ]
                 , Table.th []
@@ -761,12 +763,12 @@ editableheadersTable headers editHeader deleteHeader =
                 , Table.th [ Table.cellAttr <| class "action-column" ]
                     [ Html.text "Actions" ]
                 ]
-            , Table.tbody []
+            , tbody = Table.tbody []
                 (headers
                     |> Dict.toList
                     |> List.map (keyValueTableRowWithControls editHeader deleteHeader)
                 )
-            )
+            }
 
 
 keyValueTableRow : ( String, String ) -> Table.Row msg

--- a/src/react/DeviceInterfaceValues.jsx
+++ b/src/react/DeviceInterfaceValues.jsx
@@ -155,7 +155,7 @@ const IndividualDatastreamTable = ({ data }) => {
   const paths = linearizePathTree('', data);
 
   return (
-    <Table>
+    <Table responsive>
       <thead>
         <tr>
           <th>Path</th>
@@ -194,7 +194,7 @@ const ObjectDatastreamTable = ({ path, values }) => {
     <>
       <h5 className="mb-1">Path</h5>
       <p>{path}</p>
-      <Table>
+      <Table responsive>
         <thead>
           <tr>
             {labels.map((label) => (


### PR DESCRIPTION
This PR adjusts the responsive behavior of tables in both Elm and React views, in order to avoid cutting out data that might be overflowing outside the table constraints.