### PR TITLE
Add independent scrolling behaviors for sidebar and content

### DIFF
--- a/cypress/integration/device_page_test.js
+++ b/cypress/integration/device_page_test.js
@@ -603,7 +603,7 @@ describe('Device page tests', () => {
             cy.contains(formatBytes(totalBytes));
             cy.contains(totalMessages);
           });
-          cy.get('svg.device-data-piechart').should('be.visible');
+          cy.get('svg.device-data-piechart').scrollIntoView().should('be.visible');
         });
     });
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -760,7 +760,7 @@ view model =
                     )
                     [ renderNavbar model realmName ]
                 , Grid.col
-                    [ Col.attrs [ class "main-content overflow-hidden" ] ]
+                    [ Col.attrs [ class "main-content vh-100 overflow-auto" ] ]
                     [ renderPage model model.selectedPage ]
                 ]
             ]
@@ -883,7 +883,7 @@ standardNavBar selectedPage realmName aeApiHealth rmApiHealth pApiHealth fApiHea
       ]
     ]
         |> List.concat
-        |> Html.nav [ class "nav navbar-dark", Flex.col ]
+        |> Html.nav [ class "nav navbar-dark flex-nowrap vh-100 overflow-auto", Flex.col ]
 
 
 dashboardBrand : Html Msg


### PR DESCRIPTION
This PR adds two separate scrolling behaviour for sidebar and content, so that scrolling a page of content won't cause the sidebar to disappear from view.
For greater accessibility, a scrollbar will now be visible for the sidebar too when needed.

Before:

![Screenshot from 2020-11-27 14-57-55](https://user-images.githubusercontent.com/60540759/100467023-22cc1e80-30d2-11eb-9042-50a869f916c6.png)

After:

![Screenshot from 2020-11-27 14-58-11](https://user-images.githubusercontent.com/60540759/100467045-295a9600-30d2-11eb-93f3-9e607bb3d90e.png)
