### PR TITLE
Fix typo in SessionManager's setup

### DIFF
--- a/cypress/fixtures/config/custom_urls.json
+++ b/cypress/fixtures/config/custom_urls.json
@@ -1,0 +1,10 @@
+{
+  "astarte_api_url": "https://api.example.com",
+  "appengine_api_url": "https://api.example.com/custom-appengine/",
+  "realm_management_api_url": "https://api.example.com/custom-realmmanagement/",
+  "pairing_api_url": "https://api.example.com/custom-pairing/",
+  "flow_api_url": "https://api.example.com/custom-flow/",
+  "auth": [{ "type": "token" }],
+  "default_auth": "token",
+  "enable_flow_preview": true
+}

--- a/cypress/integration/login_test.js
+++ b/cypress/integration/login_test.js
@@ -70,5 +70,32 @@ describe('Login tests', () => {
       cy.get('#main-navbar').should('not.contain', 'Pipelines');
       cy.get('#main-navbar').should('not.contain', 'Blocks');
     });
+
+    it('use custom Astarte URLs when configured to do so', function () {
+      cy.fixture('config/custom_urls').then((userConfig) => {
+        cy.route('/user-config/config.json', userConfig);
+        cy.route('https://api.example.com/custom-appengine/health', '').as(
+          'appEngineHealthRequest',
+        );
+        cy.route('https://api.example.com/custom-realmmanagement/health', '').as(
+          'realmManagementHealthRequest',
+        );
+        cy.route('https://api.example.com/custom-pairing/health', '').as('pairingHealthRequest');
+        cy.route('https://api.example.com/custom-flow/health', '').as('flowHealthRequest');
+
+        cy.visit('/login');
+
+        cy.get('input[id=astarteRealm]').clear().type(this.realm.name);
+        cy.get('textarea[id=astarteToken]').type(this.realm.infinite_token);
+        cy.get('.btn[type=submit]').click();
+
+        cy.wait([
+          '@appEngineHealthRequest',
+          '@realmManagementHealthRequest',
+          '@pairingHealthRequest',
+          '@flowHealthRequest',
+        ]);
+      });
+    });
   });
 });

--- a/src/react/SessionManager.js
+++ b/src/react/SessionManager.js
@@ -55,7 +55,7 @@ class SessionManager {
     }
 
     if (appConfig.flow_api_url) {
-      flowApiUrl = new URL(appConfig.appConfig);
+      flowApiUrl = new URL(appConfig.flow_api_url);
     }
 
     this.config = {


### PR DESCRIPTION
This PR fixes a typo in the constructor of SessionManager that prevented correct handling of a custom flow_api_url when supplied in app's config: supplying such url would crash the app.
Along with the fix, a Cypress test is added to ensure that if custom Astarte URLs are supplied in the app's config, they are correctly handled by SessionManager and used by the app.