### PR TITLE
Fix app crashing when Flow is disabled in the app's config

### DIFF
--- a/cypress/fixtures/config/flowDisabled.json
+++ b/cypress/fixtures/config/flowDisabled.json
@@ -1,0 +1,5 @@
+{
+  "astarte_api_url": "localhost",
+  "auth": [{ "type": "token" }],
+  "default_auth": "token"
+}

--- a/cypress/integration/login_test.js
+++ b/cypress/integration/login_test.js
@@ -52,5 +52,23 @@ describe('Login tests', () => {
 
       cy.wait('@httpsRequest');
     });
+
+    it('correctly loads without Flow features when configured to do so', function () {
+      cy.fixture('config/flowDisabled').then((userConfig) => {
+        cy.route('/user-config/config.json', userConfig);
+      });
+
+      cy.visit('/login');
+
+      cy.get('input[id=astarteRealm]').clear().type(this.realm.name);
+      cy.get('textarea[id=astarteToken]').type(this.realm.infinite_token);
+      cy.get('.btn[type=submit]').click();
+
+      cy.get('#status-card').should('not.contain', 'Flow');
+      cy.get('#main-navbar').should('be.visible');
+      cy.get('#main-navbar').should('not.contain', 'Flows');
+      cy.get('#main-navbar').should('not.contain', 'Pipelines');
+      cy.get('#main-navbar').should('not.contain', 'Blocks');
+    });
   });
 });

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -32,7 +32,7 @@ import Bootstrap.Utilities.Spacing as Spacing
 import Browser exposing (UrlRequest(..))
 import Browser.Navigation
 import Html exposing (Html, a, div, hr, img, li, p, small, span, text, ul)
-import Html.Attributes exposing (class, classList, href, src, style)
+import Html.Attributes exposing (id, class, classList, href, src, style)
 import Icons exposing (Icon)
 import Json.Decode as Decode exposing (Value, at, string)
 import ListUtils exposing (addWhen)
@@ -752,11 +752,11 @@ view model =
                 [ Grid.col
                     (if showNavbar then
                         [ Col.xsAuto
-                        , Col.attrs [ class "nav-col" ]
+                        , Col.attrs [ id "main-navbar", class "nav-col" ]
                         ]
 
                      else
-                        [ Col.attrs [ Display.none ] ]
+                        [ Col.attrs [ id "main-navbar", Display.none ] ]
                     )
                     [ renderNavbar model realmName ]
                 , Grid.col

--- a/src/react/HomePage.jsx
+++ b/src/react/HomePage.jsx
@@ -78,7 +78,7 @@ export default ({ astarte, history }) => {
             realmManagement={realmManagementHealth.status}
             pairing={pairingHealth.status}
             showFlowStatus={astarte.config.enableFlowPreview}
-            flow={flowHealth.status}
+            flow={astarte.config.enableFlowPreview ? flowHealth.status : null}
           />
         </Col>
         <WaitForData data={devicesStats.value} status={devicesStats.status}>

--- a/src/react/SessionManager.js
+++ b/src/react/SessionManager.js
@@ -59,7 +59,7 @@ class SessionManager {
     }
 
     this.config = {
-      enableFlowPreview: appConfig.enable_flow_preview,
+      enableFlowPreview: !!appConfig.enable_flow_preview,
       appEngineApiUrl,
       realmManagementApiUrl,
       pairingApiUrl,
@@ -119,14 +119,11 @@ class SessionManager {
       realm_management_url: urlToSchemalessString(realmManagementApiUrl),
       appengine_url: urlToSchemalessString(appEngineApiUrl),
       pairing_url: urlToSchemalessString(pairingApiUrl),
+      flow_url: urlToSchemalessString(flowApiUrl),
       enable_flow_preview: enableFlowPreview,
       realm,
       token,
     };
-
-    if (enableFlowPreview) {
-      apiConfig.flow_url = urlToSchemalessString(flowApiUrl);
-    }
 
     return {
       api_config: apiConfig,


### PR DESCRIPTION
This PR fixes the app's behavior in the case where Flow is disabled in the app's config.
Indeed, that resulted in the app crashing on first login. The fix involves:

- Avoiding to read from flowHealth variable in Homepage when Flow is disabled
- In SessionManager, strictly parsing enable_flow_preview as boolean and making sure to always return a flow_url, so the session passed to the Elm side can be correctly parsed and doesn't trigger a NotLoggedIn state

A Cypress test is also added to ensure the app correctly loads when Flow is disabled and that Flow features are disabled: upon login, the sidebar should be visible without showing links to Flow pages and the Homepage shouldn't report health status for Flow APIs.