### PR TITLE
Invite device registration after wiping credentials in DevicePage

### DIFF
--- a/cypress/integration/device_page_test.js
+++ b/cypress/integration/device_page_test.js
@@ -253,6 +253,16 @@ describe('Device page tests', () => {
         );
         cy.get('.modal').contains('Wipe credentials secret').click();
         cy.wait('@wipeCredentialsSecretRequest');
+        cy.get('.modal')
+          .contains(
+            "The device's credentials secret was wiped from Astarte. You can click here to register the device again and retrieve its new credentials secret.",
+          )
+          .contains('click here')
+          .should('have.attr', 'href')
+          .then((href) => {
+            expect(href.endsWith(`/devices/register?deviceId=${this.device.data.id}`)).to.be.true;
+          });
+        cy.get('.modal button').contains('OK').click();
       });
     });
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -512,7 +512,7 @@ pageInit realmRoute config session =
         Route.DeviceList ->
             initReactPage session Devices "devices-list" realmRoute
 
-        Route.RegisterDevice ->
+        Route.RegisterDevice _ ->
             initReactPage session Devices "devices-register" realmRoute
 
         Route.GroupList ->

--- a/src/elm/Modal/ConfirmModal.elm
+++ b/src/elm/Modal/ConfirmModal.elm
@@ -31,8 +31,9 @@ import HtmlUtils
 
 type alias Model =
     { title : String
-    , body : String
+    , body : Html Msg
     , action : String
+    , canCancel: Bool
     , modalType : ModalType
     , visibility : Modal.Visibility
     }
@@ -43,8 +44,8 @@ type ModalType
     | Danger
 
 
-init : String -> String -> Maybe String -> Maybe ModalType -> Bool -> Model
-init modalTitle body action modalType shown =
+init : String -> Html Msg -> Maybe String -> Maybe ModalType -> Bool -> Bool -> Model
+init modalTitle body action modalType shown canCancel =
     { title = modalTitle
     , body = body
     , action = action |> Maybe.withDefault "Confirm"
@@ -55,6 +56,7 @@ init modalTitle body action modalType shown =
 
         else
             Modal.hidden
+    , canCancel = canCancel
     }
 
 
@@ -87,20 +89,29 @@ update message model =
             )
 
 
+htmlIf : Bool -> Html msg -> Html msg
+htmlIf cond el =
+    if cond then
+        el
+
+    else
+        Html.text ""
+
+
 view : Model -> Html Msg
 view model =
     Modal.config (Close ModalCancel)
         |> Modal.large
         |> Modal.h5 [] [ Html.text model.title ]
         |> Modal.body []
-            [ Html.p [] [ Html.text model.body ]
+            [ Html.p [] [ model.body ]
             ]
         |> Modal.footer []
-            [ Button.button
+            [ htmlIf model.canCancel (Button.button
                 [ Button.secondary
                 , Button.onClick <| Close ModalCancel
                 ]
-                [ Html.text "Cancel" ]
+                [ Html.text "Cancel" ])
             , Button.button
                 [ buttonStyle model.modalType
                 , Button.onClick <| Close ModalOk

--- a/src/elm/Page/TriggerBuilder.elm
+++ b/src/elm/Page/TriggerBuilder.elm
@@ -951,9 +951,10 @@ update session msg model =
                 modalModel =
                     ConfirmModal.init
                         "Remove Header"
-                        ("Remove custom header \"" ++ header ++ "\"?")
+                        (Html.text ("Remove custom header \"" ++ header ++ "\"?"))
                         (Just "Remove header")
                         (Just ConfirmModal.Danger)
+                        True
                         True
 
                 modal =
@@ -996,9 +997,10 @@ update session msg model =
                 modalModel =
                     ConfirmModal.init
                         "Remove Header"
-                        ("Remove static header \"" ++ header ++ "\"?")
+                        (Html.text ("Remove static header \"" ++ header ++ "\"?"))
                         (Just "Remove header")
                         (Just ConfirmModal.Danger)
+                        True
                         True
 
                 modal =

--- a/src/elm/Route.elm
+++ b/src/elm/Route.elm
@@ -53,7 +53,7 @@ type RealmRoute
     | DeviceList
     | ShowDevice String
     | ShowDeviceData String String
-    | RegisterDevice
+    | RegisterDevice (Maybe String)
     | GroupList
     | GroupDevices String
     | FlowInstances
@@ -90,7 +90,7 @@ realmRouteParser =
         , map NewTrigger (s "triggers" </> s "new")
         , map ShowTrigger (s "triggers" </> string)
         , map DeviceList (s "devices")
-        , map RegisterDevice (s "devices" </> s "register")
+        , map RegisterDevice (s "devices" </> s "register" <?> Query.string "deviceId")
         , map ShowDevice (s "devices" </> string)
         , map ShowDeviceData (s "devices" </> string </> s "interfaces" </> string)
         , map GroupList (s "groups")
@@ -177,8 +177,13 @@ toString route =
                 Realm (ShowDeviceData deviceId interfaceName) ->
                     [ "devices", deviceId, "interfaces", interfaceName ]
 
-                Realm RegisterDevice ->
-                    [ "devices", "register" ]
+                Realm (RegisterDevice d) ->
+                    case d of
+                        Just deviceId ->
+                            [ "devices", "register?deviceId=" ++ deviceId ]
+
+                        Nothing ->
+                            [ "devices", "register" ]
 
                 Realm GroupList ->
                     [ "groups" ]

--- a/src/react/RegisterDevicePage.tsx
+++ b/src/react/RegisterDevicePage.tsx
@@ -255,10 +255,11 @@ const NamespaceModal = ({ onCancel, onConfirm }: NamespaceModalProps) => {
 
 interface Props {
   astarte: AstarteClient;
+  deviceId: string;
 }
 
-export default ({ astarte }: Props): React.ReactElement => {
-  const [deviceId, setDeviceId] = useState<AstarteDevice['id']>('');
+export default ({ astarte, deviceId: initialDeviceId }: Props): React.ReactElement => {
+  const [deviceId, setDeviceId] = useState<AstarteDevice['id']>(initialDeviceId);
   const [deviceSecret, setDeviceSecret] = useState<string>('');
   const [shouldSendIntrospection, setShouldSendIntrospection] = useState(false);
   const [introspectionInterfaces, setIntrospectionInterfaces] = useState<

--- a/src/react/Router.jsx
+++ b/src/react/Router.jsx
@@ -72,7 +72,7 @@ export default ({ reactHistory: history, astarteClient, sessionManager, config, 
         <Route path="triggers" element={<TriggersPage {...pageProps} />} />
         <Route path="interfaces" element={<InterfacesPage {...pageProps} />} />
         <Route path="devices" element={<DevicesPage {...pageProps} />} />
-        <Route path="devices/register" element={<RegisterDevicePage {...pageProps} />} />
+        <Route path="devices/register" element={<RegisterDevice {...pageProps} />} />
         <Route
           path="devices/:deviceId/interfaces/:interfaceName"
           element={<DeviceDataSubPath {...pageProps} />}
@@ -124,6 +124,13 @@ function Login({ defaultLoginType, ...props }) {
   const loginType = new URLSearchParams(search).get('type') || defaultLoginType;
 
   return <LoginPage type={loginType} {...props} />;
+}
+
+function RegisterDevice(props) {
+  const searchQuery = new URLSearchParams(useLocation().search);
+  const deviceId = searchQuery.get('deviceId') || '';
+
+  return <RegisterDevicePage deviceId={deviceId} {...props} />;
 }
 
 function GroupDevicesSubPath(props) {


### PR DESCRIPTION
This PR implements a confirmation modal to be shown in DevicePage upon successful wiping of device's credentials secret, so that a feedback is displayed together with an invite to register the device again. A link is included in the feedback, so that by clicking it the user is redirected to the registration form already filled with the correct device ID.

![wiped credentials feedback](https://user-images.githubusercontent.com/60540759/104475780-c5c3f380-55bf-11eb-8c85-43760ba6d0df.png)

