### PR TITLE
Fix app crashing when no config is supplied

### DIFF
--- a/cypress/integration/interface_builder_test.js
+++ b/cypress/integration/interface_builder_test.js
@@ -1,4 +1,19 @@
 describe('Interface builder tests', () => {
+  context("without an app's config", () => {
+    it('starts up as a standalone Interface Editor', () => {
+      cy.server();
+      cy.route({
+        method: 'GET',
+        url: '/user-config/config.json',
+        status: 404,
+        response: '',
+      });
+      cy.visit('/');
+      cy.get('h2').contains('Interface Editor');
+      cy.get('#interfaceName').should('have.value', '');
+    });
+  });
+
   context('no access before login', () => {
     it('redirects to login', () => {
       cy.visit('/interfaces/new');

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -200,6 +200,12 @@ function clearReact() {
 $.getJSON('/user-config/config.json', (result) => {
   dashboardConfig = result;
 }).always(() => {
+  if (!dashboardConfig) {
+    // Starts app as a standalone Interface Editor
+    elmApp.init();
+    return;
+  }
+
   sessionManager = new SessionManager(dashboardConfig);
 
   const parameters = {


### PR DESCRIPTION
This PR adds a fix to ensure the app correctly loads as a standalone Interface Editor when no config is supplied.
A Cypress test is added as well to test for such behavior.
