### PR TITLE
Double encode group names in Astarte API URLs

### DIFF
--- a/cypress/integration/device_page_test.js
+++ b/cypress/integration/device_page_test.js
@@ -554,6 +554,53 @@ describe('Device page tests', () => {
       });
     });
 
+    it('correctly adds the device to a group with symbols in its name', function () {
+      const groupName = '!"£$%&/()=?^';
+      const encodedGroupName = encodeURIComponent(groupName);
+      const deviceGroups = ['group1', 'group2'];
+      const allGroups = deviceGroups.concat(groupName);
+      const device = _.merge({}, this.deviceDetailed);
+      device.data.groups = deviceGroups;
+      const updatedDevice = _.merge({}, this.deviceDetailed);
+      updatedDevice.data.groups = allGroups;
+      cy.server();
+      cy.route('GET', '/appengine/v1/*/groups', { data: allGroups });
+      cy.route('GET', '/appengine/v1/*/devices/*', device);
+      cy.route({
+        method: 'POST',
+        url: `/appengine/v1/*/groups/${encodedGroupName}/devices`,
+        status: 201,
+        response: '',
+      }).as('updateGroupRequest');
+
+      cy.visit(`/devices/${device.data.id}`);
+      cy.get('.main-content').within(() => {
+        cy.get('.card-header')
+          .contains('Groups')
+          .parents('.card')
+          .within(() => {
+            cy.get('table tbody tr').should('have.length', deviceGroups.length);
+            cy.contains('Add to existing group').click();
+          });
+        cy.get('.modal-header')
+          .contains('Select Existing Group')
+          .parents('.modal')
+          .within(() => {
+            cy.get('button').contains('Confirm').should('be.disabled');
+            cy.contains(groupName).click();
+            cy.route('GET', '/appengine/v1/*/devices/*', updatedDevice).as('getDeviceRequest');
+            cy.get('button').contains('Confirm').click();
+          });
+        cy.wait(['@updateGroupRequest', '@getDeviceRequest']);
+        cy.get('.card-header')
+          .contains('Groups')
+          .parents('.card')
+          .within(() => {
+            cy.contains(groupName);
+          });
+      });
+    });
+
     it('correctly renders Device Stats', function () {
       cy.server();
       cy.route('GET', '/appengine/v1/*/devices/*', '@deviceDetailed');

--- a/cypress/integration/group_page_test.js
+++ b/cypress/integration/group_page_test.js
@@ -80,5 +80,29 @@ describe('Group page tests', () => {
         cy.get('[role="dialog"]').get('button').contains('Remove').click();
       });
     });
+
+    it('correctly removes a device from a group with symbols in its name', function () {
+      const groupName = '!"£$%&/()=?^';
+      const encodedGroupName = encodeURIComponent(groupName);
+      const groupFixture = 'group.special-characters.devices.json';
+      cy.fixture(groupFixture).then((groupDevices) => {
+        cy.server();
+        cy.route(
+          'GET',
+          `/appengine/v1/${this.realm.name}/groups/${encodedGroupName}/devices?details=true`,
+          groupDevices,
+        );
+        cy.route({
+          method: 'DELETE',
+          url: `/appengine/v1/${this.realm.name}/groups/${encodedGroupName}/devices/*`,
+          status: 204,
+        }).as('deleteDeviceRequest');
+
+        cy.visit(`/groups/${encodeURIComponent(encodedGroupName)}`);
+        cy.get('.main-content table tbody tr .btn').first().click();
+        cy.get('[role="dialog"]').get('button').contains('Remove').click();
+        cy.wait('@deleteDeviceRequest');
+      });
+    });
   });
 });

--- a/src/astarte-client/client.ts
+++ b/src/astarte-client/client.ts
@@ -363,10 +363,13 @@ class AstarteClient {
       throw Error('Invalid device ID');
     }
 
+    /* Double encoding to preserve the URL format when groupName contains % and / */
+    const encodedGroupName = encodeURIComponent(encodeURIComponent(groupName));
+
     await this.$delete(
       this.apiConfig.deviceInGroup({
         ...this.config,
-        groupName,
+        groupName: encodedGroupName,
         deviceId,
       }),
     );

--- a/src/elm/AstarteApi.elm
+++ b/src/elm/AstarteApi.elm
@@ -68,6 +68,7 @@ import Json.Encode as Encode exposing (Value)
 import Types.Device as Device exposing (Device)
 import Types.Interface as Interface exposing (Interface)
 import Types.Trigger as Trigger exposing (Trigger)
+import Url
 import Url.Builder exposing (crossOrigin)
 
 
@@ -609,10 +610,17 @@ groupList apiConfig resultMsg =
 
 addDeviceToGroup : Config -> String -> String -> (Result Error () -> msg) -> Cmd msg
 addDeviceToGroup apiConfig groupName deviceId resultMsg =
+    let
+        {- Double encoding to preserve the URL format when groupName contains % and / -}
+        encodedGroupName =
+            groupName
+            |> Url.percentEncode
+            |> Url.percentEncode
+    in
     Http.request
         { method = "POST"
         , headers = buildHeaders apiConfig.token
-        , url = buildUrl apiConfig.secureConnection apiConfig.appengineUrl [ "v1", apiConfig.realm, "groups", groupName, "devices" ] []
+        , url = buildUrl apiConfig.secureConnection apiConfig.appengineUrl [ "v1", apiConfig.realm, "groups", encodedGroupName, "devices" ] []
         , body = Http.jsonBody <| Encode.object [ ( "data", Encode.object [ ( "device_id", Encode.string deviceId ) ] ) ]
         , expect = expectWhateverAstarteReply resultMsg
         , timeout = Nothing


### PR DESCRIPTION
make sure percent and slash character are properly encoded in API URLs

Signed-off-by: Mattia <mattia.pavinati@ispirata.com>