### PR TITLE
Add Cypress interaction tests for the Interface Editor

### DIFF
--- a/cypress/fixtures/test.astarte.NoDefaultsInterface.json
+++ b/cypress/fixtures/test.astarte.NoDefaultsInterface.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "interface_name": "test.astarte.NoDefaultsInterface",
+    "version_major": 2,
+    "version_minor": 2,
+    "type": "datastream",
+    "ownership": "device",
+    "aggregation": "object",
+    "description": "Interface description",
+    "doc": "Interface documentation",
+    "mappings": [
+      {
+        "endpoint": "/objects/boolean",
+        "type": "boolean",
+        "reliability": "guaranteed",
+        "retention": "volatile",
+        "expiry": 120,
+        "database_retention_policy": "use_ttl",
+        "database_retention_ttl": 120,
+        "explicit_timestamp": true
+      },
+      {
+        "endpoint": "/objects/string",
+        "type": "string",
+        "reliability": "guaranteed",
+        "retention": "volatile",
+        "expiry": 120,
+        "database_retention_policy": "use_ttl",
+        "database_retention_ttl": 120,
+        "explicit_timestamp": true,
+        "description": "Mapping description",
+        "doc": "Mapping documentation"
+      }
+    ]
+  }
+}

--- a/cypress/fixtures/test.astarte.SpecifiedDefaultsInterface.json
+++ b/cypress/fixtures/test.astarte.SpecifiedDefaultsInterface.json
@@ -1,0 +1,34 @@
+{
+  "data": {
+    "interface_name": "test.astarte.SpecifiedDefaultsInterface",
+    "version_major": 0,
+    "version_minor": 1,
+    "type": "datastream",
+    "ownership": "device",
+    "aggregation": "individual",
+    "description": "Interface description",
+    "doc": "Interface documentation",
+    "mappings": [
+      {
+        "endpoint": "/objects/boolean",
+        "type": "boolean",
+        "reliability": "unreliable",
+        "retention": "discard",
+        "database_retention_policy": "no_ttl",
+        "explicit_timestamp": false
+      },
+      {
+        "endpoint": "/objects/string",
+        "type": "string",
+        "reliability": "unreliable",
+        "retention": "volatile",
+        "expiry": 0,
+        "database_retention_policy": "use_ttl",
+        "database_retention_ttl": 60,
+        "explicit_timestamp": false,
+        "description": "Mapping description",
+        "doc": "Mapping documentation"
+      }
+    ]
+  }
+}

--- a/cypress/integration/interface_builder_test.js
+++ b/cypress/integration/interface_builder_test.js
@@ -1,3 +1,293 @@
+const _ = require('lodash');
+
+const parseMappingOptions = (mapping) => {
+  return {
+    reliability: _.get(mapping, 'reliability', 'unreliable'),
+    explicitTimestamp: _.get(mapping, 'explicit_timestamp', false),
+    retention: _.get(mapping, 'retention', 'discard'),
+    expiry: _.get(mapping, 'expiry', 0),
+    databaseRetention: _.get(mapping, 'database_retention_policy', 'no_ttl'),
+    databaseTTL: _.get(mapping, 'database_retention_ttl'),
+    allowUnset: _.get(mapping, 'allow_unset', false),
+  };
+};
+
+const setupInterfaceEditorFromSource = (iface) => {
+  cy.get('#interfaceSource')
+    .clear()
+    .type(JSON.stringify(iface), { parseSpecialCharSequences: false });
+  cy.wait(500);
+};
+
+const setupInterfaceEditorFromUI = (iface) => {
+  cy.get('#interfaceName').scrollIntoView().clear().type(iface.interface_name);
+  if (iface.version_major > 0) {
+    cy.get('#interfaceMajor').scrollIntoView().type(`{selectall}${iface.version_major}`);
+    cy.get('#interfaceMinor').scrollIntoView().type(`{selectall}${iface.version_minor}`);
+  } else {
+    cy.get('#interfaceMinor').scrollIntoView().type(`{selectall}${iface.version_minor}`);
+    cy.get('#interfaceMajor').scrollIntoView().type(`{selectall}${iface.version_major}`);
+  }
+  if (iface.ownership === 'server') {
+    cy.get('#interfaceOwnershipServer').scrollIntoView().check();
+  } else {
+    cy.get('#interfaceOwnershipDevice').scrollIntoView().check();
+  }
+  if (iface.type === 'properties') {
+    cy.get('#interfaceTypeProperties').scrollIntoView().scrollIntoView().check();
+  } else {
+    cy.get('#interfaceTypeDatastream').scrollIntoView().check();
+    if (iface.aggregation === 'object') {
+      cy.get('#interfaceAggregationObject').scrollIntoView().check();
+    } else {
+      cy.get('#interfaceAggregationIndividual').scrollIntoView().check();
+    }
+  }
+  if (iface.aggregation === 'object') {
+    const {
+      reliability,
+      explicitTimestamp,
+      retention,
+      expiry,
+      databaseRetention,
+      databaseTTL,
+    } = parseMappingOptions(_.get(iface.mappings, '0'));
+    cy.get('#objectMappingReliability').scrollIntoView().select(reliability);
+    if (explicitTimestamp) {
+      cy.get('#objectMappingExplicitTimestamp').scrollIntoView().check();
+    } else {
+      cy.get('#objectMappingExplicitTimestamp').scrollIntoView().uncheck();
+    }
+    cy.get('#objectMappingRetention').scrollIntoView().select(retention);
+    cy.get('#objectMappingDatabaseRetention').scrollIntoView().select(databaseRetention);
+    if (retention !== 'discard') {
+      cy.get('#objectMappingExpiry').scrollIntoView().type(`{selectall}${expiry}`);
+    }
+    if (databaseRetention !== 'no_ttl') {
+      cy.get('#objectMappingTTL').scrollIntoView().type(`{selectall}${databaseTTL}`);
+    }
+  }
+  cy.get('#interfaceDescription').scrollIntoView().clear();
+  if (iface.description) {
+    cy.get('#interfaceDescription')
+      .scrollIntoView()
+      .type(iface.description, { parseSpecialCharSequences: false });
+  }
+  cy.get('#interfaceDocumentation').scrollIntoView().clear();
+  if (iface.doc) {
+    cy.get('#interfaceDocumentation')
+      .scrollIntoView()
+      .type(iface.doc, { parseSpecialCharSequences: false });
+  }
+  (iface.mappings || []).forEach((mapping) => {
+    cy.get('button').contains('Add new mapping...').click();
+    cy.get('.modal.show').within(() => {
+      cy.get('#mappingEndpoint')
+        .scrollIntoView()
+        .clear()
+        .type(mapping.endpoint, { parseSpecialCharSequences: false });
+      cy.get('#mappingType').scrollIntoView().select(mapping.type);
+      cy.get('#mappingDescription').scrollIntoView().clear();
+      if (mapping.description) {
+        cy.get('#mappingDescription').scrollIntoView().type(mapping.description, {
+          parseSpecialCharSequences: false,
+        });
+      }
+      cy.get('#mappingDocumentation').scrollIntoView().clear();
+      if (mapping.doc) {
+        cy.get('#mappingDocumentation')
+          .scrollIntoView()
+          .type(mapping.doc, { parseSpecialCharSequences: false });
+      }
+      const {
+        reliability,
+        explicitTimestamp,
+        retention,
+        expiry,
+        databaseRetention,
+        databaseTTL,
+        allowUnset,
+      } = parseMappingOptions(mapping);
+      if (iface.type === 'properties') {
+        if (allowUnset) {
+          cy.get('#mappingAllowUnset').scrollIntoView().check();
+        } else {
+          cy.get('#mappingAllowUnset').scrollIntoView().uncheck();
+        }
+      } else if (iface.type === 'datastream' && iface.aggregation !== 'object') {
+        cy.get('#mappingReliability').scrollIntoView().select(reliability);
+        cy.get('#mappingRetention').scrollIntoView().select(retention);
+        cy.get('#mappingDatabaseRetention').scrollIntoView().select(databaseRetention);
+        if (explicitTimestamp) {
+          cy.get('#mappingExplicitTimestamp').scrollIntoView().check();
+        } else {
+          cy.get('#mappingExplicitTimestamp').scrollIntoView().uncheck();
+        }
+        if (retention !== 'discard') {
+          cy.get('#mappingExpiry').scrollIntoView().type(`{selectall}${expiry}`);
+        }
+        if (databaseRetention !== 'no_ttl') {
+          cy.get('#mappingTTL').scrollIntoView().type(`{selectall}${databaseTTL}`);
+        }
+      }
+      cy.get('button').contains('Confirm').click();
+    });
+  });
+};
+
+const checkMappingEditorUIValues = ({ mapping, type, aggregation = 'individual' }) => {
+  cy.get('.card button')
+    .contains(mapping.endpoint)
+    .scrollIntoView()
+    .should('be.visible')
+    .parents('.card')
+    .within(() => {
+      cy.get('button').contains('Edit...').click();
+    });
+  cy.get('.modal.show').within(() => {
+    cy.get('#mappingEndpoint')
+      .scrollIntoView()
+      .should('be.visible')
+      .and('have.value', mapping.endpoint);
+    cy.get('#mappingType').scrollIntoView().should('be.visible').and('have.value', mapping.type);
+    cy.get('#mappingDescription')
+      .scrollIntoView()
+      .should('be.visible')
+      .and('have.value', mapping.description || '');
+    cy.get('#mappingDocumentation')
+      .scrollIntoView()
+      .should('be.visible')
+      .and('have.value', mapping.doc || '');
+    const {
+      reliability,
+      explicitTimestamp,
+      retention,
+      expiry,
+      databaseRetention,
+      databaseTTL,
+      allowUnset,
+    } = parseMappingOptions(mapping);
+    if (type === 'properties') {
+      cy.get('#mappingAllowUnset')
+        .scrollIntoView()
+        .should('be.visible')
+        .and(allowUnset ? 'be.checked' : 'not.be.checked');
+    } else if (type === 'datastream' && aggregation !== 'object') {
+      cy.get('#mappingReliability')
+        .scrollIntoView()
+        .should('be.visible')
+        .and('have.value', reliability || 'unreliable');
+      cy.get('#mappingRetention')
+        .scrollIntoView()
+        .should('be.visible')
+        .and('have.value', retention || 'discard');
+      cy.get('#mappingDatabaseRetention')
+        .scrollIntoView()
+        .should('be.visible')
+        .and('have.value', databaseRetention || 'no_ttl');
+      cy.get('#mappingExplicitTimestamp')
+        .scrollIntoView()
+        .should('be.visible')
+        .and(explicitTimestamp ? 'be.checked' : 'not.be.checked');
+      if (retention !== 'discard') {
+        cy.get('#mappingExpiry')
+          .scrollIntoView()
+          .should('be.visible')
+          .and('have.value', expiry || 0);
+      }
+      if (databaseRetention !== 'no_ttl') {
+        cy.get('#mappingTTL')
+          .scrollIntoView()
+          .should('be.visible')
+          .and('have.value', databaseTTL || 60);
+      }
+    }
+    cy.get('button').contains('Cancel').click();
+  });
+};
+
+const checkInterfaceEditorUIValues = (iface) => {
+  cy.get('#interfaceName')
+    .scrollIntoView()
+    .should('be.visible')
+    .and('have.value', iface.interface_name);
+  cy.get('#interfaceMajor')
+    .scrollIntoView()
+    .should('be.visible')
+    .and('have.value', iface.version_major);
+  cy.get('#interfaceMinor')
+    .scrollIntoView()
+    .should('be.visible')
+    .and('have.value', iface.version_minor);
+  cy.get('#interfaceDescription')
+    .scrollIntoView()
+    .should('be.visible')
+    .and('have.value', iface.description || '');
+  cy.get('#interfaceDocumentation')
+    .scrollIntoView()
+    .should('be.visible')
+    .and('have.value', iface.doc || '');
+  if (iface.ownership === 'server') {
+    cy.get('#interfaceOwnershipServer').scrollIntoView().should('be.visible').and('be.checked');
+  } else {
+    cy.get('#interfaceOwnershipDevice').scrollIntoView().should('be.visible').and('be.checked');
+  }
+  if (iface.type === 'properties') {
+    cy.get('#interfaceTypeProperties').scrollIntoView().should('be.visible').and('be.checked');
+  } else {
+    cy.get('#interfaceTypeDatastream').scrollIntoView().should('be.visible').and('be.checked');
+    if (iface.aggregation === 'object') {
+      cy.get('#interfaceAggregationObject').scrollIntoView().should('be.visible').and('be.checked');
+    } else {
+      cy.get('#interfaceAggregationIndividual')
+        .scrollIntoView()
+        .should('be.visible')
+        .and('be.checked');
+    }
+  }
+  if (iface.aggregation === 'object') {
+    const {
+      reliability,
+      explicitTimestamp,
+      retention,
+      expiry,
+      databaseRetention,
+      databaseTTL,
+    } = parseMappingOptions(_.get(iface.mappings, '0'));
+    cy.get('#objectMappingReliability')
+      .scrollIntoView()
+      .should('be.visible')
+      .and('have.value', reliability || 'unreliable');
+    cy.get('#objectMappingExplicitTimestamp')
+      .scrollIntoView()
+      .should('be.visible')
+      .and(explicitTimestamp ? 'be.checked' : 'not.be.checked');
+    cy.get('#objectMappingRetention')
+      .scrollIntoView()
+      .should('be.visible')
+      .and('have.value', retention || 'discard');
+    cy.get('#objectMappingDatabaseRetention')
+      .scrollIntoView()
+      .should('be.visible')
+      .and('have.value', databaseRetention || 'no_ttl');
+    if (retention !== 'discard') {
+      cy.get('#objectMappingExpiry')
+        .scrollIntoView()
+        .should('be.visible')
+        .and('have.value', expiry || 0);
+    }
+    if (databaseRetention !== 'no_ttl') {
+      cy.get('#objectMappingTTL')
+        .scrollIntoView()
+        .should('be.visible')
+        .and('have.value', databaseTTL || 60);
+    }
+  }
+  (iface.mappings || []).forEach((mapping) => {
+    cy.get('.card button').contains(mapping.endpoint).scrollIntoView().should('be.visible');
+  });
+};
+
 describe('Interface builder tests', () => {
   context("without an app's config", () => {
     it('starts up as a standalone Interface Editor', () => {
@@ -27,50 +317,626 @@ describe('Interface builder tests', () => {
   context('authenticated', () => {
     beforeEach(() => {
       cy.login();
-
-      cy.fixture('test.astarte.FirstInterface').as('test_interface');
-      cy.server();
-      cy.route('GET', '/realmmanagement/v1/*/interfaces/*/*', '@test_interface');
-      cy.wait(200);
     });
 
-    it('loads empty builder', () => {
-      cy.visit('/interfaces/new');
-      cy.location('pathname').should('eq', '/interfaces/new');
-      cy.get('#interfaceName').should('have.value', '');
+    context('new interface page', () => {
+      beforeEach(() => {
+        cy.visit('/interfaces/new');
+      });
 
-      // default interface version should be 0.1
-      cy.get('#interfaceMajor').should('have.value', '0');
-      cy.get('#interfaceMinor').should('have.value', '1');
+      it('successfully loads New Interface page', function () {
+        cy.location('pathname').should('eq', '/interfaces/new');
+        cy.get('.main-content h2').contains('Interface Editor');
+      });
+
+      it('has a Hide button to toggle Interface Source visibility', () => {
+        cy.get('#interfaceSource').scrollIntoView().should('be.visible');
+        cy.get('button').contains('Hide source').scrollIntoView().click();
+        cy.get('#interfaceSource').should('not.be.visible');
+        cy.get('button').contains('Show source').scrollIntoView().click();
+        cy.get('#interfaceSource').scrollIntoView().should('be.visible');
+      });
+
+      it('correctly displays default and disabled options', () => {
+        cy.get('label[for="interfaceName"]').contains('Name');
+        cy.get('#interfaceName').should('be.enabled').and('be.empty');
+        // default interface version should be 0.1
+        cy.get('label[for="interfaceMajor"]').contains('Major');
+        cy.get('#interfaceMajor').should('be.enabled').and('have.value', '0');
+        cy.get('label[for="interfaceMinor"]').contains('Minor');
+        cy.get('#interfaceMinor').should('be.enabled').and('have.value', '1');
+        cy.get('label[for="interfaceTypeDatastream"]').contains('Datastream');
+        cy.get('#interfaceTypeDatastream').should('be.enabled').and('not.be.checked');
+        cy.get('label[for="interfaceTypeProperties"]').contains('Properties');
+        cy.get('#interfaceTypeProperties').should('be.enabled').and('be.checked');
+        cy.get('label[for="interfaceAggregationIndividual"]').contains('Individual');
+        cy.get('#interfaceAggregationIndividual').should('be.disabled');
+        cy.get('label[for="interfaceAggregationObject"]').contains('Object');
+        cy.get('#interfaceAggregationObject').should('be.disabled');
+        cy.get('label[for="interfaceOwnershipDevice"]').contains('Device');
+        cy.get('#interfaceOwnershipDevice').should('be.enabled').and('be.checked');
+        cy.get('label[for="interfaceOwnershipServer"]').contains('Server');
+        cy.get('#interfaceOwnershipServer').should('be.enabled').and('not.be.checked');
+        cy.get('label[for="interfaceDescription"]').contains('Description');
+        cy.get('#interfaceDescription').should('be.enabled').and('be.empty');
+        cy.get('label[for="interfaceDocumentation"]').contains('Documentation');
+        cy.get('#interfaceDocumentation').should('be.enabled').and('be.empty');
+        cy.get('button').contains('Add new mapping...');
+
+        // Select Datastream type
+        cy.get('label').contains('Datastream').click();
+        cy.get('#interfaceAggregationIndividual').should('be.enabled').and('be.checked');
+        cy.get('#interfaceAggregationObject').should('be.enabled').and('not.be.checked');
+
+        // Select Object type
+        cy.get('label').contains('Object').click();
+
+        cy.get('label[for="objectMappingReliability"]').contains('Reliability');
+        cy.get('#objectMappingReliability').should('be.enabled').and('have.value', 'unreliable');
+        cy.get('label[for="objectMappingExplicitTimestamp"]').contains('Explicit timestamp');
+        cy.get('#objectMappingExplicitTimestamp').should('be.enabled').and('be.checked');
+        cy.get('label[for="objectMappingRetention"]').contains('Retention');
+        cy.get('#objectMappingRetention').should('be.enabled').and('have.value', 'discard');
+        cy.get('label[for="objectMappingDatabaseRetention"]').contains('Database Retention');
+        cy.get('#objectMappingDatabaseRetention').should('be.enabled').and('have.value', 'no_ttl');
+
+        // Select Volatile retention
+        cy.get('#objectMappingRetention').select('volatile');
+
+        cy.get('label[for="objectMappingExpiry"]').contains('Expiry');
+        cy.get('#objectMappingExpiry').should('be.enabled').and('have.value', '0');
+
+        // Select use_ttl database retention
+        cy.get('#objectMappingDatabaseRetention').select('use_ttl');
+
+        cy.get('label[for="objectMappingTTL"]').contains('TTL');
+        cy.get('#objectMappingTTL').should('be.enabled').and('have.value', '60');
+      });
+
+      it('displays correct Mapping editor depending on interface type', () => {
+        // Properties interface
+        cy.get('label').contains('Properties').click();
+        cy.get('button').contains('Add new mapping...').click();
+        cy.get('.modal.show').within(() => {
+          cy.get('.modal-header').contains('Add new mapping');
+          cy.get('label[for="mappingEndpoint"]').contains('Endpoint');
+          cy.get('#mappingEndpoint').should('be.enabled').and('be.empty');
+          cy.get('label[for="mappingType"]').contains('Type');
+          cy.get('#mappingType').should('be.enabled').and('have.value', 'double');
+          cy.get('label[for="mappingAllowUnset"]').contains('Allow unset');
+          cy.get('#mappingAllowUnset').should('be.enabled').and('not.be.checked');
+          cy.get('label[for="mappingDescription"]').contains('Description');
+          cy.get('#mappingDescription').should('be.enabled').and('be.empty');
+          cy.get('label[for="mappingDocumentation"]').contains('Documentation');
+          cy.get('#mappingDocumentation').should('be.enabled').and('be.empty');
+          cy.get('button').contains('Confirm').should('be.disabled');
+          cy.get('button').contains('Cancel').click();
+        });
+
+        // Datastream Object interface
+        cy.get('label').contains('Datastream').click();
+        cy.get('label').contains('Object').click();
+        cy.get('button').contains('Add new mapping...').click();
+        cy.get('.modal.show').within(() => {
+          cy.get('.modal-header').contains('Add new mapping');
+          cy.get('label[for="mappingEndpoint"]').contains('Endpoint');
+          cy.get('#mappingEndpoint').should('be.enabled').and('be.empty');
+          cy.get('label[for="mappingType"]').contains('Type');
+          cy.get('#mappingType').should('be.enabled').and('have.value', 'double');
+          cy.get('label[for="mappingDescription"]').contains('Description');
+          cy.get('#mappingDescription').should('be.enabled').and('be.empty');
+          cy.get('label[for="mappingDocumentation"]').contains('Documentation');
+          cy.get('#mappingDocumentation').should('be.enabled').and('be.empty');
+          cy.get('button').contains('Confirm').should('be.disabled');
+          cy.get('button').contains('Cancel').click();
+        });
+
+        // Datastream Individual interface
+        cy.get('label').contains('Datastream').click();
+        cy.get('label').contains('Individual').click();
+        cy.get('button').contains('Add new mapping...').click();
+        cy.get('.modal.show').within(() => {
+          cy.get('.modal-header').contains('Add new mapping');
+          cy.get('label[for="mappingEndpoint"]').contains('Endpoint');
+          cy.get('#mappingEndpoint').should('be.enabled').and('be.empty');
+          cy.get('label[for="mappingType"]').contains('Type');
+          cy.get('#mappingType').should('be.enabled').and('have.value', 'double');
+          cy.get('label[for="mappingReliability"]').contains('Reliability');
+          cy.get('#mappingReliability').should('be.enabled').and('have.value', 'unreliable');
+          cy.get('label[for="mappingRetention"]').contains('Retention');
+          cy.get('#mappingRetention').should('be.enabled').and('have.value', 'discard');
+          cy.get('label[for="mappingDatabaseRetention"]').contains('Database retention');
+          cy.get('#mappingDatabaseRetention').should('be.enabled').and('have.value', 'no_ttl');
+          cy.get('label[for="mappingExplicitTimestamp"]').contains('Explicit timestamp');
+          cy.get('#mappingExplicitTimestamp').should('be.enabled').and('be.checked');
+          cy.get('label[for="mappingDescription"]').contains('Description');
+          cy.get('#mappingDescription').should('be.enabled').and('be.empty');
+          cy.get('label[for="mappingDocumentation"]').contains('Documentation');
+          cy.get('#mappingDocumentation').should('be.enabled').and('be.empty');
+
+          // Select Volatile retention
+          cy.get('#mappingRetention').select('volatile');
+          cy.get('label[for="mappingExpiry"]').contains('Expiry');
+          cy.get('#mappingExpiry').should('be.enabled').and('have.value', '0');
+
+          // Select use_ttl database retention
+          cy.get('#mappingDatabaseRetention').select('use_ttl');
+          cy.get('label[for="mappingTTL"]').contains('TTL');
+          cy.get('#mappingTTL').should('be.enabled').and('have.value', '60');
+
+          cy.get('button').contains('Confirm').should('be.disabled');
+          cy.get('button').contains('Cancel').click();
+        });
+      });
+
+      it('can add, edit and remove mappings', () => {
+        const mappingEndpoint = '/mapping_endpoint';
+
+        // Add new mapping
+        cy.get('button').contains('Add new mapping...').click();
+        cy.get('.modal.show').within(() => {
+          cy.get('.modal-header').contains('Add new mapping');
+          cy.get('#mappingEndpoint').type(mappingEndpoint);
+          cy.get('#mappingType').select('double');
+          cy.get('button').contains('Confirm').click();
+        });
+        cy.get('button')
+          .contains(mappingEndpoint)
+          .parents('.card')
+          .within(() => {
+            cy.get('.badge').contains('double');
+          });
+
+        // Edit mapping
+        cy.get('button')
+          .contains(mappingEndpoint)
+          .parents('.card')
+          .within(() => {
+            cy.get('button').contains('Edit...').click();
+          });
+        cy.get('.modal.show').within(() => {
+          cy.get('.modal-header').contains('Edit mapping');
+          cy.get('#mappingType').select('string');
+          cy.get('button').contains('Confirm').click();
+        });
+        cy.get('button')
+          .contains(mappingEndpoint)
+          .parents('.card')
+          .within(() => {
+            cy.get('.badge').contains('string');
+          });
+
+        // Remove mapping
+        cy.get('button')
+          .contains(mappingEndpoint)
+          .parents('.card')
+          .within(() => {
+            cy.get('button').contains('Remove').click();
+          });
+        cy.get('button').contains(mappingEndpoint).should('not.exist');
+      });
+
+      it('shows the correct confirmation modal before installing the interface', () => {
+        const interfaceName = 'com.samples.Interface';
+
+        // Set name
+        cy.get('#interfaceName').type(interfaceName);
+
+        // Set draft version
+        cy.get('#interfaceMinor').type('{selectall}1');
+        cy.get('#interfaceMajor').type('{selectall}0');
+
+        // Add mapping
+        cy.get('button').contains('Add new mapping...').click();
+        cy.get('.modal.show').within(() => {
+          cy.get('.modal-header').contains('Add new mapping');
+          cy.get('#mappingEndpoint').type('/enpdoint');
+          cy.get('button').contains('Confirm').click();
+        });
+
+        // Modal confirmation for draft version
+        cy.get('button').contains('Install interface').click();
+        cy.get('.modal.show').within(() => {
+          cy.get('.modal-header').contains('Confirmation Required');
+          cy.contains(`You are about to install the interface ${interfaceName}.`);
+          cy.contains(
+            'As its major version is 0, this is a draft interface, which can be deleted.',
+          );
+          cy.contains('In such a case, any data sent through this interface will be lost.');
+          cy.contains('Draft Interfaces should be used for development and testing purposes only.');
+          cy.contains('Are you sure you want to continue?');
+          cy.get('button').contains('Cancel').click();
+        });
+
+        // Set major version
+        cy.get('#interfaceMajor').type('{selectall}1');
+
+        // Modal confirmation for major version
+        cy.get('button').contains('Install interface').click();
+        cy.get('.modal.show').within(() => {
+          cy.get('.modal-header').contains('Confirmation Required');
+          cy.contains(`You are about to install the interface ${interfaceName}.`);
+          cy.contains(
+            'Interface major is greater than zero, that means you will not be able to change already installed mappings.',
+          );
+          cy.contains('Are you sure you want to continue?');
+          cy.get('button').contains('Cancel').click();
+        });
+      });
+
+      it('correctly reports errors and warning for the interface name property', () => {
+        // Empty name
+        cy.get('#interfaceName').clear();
+        cy.get('#interfaceName').should('have.class', 'is-invalid');
+
+        // Invalid name
+        cy.get('#interfaceName').type('invalid_name!');
+        cy.get('#interfaceName').should('have.class', 'is-invalid');
+
+        // Valid but poor name
+        cy.get('#interfaceName').clear().type('name');
+        cy.get('#interfaceName').should('not.have.class', 'is-invalid');
+        cy.get('#interfaceName')
+          .parents('.form-group')
+          .get('i.fa-exclamation-circle')
+          .should('be.visible');
+
+        // Valid name
+        cy.get('#interfaceName').clear().type('com.sample.Name');
+        cy.get('#interfaceName').should('not.have.class', 'is-invalid');
+        cy.get('#interfaceName')
+          .parents('.form-group')
+          .get('i.fa-exclamation-circle')
+          .should('not.be.visible');
+      });
+
+      it('correctly reports errors in mapping editor for the endpoint field', () => {
+        cy.get('button').contains('Add new mapping...').click();
+        cy.get('.modal.show').within(() => {
+          cy.get('#mappingEndpoint').clear();
+          cy.get('#mappingEndpoint').should('have.class', 'is-invalid');
+          cy.get('#mappingEndpoint').type('invalid_endpoint!');
+          cy.get('#mappingEndpoint').should('have.class', 'is-invalid');
+          cy.get('#mappingEndpoint').clear().type('/valid_endpoint');
+          cy.get('#mappingEndpoint').should('not.have.class', 'is-invalid');
+        });
+      });
+
+      it('correctly loads interface from its source', () => {
+        const interfaceFixtures = [
+          'test.astarte.NoDefaultsInterface',
+          'test.astarte.PropertiesInterface',
+          'test.astarte.IndividualObjectInterface',
+          'test.astarte.AggregatedObjectInterface',
+        ];
+        interfaceFixtures.forEach((interfaceFixture) => {
+          cy.fixture(interfaceFixture).then(({ data: iface }) => {
+            setupInterfaceEditorFromSource(iface);
+            checkInterfaceEditorUIValues(iface);
+          });
+        });
+      });
+
+      it('can correctly build an interface with the UI', () => {
+        const interfaceFixtures = [
+          'test.astarte.NoDefaultsInterface',
+          'test.astarte.PropertiesInterface',
+          'test.astarte.IndividualObjectInterface',
+          'test.astarte.AggregatedObjectInterface',
+        ];
+        interfaceFixtures.forEach((interfaceFixture) => {
+          cy.fixture(interfaceFixture).then(({ data: iface }) => {
+            setupInterfaceEditorFromUI(iface);
+            checkInterfaceEditorUIValues(iface);
+            (iface.mappings || []).forEach((mapping) => {
+              checkMappingEditorUIValues({
+                mapping,
+                type: iface.type,
+                aggregation: iface.aggregation,
+              });
+            });
+          });
+        });
+      });
+
+      it('redirects to list of interfaces after a new interface installation', () => {
+        cy.fixture('test.astarte.PropertiesInterface').then((interfaceFixture) => {
+          cy.route({
+            method: 'POST',
+            url: '/realmmanagement/v1/*/interfaces',
+            status: 201,
+            response: interfaceFixture,
+          }).as('installInterfaceRequest');
+          setupInterfaceEditorFromUI(interfaceFixture.data);
+          cy.get('button').contains('Install interface').click();
+          cy.get('.modal.show button').contains('Confirm').click();
+          cy.wait('@installInterfaceRequest')
+            .its('requestBody.data')
+            .should('deep.eq', interfaceFixture.data);
+          cy.location('pathname').should('eq', '/interfaces');
+        });
+      });
     });
 
-    it('shows selected interface', function() {
-      const testInterfaceName = this.test_interface.data.interface_name;
-      const testInterfaceMajor = this.test_interface.data.version_major;
-      const testInterfaceMinor = this.test_interface.data.version_minor;
-      cy.visit(`/interfaces/${testInterfaceName}/${testInterfaceMajor}`);
-      cy.location('pathname').should('eq', `/interfaces/${testInterfaceName}/${testInterfaceMajor}`);
+    context('edit interface page', () => {
+      it('correctly loads interface data into the Editor UI', () => {
+        const interfaceFixtures = [
+          'test.astarte.NoDefaultsInterface',
+          'test.astarte.PropertiesInterface',
+          'test.astarte.IndividualObjectInterface',
+          'test.astarte.AggregatedObjectInterface',
+        ];
+        interfaceFixtures.forEach((interfaceFixture) => {
+          cy.fixture(interfaceFixture).then(({ data: iface }) => {
+            cy.route(
+              'GET',
+              `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+              { data: iface },
+            );
+            cy.visit(`/interfaces/${iface.interface_name}/${iface.version_major}`);
+            cy.location('pathname').should(
+              'eq',
+              `/interfaces/${iface.interface_name}/${iface.version_major}`,
+            );
+            checkInterfaceEditorUIValues(iface);
+          });
+        });
+      });
 
-      cy.get('#interfaceName').should('have.value', testInterfaceName);
-      cy.get('#interfaceMajor').should('have.value', testInterfaceMajor).and('have.attr', 'readonly');
-      cy.get('#interfaceMinor').should('have.value', testInterfaceMinor);
-    });
+      it('correctly displays fields as disabled to prevent breaking changes from being made', function () {
+        cy.fixture('test.astarte.NoDefaultsInterface').then(({ data: iface }) => {
+          cy.route(
+            'GET',
+            `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+            { data: iface },
+          );
+          cy.visit(`/interfaces/${iface.interface_name}/${iface.version_major}`);
+          cy.get('#interfaceName').should('have.attr', 'readonly');
+          cy.get('#interfaceMajor').should('have.attr', 'readonly');
+          cy.get('#interfaceTypeDatastream').should('be.disabled');
+          cy.get('#interfaceTypeProperties').should('be.disabled');
+          cy.get('#interfaceAggregationIndividual').should('be.disabled');
+          cy.get('#interfaceAggregationObject').should('be.disabled');
+          cy.get('#interfaceOwnershipDevice').should('be.disabled');
+          cy.get('#interfaceOwnershipServer').should('be.disabled');
+          cy.get('#objectMappingReliability').should('be.disabled');
+          cy.get('#objectMappingExplicitTimestamp').should('be.disabled');
+          cy.get('#objectMappingRetention').should('be.disabled');
+          cy.get('#objectMappingExpiry').should('be.disabled');
+          cy.get('#objectMappingDatabaseRetention').should('be.disabled');
+          cy.get('#objectMappingTTL').should('be.disabled');
+          cy.get('.card button')
+            .contains(iface.mappings[0].endpoint)
+            .should('exist')
+            .parents('.card')
+            .within(() => {
+              cy.get('button').contains('Edit...').should('not.exist');
+              cy.get('button').contains('Remove').should('not.exist');
+            });
+        });
+      });
 
-    it('redirects to list of interfaces after a new interface installation', function () {
-      cy.route({
-        method: 'POST',
-        url: '/realmmanagement/v1/*/interfaces',
-        status: 201,
-        response: '@test_interface',
-      }).as('installInterfaceRequest');
-      cy.visit('/interfaces/new');
-      cy.get('#interfaceSource')
-        .clear()
-        .type(JSON.stringify(this.test_interface.data), { parseSpecialCharSequences: false });
-      cy.get('button').contains('Install interface').click();
-      cy.get('.modal.show button').contains('Confirm').click();
-      cy.location('pathname').should('eq', '/interfaces');
-      cy.get('h2').contains('Interfaces');
+      it('can add, edit and remove new mappings', function () {
+        cy.fixture('test.astarte.NoDefaultsInterface').then(({ data: iface }) => {
+          cy.route(
+            'GET',
+            `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+            { data: iface },
+          );
+          cy.visit(`/interfaces/${iface.interface_name}/${iface.version_major}`);
+
+          const mappingEndpoint = '/new_mapping_endpoint';
+
+          // Add new mapping
+          cy.get('button').contains('Add new mapping...').click();
+          cy.get('.modal.show').within(() => {
+            cy.get('.modal-header').contains('Add new mapping');
+            cy.get('#mappingEndpoint').type(mappingEndpoint);
+            cy.get('#mappingType').select('double');
+            cy.get('button').contains('Confirm').click();
+          });
+          cy.get('button')
+            .contains(mappingEndpoint)
+            .parents('.card')
+            .within(() => {
+              cy.get('.badge').contains('double');
+            });
+
+          // Edit mapping
+          cy.get('button')
+            .contains(mappingEndpoint)
+            .parents('.card')
+            .within(() => {
+              cy.get('button').contains('Edit...').click();
+            });
+          cy.get('.modal.show').within(() => {
+            cy.get('.modal-header').contains('Edit mapping');
+            cy.get('#mappingType').select('string');
+            cy.get('button').contains('Confirm').click();
+          });
+          cy.get('button')
+            .contains(mappingEndpoint)
+            .parents('.card')
+            .within(() => {
+              cy.get('.badge').contains('string');
+            });
+
+          // Remove mapping
+          cy.get('button')
+            .contains(mappingEndpoint)
+            .parents('.card')
+            .within(() => {
+              cy.get('button').contains('Remove').click();
+            });
+          cy.get('button').contains(mappingEndpoint).should('not.exist');
+        });
+      });
+
+      it('can only delete a draft Interface', function () {
+        const draftInterface = {
+          interface_name: 'test.astarte.DraftInterface',
+          version_major: 0,
+          version_minor: 1,
+          type: 'datastream',
+          ownership: 'device',
+          mappings: [
+            {
+              endpoint: '/test',
+              type: 'double',
+            },
+          ],
+        };
+        const majorInterface = _.merge({}, draftInterface, { version_major: 1 });
+
+        cy.route(
+          'GET',
+          `/realmmanagement/v1/*/interfaces/${majorInterface.interface_name}/${majorInterface.version_major}`,
+          { data: majorInterface },
+        );
+        cy.visit(`/interfaces/${majorInterface.interface_name}/${majorInterface.version_major}`);
+        cy.get('button').contains('Delete interface').scrollIntoView().should('not.be.visible');
+
+        cy.route(
+          'GET',
+          `/realmmanagement/v1/*/interfaces/${draftInterface.interface_name}/${draftInterface.version_major}`,
+          { data: draftInterface },
+        );
+        cy.route({
+          method: 'DELETE',
+          url: `/realmmanagement/v1/*/interfaces/${draftInterface.interface_name}/${draftInterface.version_major}`,
+          status: 204,
+          response: '',
+        }).as('deleteInterfaceRequest');
+        cy.visit(`/interfaces/${draftInterface.interface_name}/${draftInterface.version_major}`);
+        cy.get('button').contains('Delete interface').scrollIntoView().click();
+        cy.get('.modal.show').within(() => {
+          cy.contains(
+            `You are going to remove ${draftInterface.interface_name} v${draftInterface.version_major}. This might cause data loss, removed interfaces cannot be restored. Are you sure?`,
+          );
+          cy.contains(`Please type ${draftInterface.interface_name} to proceed.`);
+          cy.get('button').contains('Confirm').should('be.disabled');
+          cy.get('#confirmInterfaceName').type(draftInterface.interface_name);
+          cy.get('button').contains('Confirm').should('be.enabled').click();
+        });
+        cy.wait('@deleteInterfaceRequest');
+        cy.location('pathname').should('eq', '/interfaces');
+      });
+
+      it('asks to confirm before correctly applying changes', function () {
+        cy.fixture('test.astarte.NoDefaultsInterface').then(({ data: iface }) => {
+          cy.route(
+            'GET',
+            `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+            { data: iface },
+          );
+          cy.route({
+            method: 'PUT',
+            url: `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+            status: 204,
+            response: '',
+          }).as('saveInterfaceRequest');
+          cy.visit(`/interfaces/${iface.interface_name}/${iface.version_major}`);
+          const newIface = _.merge({}, iface, {
+            version_minor: iface.version_minor + 1,
+            doc: 'New documentation',
+          });
+          cy.get('#interfaceMinor').type(`{selectall}${newIface.version_minor}`);
+          cy.get('#interfaceDocumentation').clear().type(newIface.doc);
+          cy.get('button').contains('Apply changes').scrollIntoView().click();
+          cy.get('.modal.show').within(() => {
+            cy.get('.modal-header').contains('Confirmation Required');
+            cy.get('.modal-body').contains(`Update the interface ${newIface.interface_name}?`);
+            cy.get('button').contains('Confirm').click();
+          });
+          cy.wait('@saveInterfaceRequest').its('requestBody.data').should('deep.eq', newIface);
+        });
+      });
+
+      it('displays and save an interface source with default values stripped out', function () {
+        // Case with no default values to strip out
+        cy.fixture('test.astarte.NoDefaultsInterface').then(({ data: iface }) => {
+          cy.route(
+            'GET',
+            `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+            { data: iface },
+          );
+          cy.route({
+            method: 'PUT',
+            url: `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+            status: 204,
+            response: '',
+          }).as('saveInterfaceRequest');
+          cy.visit(`/interfaces/${iface.interface_name}/${iface.version_major}`);
+          const newIface = _.merge({}, iface, {
+            version_minor: iface.version_minor + 1,
+            doc: 'New documentation',
+          });
+
+          // Source should be displayed equal, without adding default values
+          cy.get('#interfaceSource')
+            .invoke('val')
+            .should((ifaceSource) => {
+              expect(JSON.parse(ifaceSource)).to.deep.eq(iface);
+            });
+
+          cy.get('#interfaceMinor').type(`{selectall}${newIface.version_minor}`);
+          cy.get('#interfaceDocumentation').clear().type(newIface.doc);
+
+          // Source should be displayed equal, without adding default values
+          cy.get('#interfaceSource')
+            .invoke('val')
+            .should((ifaceSource) => {
+              expect(JSON.parse(ifaceSource)).to.deep.eq(newIface);
+            });
+
+          // Interface should be saved without adding default values
+          cy.get('button').contains('Apply changes').scrollIntoView().click();
+          cy.get('.modal.show button').contains('Confirm').click();
+          cy.wait('@saveInterfaceRequest').its('requestBody.data').should('deep.eq', newIface);
+        });
+
+        // Case with default values to strip out
+        cy.fixture('test.astarte.SpecifiedDefaultsInterface').then(({ data: iface }) => {
+          cy.route(
+            'GET',
+            `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+            { data: iface },
+          );
+          cy.route({
+            method: 'PUT',
+            url: `/realmmanagement/v1/*/interfaces/${iface.interface_name}/${iface.version_major}`,
+            status: 204,
+            response: '',
+          }).as('saveInterfaceRequest');
+          cy.visit(`/interfaces/${iface.interface_name}/${iface.version_major}`);
+          const newIface = _.merge({}, iface, {
+            version_minor: iface.version_minor + 1,
+            doc: 'New documentation',
+          });
+
+          // Source should not be displayed equal, since default values are stripped out
+          cy.get('#interfaceSource')
+            .invoke('val')
+            .should((ifaceSource) => {
+              expect(JSON.parse(ifaceSource)).not.to.deep.eq(iface);
+            });
+
+          cy.get('#interfaceMinor').type(`{selectall}${newIface.version_minor}`);
+          cy.get('#interfaceDocumentation').clear().type(newIface.doc);
+
+          // Source should not be displayed equal, since default values are stripped out
+          cy.get('#interfaceSource')
+            .invoke('val')
+            .should((ifaceSource) => {
+              expect(JSON.parse(ifaceSource)).not.to.deep.eq(newIface);
+            });
+
+          // Interface should be saved with default values stripped out
+          cy.get('button').contains('Apply changes').scrollIntoView().click();
+          cy.get('.modal.show button').contains('Confirm').click();
+          cy.wait('@saveInterfaceRequest').its('requestBody.data').should('not.deep.eq', newIface);
+        });
+      });
     });
   });
 });

--- a/elm.json
+++ b/elm.json
@@ -23,7 +23,7 @@
             "folkertdev/one-true-path-experiment": "4.0.3",
             "gampleman/elm-visualization": "2.0.1",
             "rtfeldman/elm-iso8601-date-strings": "1.1.3",
-            "rundis/elm-bootstrap": "5.1.0"
+            "rundis/elm-bootstrap": "5.2.0"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/src/elm/Modal/MappingBuilder.elm
+++ b/src/elm/Modal/MappingBuilder.elm
@@ -504,7 +504,7 @@ renderMappingEndpointInput endpoint isObject editMode endpointWarningPopup =
     Form.group []
         [ Form.label [ for "mappingEndpoint" ] [ text "Endpoint" ]
         , Input.text
-            [ Input.id "Endpoint"
+            [ Input.id "mappingEndpoint"
             , Input.value endpoint
             , Input.disabled editMode
             , Input.onInput UpdateMappingEndpoint

--- a/src/elm/Modal/MappingBuilder.elm
+++ b/src/elm/Modal/MappingBuilder.elm
@@ -236,6 +236,7 @@ view : Model -> Html Msg
 view model =
     Modal.config (Close ModalCancel)
         |> Modal.large
+        |> Modal.scrollableBody True
         |> Modal.h5 []
             [ if model.editMode then
                 text "Edit mapping"

--- a/src/elm/Modal/MappingBuilder.elm
+++ b/src/elm/Modal/MappingBuilder.elm
@@ -284,9 +284,9 @@ renderBody mapping isProperties isObject editMode endpointWarningPopup =
                     Col.sm12
                 ]
                 [ Form.group []
-                    [ Form.label [ for "mappingTypes" ] [ text "Type" ]
+                    [ Form.label [ for "mappingType" ] [ text "Type" ]
                     , Select.select
-                        [ Select.id "mappingTypes"
+                        [ Select.id "mappingType"
                         , Select.onChange UpdateMappingType
                         ]
                         (List.map (\t -> renderMappingTypeItem (t == mapping.mType) t) InterfaceMapping.mappingTypeList)
@@ -442,7 +442,7 @@ renderBody mapping isProperties isObject editMode endpointWarningPopup =
             , Form.col [ Col.sm3 ]
                 [ Form.group []
                     [ Checkbox.checkbox
-                        [ Checkbox.id "mappingExpTimestamp"
+                        [ Checkbox.id "mappingExplicitTimestamp"
                         , Checkbox.checked mapping.explicitTimestamp
                         , Checkbox.onCheck UpdateMappingTimestamp
                         ]
@@ -466,9 +466,9 @@ renderBody mapping isProperties isObject editMode endpointWarningPopup =
         , Form.row []
             [ Form.col [ Col.sm12 ]
                 [ Form.group []
-                    [ Form.label [ for "mappingDoc" ] [ text "Documentation" ]
+                    [ Form.label [ for "mappingDocumentation" ] [ text "Documentation" ]
                     , Textarea.textarea
-                        [ Textarea.id "mappingDoc"
+                        [ Textarea.id "mappingDocumentation"
                         , Textarea.rows 1
                         , Textarea.value <| mapping.doc
                         , Textarea.onInput UpdateMappingDoc

--- a/src/elm/Page/InterfaceBuilder.elm
+++ b/src/elm/Page/InterfaceBuilder.elm
@@ -62,6 +62,7 @@ import Types.InterfaceMapping as InterfaceMapping
         , mappingTypeToEnglishString
         , reliabilityToEnglishString
         , retentionToEnglishString
+        , databaseRetentionToEnglishString
         )
 import Types.Session exposing (Session)
 import Types.SuggestionPopup as SuggestionPopup exposing (SuggestionPopup)
@@ -259,6 +260,8 @@ update session msg model =
                             { reliability = mapping.reliability
                             , retention = mapping.retention
                             , expiry = mapping.expiry
+                            , databaseRetention = mapping.databaseRetention
+                            , ttl = mapping.ttl
                             , explicitTimestamp = mapping.explicitTimestamp
                             }
 
@@ -266,6 +269,8 @@ update session msg model =
                             { reliability = InterfaceMapping.Unreliable
                             , retention = InterfaceMapping.Discard
                             , expiry = 0
+                            , databaseRetention = InterfaceMapping.NoTTL
+                            , ttl = 60
                             , explicitTimestamp = True
                             }
             in
@@ -278,6 +283,8 @@ update session msg model =
                 , objectReliability = commonObjectParams.reliability
                 , objectRetention = commonObjectParams.retention
                 , objectExpiry = commonObjectParams.expiry
+                , objectDatabaseRetention = commonObjectParams.databaseRetention
+                , objectTTL = commonObjectParams.ttl
                 , objectExplicitTimestamp = commonObjectParams.explicitTimestamp
                 , showSpinner = False
               }
@@ -420,6 +427,8 @@ update session msg model =
                                         { reliability = mapping.reliability
                                         , retention = mapping.retention
                                         , expiry = mapping.expiry
+                                        , databaseRetention = mapping.databaseRetention
+                                        , ttl = mapping.ttl
                                         , explicitTimestamp = mapping.explicitTimestamp
                                         }
 
@@ -427,6 +436,8 @@ update session msg model =
                                         { reliability = InterfaceMapping.Unreliable
                                         , retention = InterfaceMapping.Discard
                                         , expiry = 0
+                                        , databaseRetention = InterfaceMapping.NoTTL
+                                        , ttl = 60
                                         , explicitTimestamp = False
                                         }
                         in
@@ -437,6 +448,8 @@ update session msg model =
                             , objectReliability = commonObjectParams.reliability
                             , objectRetention = commonObjectParams.retention
                             , objectExpiry = commonObjectParams.expiry
+                            , objectDatabaseRetention = commonObjectParams.databaseRetention
+                            , objectTTL = commonObjectParams.ttl
                             , objectExplicitTimestamp = commonObjectParams.explicitTimestamp
                           }
                         , Cmd.none
@@ -1483,11 +1496,17 @@ renderMapping mapping =
         , options = [ Card.attrs [ Spacing.mb2 ] ]
         , header = renderMappingHeader mapping
         , blocks =
-            [ ( textBlock "Allow Unset" ""
+            [ ( textBlock "Description" mapping.description
+              , String.isEmpty mapping.description
+              )
+            , ( textBlock "Documentation" mapping.doc
+              , String.isEmpty mapping.doc
+              )
+            , ( textBlock "Allow Unset" <| boolToString mapping.allowUnset
               , not mapping.allowUnset
               )
-            , ( textBlock "Description" mapping.description
-              , String.isEmpty mapping.description
+            , ( textBlock "Explicit Timestamp" <| boolToString mapping.explicitTimestamp
+              , not mapping.explicitTimestamp
               )
             , ( textBlock "Reliability" <| reliabilityToEnglishString mapping.reliability
               , mapping.reliability == InterfaceMapping.Unreliable
@@ -1495,14 +1514,14 @@ renderMapping mapping =
             , ( textBlock "Retention" <| retentionToEnglishString mapping.retention
               , mapping.retention == InterfaceMapping.Discard
               )
-            , ( textBlock "Expiry" <| String.fromInt mapping.expiry
+            , ( textBlock "Expiry" <| String.fromInt mapping.expiry ++ " seconds"
               , mapping.retention == InterfaceMapping.Discard || mapping.expiry == 0
               )
-            , ( textBlock "Explicit Timestamp" <| boolToString mapping.explicitTimestamp
-              , not mapping.explicitTimestamp
+            , ( textBlock "Database Retention" <| databaseRetentionToEnglishString mapping.databaseRetention
+              , mapping.databaseRetention == InterfaceMapping.NoTTL
               )
-            , ( textBlock "Doc" mapping.doc
-              , String.isEmpty mapping.doc
+            , ( textBlock "Database Retention TTL" <| String.fromInt mapping.ttl ++ " seconds"
+              , mapping.databaseRetention == InterfaceMapping.NoTTL
               )
             ]
                 |> List.filterMap
@@ -1710,7 +1729,7 @@ subscriptions model =
 boolToString : Bool -> String
 boolToString b =
     if b then
-        "true"
+        "True"
 
     else
-        "false"
+        "False"

--- a/src/elm/Page/InterfaceBuilder.elm
+++ b/src/elm/Page/InterfaceBuilder.elm
@@ -1103,14 +1103,14 @@ renderContent model interface interfaceEditMode accordionState =
                             |> Fieldset.children
                                 (Radio.radioList "interfaceType"
                                     [ Radio.create
-                                        [ Radio.id "itrb1"
+                                        [ Radio.id "interfaceTypeDatastream"
                                         , Radio.disabled interfaceEditMode
                                         , Radio.checked <| interface.iType == Interface.Datastream
                                         , Radio.onClick <| UpdateInterfaceType Interface.Datastream
                                         ]
                                         "Datastream"
                                     , Radio.create
-                                        [ Radio.id "itrb2"
+                                        [ Radio.id "interfaceTypeProperties"
                                         , Radio.disabled interfaceEditMode
                                         , Radio.checked <| interface.iType == Interface.Properties
                                         , Radio.onClick <| UpdateInterfaceType Interface.Properties
@@ -1129,14 +1129,14 @@ renderContent model interface interfaceEditMode accordionState =
                             |> Fieldset.children
                                 (Radio.radioList "interfaceAggregation"
                                     [ Radio.create
-                                        [ Radio.id "iarb1"
+                                        [ Radio.id "interfaceAggregationIndividual"
                                         , Radio.disabled <| interfaceEditMode || interface.iType == Interface.Properties
                                         , Radio.checked <| interface.aggregation == Interface.Individual
                                         , Radio.onClick <| UpdateInterfaceAggregation Interface.Individual
                                         ]
                                         "Individual"
                                     , Radio.create
-                                        [ Radio.id "iarb2"
+                                        [ Radio.id "interfaceAggregationObject"
                                         , Radio.disabled <| interfaceEditMode || interface.iType == Interface.Properties
                                         , Radio.checked <| interface.aggregation == Interface.Object
                                         , Radio.onClick <| UpdateInterfaceAggregation Interface.Object
@@ -1155,14 +1155,14 @@ renderContent model interface interfaceEditMode accordionState =
                             |> Fieldset.children
                                 (Radio.radioList "interfaceOwnership"
                                     [ Radio.create
-                                        [ Radio.id "iorb1"
+                                        [ Radio.id "interfaceOwnershipDevice"
                                         , Radio.disabled <| interfaceEditMode
                                         , Radio.checked <| interface.ownership == Interface.Device
                                         , Radio.onClick <| UpdateInterfaceOwnership Interface.Device
                                         ]
                                         "Device"
                                     , Radio.create
-                                        [ Radio.id "iorb2"
+                                        [ Radio.id "interfaceOwnershipServer"
                                         , Radio.disabled <| interfaceEditMode
                                         , Radio.checked <| interface.ownership == Interface.Server
                                         , Radio.onClick <| UpdateInterfaceOwnership Interface.Server
@@ -1191,9 +1191,9 @@ renderContent model interface interfaceEditMode accordionState =
             , Form.row []
                 [ Form.col [ Col.sm12 ]
                     [ Form.group []
-                        [ Form.label [ for "interfaceDoc" ] [ text "Documentation" ]
+                        [ Form.label [ for "interfaceDocumentation" ] [ text "Documentation" ]
                         , Textarea.textarea
-                            [ Textarea.id "interfaceDoc"
+                            [ Textarea.id "interfaceDocumentation"
                             , Textarea.rows 3
                             , Textarea.value interface.doc
                             , Textarea.onInput UpdateInterfaceDoc
@@ -1305,7 +1305,7 @@ renderCommonMappingSettings model =
             ]
             [ Form.group []
                 [ Checkbox.checkbox
-                    [ Checkbox.id "objectMappingExpTimestamp"
+                    [ Checkbox.id "objectMappingExplicitTimestamp"
                     , Checkbox.disabled model.interfaceEditMode
                     , Checkbox.checked model.objectExplicitTimestamp
                     , Checkbox.onCheck UpdateObjectMappingExplicitTimestamp
@@ -1374,9 +1374,9 @@ renderCommonMappingSettings model =
                 Col.sm6
             ]
             [ Form.group []
-                [ Form.label [ for "objectDatabaseRetention" ] [ text "Database Retention" ]
+                [ Form.label [ for "objectMappingDatabaseRetention" ] [ text "Database Retention" ]
                 , Select.select
-                    [ Select.id "objectDatabaseRetention"
+                    [ Select.id "objectMappingDatabaseRetention"
                     , Select.disabled model.interfaceEditMode
                     , Select.onChange UpdateObjectMappingDatabaseRetention
                     ]
@@ -1401,9 +1401,9 @@ renderCommonMappingSettings model =
                 Col.sm6
             ]
             [ Form.group []
-                [ Form.label [ for "objectTTL" ] [ text "TTL" ]
+                [ Form.label [ for "objectMappingTTL" ] [ text "TTL" ]
                 , InputGroup.number
-                    [ Input.id "objectTTL"
+                    [ Input.id "objectMappingTTL"
                     , Input.disabled model.interfaceEditMode
                     , Input.value <| String.fromInt model.objectTTL
                     , Input.onInput UpdateObjectMappingTTL

--- a/src/elm/Types/InterfaceMapping.elm
+++ b/src/elm/Types/InterfaceMapping.elm
@@ -36,6 +36,7 @@ module Types.InterfaceMapping exposing
     , mappingTypeToString
     , reliabilityToEnglishString
     , retentionToEnglishString
+    , databaseRetentionToEnglishString
     , setAllowUnset
     , setDatabaseRetention
     , setDescription
@@ -641,3 +642,12 @@ retentionToEnglishString retention =
 
         Stored ->
             "Stored"
+
+databaseRetentionToEnglishString : DatabaseRetention -> String
+databaseRetentionToEnglishString databaseRetention =
+    case databaseRetention of
+        NoTTL ->
+            "No TTL"
+
+        UseTTL ->
+            "Use TTL"


### PR DESCRIPTION
This PR adds more specific Cypress tests to check correct behavior of the Interface Editor in both the New Interface and Edit Interface pages. The tests include:

- correct displaying of interface properties values
- correct rendering of disabled or readonly values
- making sure a proper confirmation modal is shown upon applying changes
- making sure a Interface Source field can be toggled visible and properly parses an interface definition
- interface mappings can be added, edited, deleted, showing a suitable Mapping Editor modal

Some fixes are also included to correct behavior of the Interface Editor:

- changed ID for the endpoint field of the Mapping Editor, so that the corresponding form label has the same ID and clicking the label correctly focuses the field
- fixed InterfaceEditor so that it correctly parses and displays the values of DatabaseRetention and TTL of a Datastream interface
- fixed Mapping Editor modal's behavior for mappings with more options (Datastream Individual case) where the form is too long and overflows the page's height. The modal's content is now scrollable so that all form fields are properly accessible and editable.