### PR TITLE
Show navbar when in standalone Interface Editor mode

### DIFF
--- a/cypress/integration/interface_builder_test.js
+++ b/cypress/integration/interface_builder_test.js
@@ -11,6 +11,12 @@ describe('Interface builder tests', () => {
       cy.visit('/');
       cy.get('h2').contains('Interface Editor');
       cy.get('#interfaceName').should('have.value', '');
+
+      cy.get('.nav-col .nav').within(() => {
+        cy.get('.nav-brand').as('brand').next('.nav-link').as('interfaceEditor');
+        cy.get('@brand').should('have.attr', 'href', '/');
+        cy.get('@interfaceEditor').should('have.attr', 'href', '/').contains('Interface Editor');
+      });
     });
   });
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -741,7 +741,7 @@ view model =
             model.session.apiConfig.realm
 
         showNavbar =
-            Session.isLoggedIn model.session
+            Session.isLoggedIn model.session || model.config == Config.EditorOnly
     in
     { title = "Astarte - Dashboard"
     , body =


### PR DESCRIPTION
This PR makes sure a navbar is shown on the side of the page even when the app is loaded in standalone Interface Editor mode.
A Cypress test is added as well to verify such behavior.
