### PR TITLE
Disable ValueChanged, ValueChangedApplied and PathCreated triggers on datastream interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [0.11.4] - Unreleased
+### Changed
+- Disable ValueChanged, ValueChangedApplied and PathCreated triggers
+  on datastream interfaces
 ### Fixed
 - Device sent bytes pie chart now showing up on Chrome browser.
 

--- a/src/elm/Page/TriggerBuilder.elm
+++ b/src/elm/Page/TriggerBuilder.elm
@@ -1148,11 +1148,37 @@ renderSimpleTrigger model =
            )
 
 
+triggerEventOptions : DataTriggerEvent -> Bool -> List (Select.Item Msg)
+triggerEventOptions currentEvent isPropertyInterface =
+    let
+        availableEvents =
+            if isPropertyInterface then
+                [ ( DataTrigger.IncomingData, "Incoming Data" )
+                , ( DataTrigger.ValueChange, "Value Change" )
+                , ( DataTrigger.ValueChangeApplied, "Value Change Applied" )
+                , ( DataTrigger.PathCreated, "Path Created" )
+                , ( DataTrigger.PathRemoved, "Path Removed" )
+                , ( DataTrigger.ValueStored, "Value Stored" )
+                ]
+
+            else
+                [ ( DataTrigger.IncomingData, "Incoming Data" )
+                , ( DataTrigger.ValueStored, "Value Stored" )
+                ]
+    in
+    List.map (dataTriggerEventOptions currentEvent) availableEvents
+
+
 renderDataTrigger : DataTrigger -> Model -> List (Html Msg)
 renderDataTrigger dataTrigger model =
     let
         isAnyInterface =
             model.selectedInterfaceName == "*"
+
+        isPropertyInterface =
+            model.refInterface
+                |> Maybe.map (\interface -> interface.iType == Interface.Properties)
+                |> Maybe.withDefault False
     in
     [ Form.row []
         [ Form.col
@@ -1215,16 +1241,7 @@ renderDataTrigger dataTrigger model =
                     , Select.disabled model.editMode
                     , Select.onChange UpdateDataTriggerCondition
                     ]
-                    (List.map
-                        (dataTriggerEventOptions dataTrigger.on)
-                        [ ( DataTrigger.IncomingData, "Incoming Data" )
-                        , ( DataTrigger.ValueChange, "Value Change" )
-                        , ( DataTrigger.ValueChangeApplied, "Value Change Applied" )
-                        , ( DataTrigger.PathCreated, "Path Created" )
-                        , ( DataTrigger.PathRemoved, "Path Removed" )
-                        , ( DataTrigger.ValueStored, "Value Stored" )
-                        ]
-                    )
+                    (triggerEventOptions dataTrigger.on isPropertyInterface)
                 ]
             ]
         ]


### PR DESCRIPTION
ValueChange, ValueChangeApplied and PathCreated can be used only with properties interfaces.
See also astarte-platform/astarte#507
and astarte-platform/astarte#425

Signed-off-by: Mattia <mattia.pavinati@ispirata.com>