### PR TITLE
Fix typos in Trigger Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   on datastream interfaces
 ### Fixed
 - Device sent bytes pie chart now showing up on Chrome browser.
+- Fix typos in the Trigger Editor
 
 ## [0.11.3] - 2020-09-24
 ### Added

--- a/src/elm/Page/TriggerBuilder.elm
+++ b/src/elm/Page/TriggerBuilder.elm
@@ -1280,7 +1280,7 @@ renderDataTrigger dataTrigger model =
             [ Form.group []
                 [ Form.label [ for "triggerOperator" ] [ text "Operator" ]
                 , Select.select
-                    [ Select.id "triggerCondition"
+                    [ Select.id "triggerOperator"
                     , Select.disabled model.editMode
                     , Select.onChange UpdateDataTriggerOperator
                     ]
@@ -1502,7 +1502,7 @@ allOperators =
     , ( "greaterThan", ">" )
     , ( "greaterOrEqualTo", ">=" )
     , ( "lessThan", "<" )
-    , ( "lessOrEqualTo", ">=" )
+    , ( "lessOrEqualTo", "<=" )
     , ( "contains", "Contains" )
     , ( "notContains", "Not Contains" )
     ]


### PR DESCRIPTION
Here we fix a couple of typos present in the Trigger Builder component:

- Fix wrong label ">=" for Condition Operator "lessOrEqualTo", so that users are not confused by seeing two ">=" identical options.
- Fix wrong DOM ID "#triggerCondition" for Condition Operator field, so that the field has a unique ID and is more accessible since it now gains focus whenever the user clicks on its label.
