### PR TITLE
Change /resource/:id routes to avoid conflicts with /resource/new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   on datastream interfaces
 - Disable ValueChange and ValueChangeApplied triggers on /* paths
   (workaround to [astarte-platform/astarte#513](https://github.com/astarte-platform/astarte/issues/513)).
+- Change `/resource/:id` routes to `/resource/:id/edit` to avoid conflicts with `/resource/new` routes
 ### Fixed
 - Device sent bytes pie chart now showing up on Chrome browser.
 - Fix typos in the Trigger Editor

--- a/src/elm/Route.elm
+++ b/src/elm/Route.elm
@@ -77,15 +77,15 @@ realmRouteParser =
         , map RealmSettings (s "settings")
         , map ListInterfaces (s "interfaces")
         , map NewInterface (s "interfaces" </> s "new")
-        , map ShowInterface (s "interfaces" </> string </> int)
+        , map ShowInterface (s "interfaces" </> string </> int </> s "edit")
         , map ListTriggers (s "triggers")
         , map NewTrigger (s "triggers" </> s "new")
-        , map ShowTrigger (s "triggers" </> string)
+        , map ShowTrigger (s "triggers" </> string </> s "edit")
         , map DeviceList (s "devices")
-        , map ShowDevice (s "devices" </> string)
+        , map ShowDevice (s "devices" </> string </> s "edit")
         , map ShowDeviceData (s "devices" </> string </> s "interfaces" </> string)
         , map GroupList (s "groups")
-        , map GroupDevices (s "groups" </> string)
+        , map GroupDevices (s "groups" </> string </> s "edit")
         ]
 
 
@@ -142,7 +142,7 @@ toString route =
                     [ "interfaces", "new" ]
 
                 Realm (ShowInterface name major) ->
-                    [ "interfaces", name, String.fromInt major ]
+                    [ "interfaces", name, String.fromInt major, "edit" ]
 
                 Realm ListTriggers ->
                     [ "triggers" ]
@@ -151,13 +151,13 @@ toString route =
                     [ "triggers", "new" ]
 
                 Realm (ShowTrigger name) ->
-                    [ "triggers", name ]
+                    [ "triggers", name, "edit" ]
 
                 Realm DeviceList ->
                     [ "devices" ]
 
                 Realm (ShowDevice deviceId) ->
-                    [ "devices", deviceId ]
+                    [ "devices", deviceId, "edit" ]
 
                 Realm (ShowDeviceData deviceId interfaceName) ->
                     [ "devices", deviceId, "interfaces", interfaceName ]
@@ -166,7 +166,7 @@ toString route =
                     [ "groups" ]
 
                 Realm (GroupDevices groupName) ->
-                    [ "groups", groupName ]
+                    [ "groups", groupName, "edit" ]
     in
     "/" ++ String.join "/" pieces
 

--- a/src/react/GroupDevicesPage.js
+++ b/src/react/GroupDevicesPage.js
@@ -237,7 +237,7 @@ function deviceTableRow(device, index, showModal) {
         </OverlayTrigger>
       </td>
       <td>
-        <Link to={`/devices/${device.id}`}>{device.name}</Link>
+        <Link to={`/devices/${device.id}/edit`}>{device.name}</Link>
       </td>
       <td>{lastEvent}</td>
       <td>

--- a/src/react/GroupsPage.js
+++ b/src/react/GroupsPage.js
@@ -157,7 +157,7 @@ export default class GroupsPage extends React.Component {
             return (
               <tr key={group.name}>
                 <td>
-                  <Link to={`/groups/${group.name}`}>{group.name}</Link>
+                  <Link to={`/groups/${group.name}/edit`}>{group.name}</Link>
                 </td>
                 <td>{group.connectedDevices}</td>
                 <td>{group.totalDevices}</td>

--- a/src/react/Router.js
+++ b/src/react/Router.js
@@ -40,7 +40,7 @@ export function getRouter(reactHistory, fallback) {
         <Route exact path="/groups/new">
           <NewGroupPage history={reactHistory} />
         </Route>
-        <Route path="/groups/:groupName">
+        <Route path="/groups/:groupName/edit">
           <GroupDevicesSubPath history={reactHistory} />
         </Route>
         <Route path="*">


### PR DESCRIPTION
This PR changes `/resource/:id` routes to `/resource/:id/edit` to avoid conflicts with `/resource/new` routes when the resource has id = new.
This change affects routes for:
- interfaces: `/interfaces/:name/:major` -> `/interfaces/:name/:major/edit`
- triggers: `/triggers/:name` -> `/triggers/:name/edit`
- devices: `/devices/:id` -> `/devices/:id/edit`
- groups: `/groups/:name` -> `/groups/:name/edit`
