### PR TITLE
Change Flow routes to avoid possible conflicting routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Pipeline source visual editor.
 - Search filters for devices page.
 
+### Changed
+- Change Flow routes to avoid possible conflicts between routes.
+
 ### Fixed
 - Fix bug which caused marking triggers as invalid on parametric endpoints containing an underscore.
 - Fix interface value page when displaying data from a parametric object datastream interface.

--- a/cypress/integration/block_page_test.js
+++ b/cypress/integration/block_page_test.js
@@ -7,7 +7,7 @@ const blockTypeToLabel = {
 describe('Block page tests', () => {
   context('no access before login', () => {
     it('redirects to home', () => {
-      cy.visit('/blocks/blockname');
+      cy.visit('/blocks/blockname/edit');
       cy.location('pathname').should('eq', '/login');
     });
   });
@@ -27,12 +27,12 @@ describe('Block page tests', () => {
               response: '',
             }).as('deleteBlockRequest');
             cy.login();
-            cy.visit(`/blocks/${customBlock.data.name}`);
+            cy.visit(`/blocks/${customBlock.data.name}/edit`);
           });
       });
 
       it('successfully loads Block page for a custom block', function () {
-        cy.location('pathname').should('eq', `/blocks/${this.customBlock.data.name}`);
+        cy.location('pathname').should('eq', `/blocks/${this.customBlock.data.name}/edit`);
         cy.get('h2').contains('Block Details');
       });
 
@@ -65,14 +65,14 @@ describe('Block page tests', () => {
           .as('nativeBlock')
           .then((nativeBlock) => {
             cy.login();
-            cy.visit(`/blocks/${nativeBlock.data.name}`);
+            cy.visit(`/blocks/${nativeBlock.data.name}/edit`);
             cy.server();
             cy.route('GET', '/flow/v1/*/blocks/*', '@nativeBlock');
           });
       });
 
       it('successfully loads Block page for a native block', function () {
-        cy.location('pathname').should('eq', `/blocks/${this.nativeBlock.data.name}`);
+        cy.location('pathname').should('eq', `/blocks/${this.nativeBlock.data.name}/edit`);
         cy.get('h2').contains('Block Details');
       });
 

--- a/cypress/integration/block_page_test.js
+++ b/cypress/integration/block_page_test.js
@@ -45,6 +45,21 @@ describe('Block page tests', () => {
         });
       });
 
+      it('correctly displays a block with the name "new"', function () {
+        const block = {
+          name: 'new',
+          schema: {},
+          source: 'source',
+          type: 'producer',
+        };
+        cy.server();
+        cy.route('GET', '/flow/v1/*/blocks/new', { data: block });
+        cy.visit('/blocks/new/edit');
+        cy.location('pathname').should('eq', '/blocks/new/edit');
+        cy.get('h2').contains('Block Details');
+        cy.get('.main-content').contains('Name').next().contains('new');
+      });
+
       it('can delete a custom block', function () {
         cy.get('.main-content').within(() => {
           cy.contains('Delete block').click();

--- a/cypress/integration/blocks_page_test.js
+++ b/cypress/integration/blocks_page_test.js
@@ -60,7 +60,7 @@ describe('Blocks page tests', () => {
 
     it('each block has a primary button that redirects to the block page', function () {
       cy.get('.main-content .card button.btn-primary').contains('Show').first().click();
-      cy.location('pathname').should('eq', `/blocks/${this.blocks.data[0].name}`);
+      cy.location('pathname').should('eq', `/blocks/${this.blocks.data[0].name}/edit`);
     });
   });
 });

--- a/cypress/integration/flow_page_test.js
+++ b/cypress/integration/flow_page_test.js
@@ -1,7 +1,7 @@
 describe('Flow page tests', () => {
   context('no access before login', () => {
     it('redirects to login', () => {
-      cy.visit('/flows/test-flow');
+      cy.visit('/flows/test-flow/edit');
       cy.location('pathname').should('eq', '/login');
     });
   });
@@ -14,12 +14,12 @@ describe('Flow page tests', () => {
           cy.server();
           cy.route('GET', `/flow/v1/*/flows/${flow.data.name}`, '@flow').as('getFlow');
           cy.login();
-          cy.visit(`/flows/${flow.data.name}`);
+          cy.visit(`/flows/${flow.data.name}/edit`);
         });
     });
 
     it('successfully loads Flow page', function () {
-      cy.location('pathname').should('eq', `/flows/${this.flow.data.name}`);
+      cy.location('pathname').should('eq', `/flows/${this.flow.data.name}/edit`);
       cy.get('h2').contains('Flow Details');
     });
 

--- a/cypress/integration/flow_page_test.js
+++ b/cypress/integration/flow_page_test.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 describe('Flow page tests', () => {
   context('no access before login', () => {
     it('redirects to login', () => {
@@ -24,6 +26,20 @@ describe('Flow page tests', () => {
     });
 
     it('correctly displays flow details', function () {
+      cy.get('.main-content').within(() => {
+        cy.contains('Flow configuration');
+        cy.get('pre code');
+      });
+    });
+
+    it('correctly displays a flow with name "new"', function () {
+      const flow = _.merge({}, this.flow.data, { name: 'new' });
+      cy.server();
+      cy.route('GET', `/flow/v1/*/flows/${flow.name}`, { data: flow }).as('getFlow');
+      cy.login();
+      cy.visit(`/flows/${flow.name}/edit`);
+      cy.location('pathname').should('eq', `/flows/new/edit`);
+      cy.get('h2').contains('Flow Details');
       cy.get('.main-content').within(() => {
         cy.contains('Flow configuration');
         cy.get('pre code');

--- a/cypress/integration/flows_page_test.js
+++ b/cypress/integration/flows_page_test.js
@@ -56,7 +56,7 @@ describe('Flows page tests', () => {
       cy.wait(['@getFlows', '@getFlow']);
       cy.get('.main-content').within(() => {
         cy.get('table tbody tr:nth-child(1)').contains(this.flow.data.name).click();
-        cy.location('pathname').should('eq', `/flows/${this.flow.data.name}`);
+        cy.location('pathname').should('eq', `/flows/${this.flow.data.name}/edit`);
       });
     });
 

--- a/cypress/integration/new_block_page_test.js
+++ b/cypress/integration/new_block_page_test.js
@@ -38,5 +38,23 @@ describe('New block page tests', () => {
       cy.wait('@postNewBlock').its('requestBody').should('deep.eq', this.customBlock);
       cy.location('pathname').should('eq', '/blocks');
     });
+
+    it('can create a Block with name "new"', function () {
+      const newBlock = {
+        name: 'new',
+        schema: {},
+        source: 'source',
+        type: 'producer',
+      };
+      cy.get('.main-content').within(() => {
+        cy.get('input#block-name').clear().type(newBlock.name);
+        cy.get('select#block-type').select(newBlock.type);
+        cy.get('textarea#block-source').clear().type(newBlock.source);
+        cy.get('textarea#block-schema').clear().type(JSON.stringify(newBlock.schema));
+        cy.contains('Create new block').scrollIntoView().click();
+      });
+      cy.wait('@postNewBlock').its('requestBody.data').should('deep.eq', newBlock);
+      cy.location('pathname').should('eq', '/blocks');
+    });
   });
 });

--- a/cypress/integration/new_flow_page_test.js
+++ b/cypress/integration/new_flow_page_test.js
@@ -1,7 +1,7 @@
 describe('New Flow page tests', () => {
   context('no access before login', () => {
     it('redirects to login', () => {
-      cy.visit('/flows/new/test-pipeline');
+      cy.visit('/flows/new?pipelineId=test-pipeline');
       cy.location('pathname').should('eq', '/login');
     });
   });
@@ -26,12 +26,13 @@ describe('New Flow page tests', () => {
             response: '@flow',
           }).as('postNewFlow');
           cy.login();
-          cy.visit(`/flows/new/${pipeline.data.name}`);
+          cy.visit(`/flows/new?pipelineId=${pipeline.data.name}`);
         });
     });
 
     it('successfully loads New Flow page', function () {
-      cy.location('pathname').should('eq', `/flows/new/${this.pipeline.data.name}`);
+      cy.location('pathname').should('eq', '/flows/new');
+      cy.location('search').should('eq', `?pipelineId=${this.pipeline.data.name}`);
       cy.get('h2').contains('Flow Configuration');
     });
 

--- a/cypress/integration/new_flow_page_test.js
+++ b/cypress/integration/new_flow_page_test.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 describe('New Flow page tests', () => {
   context('no access before login', () => {
     it('redirects to login', () => {
@@ -49,6 +51,26 @@ describe('New Flow page tests', () => {
           .type(JSON.stringify(this.flow.data.config), { parseSpecialCharSequences: false });
         cy.get('button').contains('Instantiate Flow').click();
         cy.wait('@postNewFlow').its('requestBody').should('deep.eq', this.flow);
+        cy.location('pathname').should('eq', '/flows');
+      });
+    });
+
+    it('can instantiate a Flow with the name "new"', function () {
+      const newFlow = _.merge({}, this.flow.data, { name: 'new' });
+      cy.server();
+      cy.route({
+        method: 'POST',
+        url: '/flow/v1/*/flows',
+        status: 201,
+        response: { data: newFlow },
+      }).as('postNewFlow');
+      cy.get('.main-content').within(() => {
+        cy.get('#flowNameInput').clear().type(newFlow.name);
+        cy.get('#flowConfigInput')
+          .clear()
+          .type(JSON.stringify(newFlow.config), { parseSpecialCharSequences: false });
+        cy.get('button').contains('Instantiate Flow').click();
+        cy.wait('@postNewFlow').its('requestBody.data').should('deep.eq', newFlow);
         cy.location('pathname').should('eq', '/flows');
       });
     });

--- a/cypress/integration/new_pipeline_page_test.js
+++ b/cypress/integration/new_pipeline_page_test.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 describe('New Pipeline page tests', () => {
   context('no access before login', () => {
     it('redirects to login', () => {
@@ -150,6 +152,42 @@ describe('New Pipeline page tests', () => {
               name: this.pipeline.data.name,
               description: this.pipeline.data.description,
               source: this.pipeline.data.source,
+            },
+          });
+        cy.location('pathname').should('eq', '/pipelines');
+      });
+    });
+
+    it('can create a pipeline with the name "new"', function () {
+      const pipeline = _.merge({}, this.pipeline.data, { name: 'new' });
+      cy.get('.main-content').within(() => {
+        const producerBlockName = this.producerBlocks[0].name;
+        const consumerBlockName = this.consumerBlocks[0].name;
+        cy.get('.flow-editor .block-item')
+          .contains(producerBlockName)
+          .dragOnto('.flow-editor .canvas-container');
+        cy.get('.canvas-container .node .producer').parents('.node').moveTo(-50, -50);
+        cy.get('.flow-editor .block-item')
+          .contains(consumerBlockName)
+          .dragOnto('.flow-editor .canvas-container');
+        cy.get('.canvas-container .node .consumer').parents('.node').moveTo(50, 50);
+        cy.get('.canvas-container .node .producer .port[data-name="Out"] > div').moveOnto(
+          '.canvas-container .node .consumer .port[data-name="In"] > div',
+        );
+        cy.get('button').contains('Generate pipeline source').scrollIntoView().click();
+
+        cy.get('#pipeline-name').scrollIntoView().type(pipeline.name);
+        cy.get('#pipeline-schema').clear();
+        cy.get('#pipeline-description').type(pipeline.description);
+        cy.get('#pipeline-source').type(`{selectall}${pipeline.source}`);
+        cy.get('button').contains('Create new pipeline').scrollIntoView().click();
+        cy.wait('@postNewPipeline')
+          .its('requestBody')
+          .should('deep.eq', {
+            data: {
+              name: pipeline.name,
+              description: pipeline.description,
+              source: pipeline.source,
             },
           });
         cy.location('pathname').should('eq', '/pipelines');

--- a/cypress/integration/pipeline_page_test.js
+++ b/cypress/integration/pipeline_page_test.js
@@ -1,7 +1,7 @@
 describe('Pipeline page tests', () => {
   context('no access before login', () => {
     it('redirects to login', () => {
-      cy.visit('/pipelines/pipeline_name');
+      cy.visit('/pipelines/pipeline_name/edit');
       cy.location('pathname').should('eq', '/login');
     });
   });
@@ -22,13 +22,13 @@ describe('Pipeline page tests', () => {
             response: '',
           }).as('deletePipelineRequest');
           cy.login();
-          cy.visit(`/pipelines/${pipeline.data.name}`);
+          cy.visit(`/pipelines/${pipeline.data.name}/edit`);
           cy.wait('@getPipeline');
         });
     });
 
     it('successfully loads Pipeline page', function () {
-      cy.location('pathname').should('eq', `/pipelines/${this.pipeline.data.name}`);
+      cy.location('pathname').should('eq', `/pipelines/${this.pipeline.data.name}/edit`);
       cy.get('h2').contains('Pipeline Details');
     });
 

--- a/cypress/integration/pipeline_page_test.js
+++ b/cypress/integration/pipeline_page_test.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 describe('Pipeline page tests', () => {
   context('no access before login', () => {
     it('redirects to login', () => {
@@ -40,6 +42,16 @@ describe('Pipeline page tests', () => {
         }
         cy.contains('Source');
       });
+    });
+
+    it('correctly displays a pipeline with the name "new"', function () {
+      const pipeline = _.merge({}, this.pipeline.data, { name: 'new' });
+      cy.server();
+      cy.route('GET', `/flow/v1/*/pipelines/${pipeline.name}`, { data: pipeline });
+      cy.visit(`/pipelines/${pipeline.name}/edit`);
+      cy.location('pathname').should('eq', `/pipelines/new/edit`);
+      cy.get('h2').contains('Pipeline Details');
+      cy.get('.main-content').contains('Name').next().contains(pipeline.name);
     });
 
     it('can delete the pipeline', function () {

--- a/cypress/integration/pipelines_page_test.js
+++ b/cypress/integration/pipelines_page_test.js
@@ -68,7 +68,7 @@ describe('Pipelines page tests', () => {
       cy.get('.main-content').within(() => {
         const pipelineName = this.pipelines.data[0];
         cy.get('.card .card-header').contains(pipelineName).click();
-        cy.location('pathname').should('eq', `/pipelines/${pipelineName}`);
+        cy.location('pathname').should('eq', `/pipelines/${pipelineName}/edit`);
       });
     });
 
@@ -81,7 +81,8 @@ describe('Pipelines page tests', () => {
           .get('button')
           .contains('Instantiate')
           .click();
-        cy.location('pathname').should('eq', `/flows/new/${pipelineName}`);
+        cy.location('pathname').should('eq', '/flows/new');
+        cy.location('search').should('eq', `?pipelineId=${pipelineName}`);
       });
     });
   });

--- a/src/elm/Route.elm
+++ b/src/elm/Route.elm
@@ -58,7 +58,7 @@ type RealmRoute
     | NewGroup
     | GroupDevices String
     | FlowInstances
-    | FlowConfigure String
+    | FlowConfigure (Maybe String)
     | FlowDetails String
     | PipelineList
     | PipelineShowSource String
@@ -98,14 +98,14 @@ realmRouteParser =
         , map NewGroup (s "groups" </> s "new")
         , map GroupDevices (s "groups" </> string </> s "edit")
         , map FlowInstances (s "flows")
-        , map FlowConfigure (s "flows" </> s "new" </> string)
-        , map FlowDetails (s "flows" </> string)
+        , map FlowConfigure (s "flows" </> s "new" <?> Query.string "pipelineId")
+        , map FlowDetails (s "flows" </> string </> s "edit")
         , map PipelineList (s "pipelines")
         , map NewPipeline (s "pipelines" </> s "new")
-        , map PipelineShowSource (s "pipelines" </> string)
+        , map PipelineShowSource (s "pipelines" </> string </> s "edit")
         , map BlockList (s "blocks")
         , map NewBlock (s "blocks" </> s "new")
-        , map BlockShowSource (s "blocks" </> string)
+        , map BlockShowSource (s "blocks" </> string </> s "edit")
         , map GroupDevices (s "groups" </> string </> s "edit")
         ]
 
@@ -207,11 +207,16 @@ toString route =
                 Realm FlowInstances ->
                     [ "flows" ]
 
-                Realm (FlowConfigure pipelineId) ->
-                    [ "flows", "new", pipelineId ]
+                Realm (FlowConfigure p) ->
+                    case p of
+                        Just pipelineId ->
+                            [ "flows", "new?pipelineId=" ++ pipelineId ]
+
+                        Nothing ->
+                            [ "flows", "new" ]
 
                 Realm (FlowDetails flowName) ->
-                    [ "flows", flowName ]
+                    [ "flows", flowName, "edit" ]
 
                 Realm PipelineList ->
                     [ "pipelines" ]
@@ -220,7 +225,7 @@ toString route =
                     [ "pipelines", "new" ]
 
                 Realm (PipelineShowSource pipelineName) ->
-                    [ "pipelines", pipelineName ]
+                    [ "pipelines", pipelineName, "edit" ]
 
                 Realm BlockList ->
                     [ "blocks" ]
@@ -229,7 +234,7 @@ toString route =
                     [ "blocks", "new" ]
 
                 Realm (BlockShowSource blockName) ->
-                    [ "blocks", blockName ]
+                    [ "blocks", blockName, "edit" ]
     in
     "/" ++ String.join "/" pieces
 

--- a/src/react/BlocksPage.tsx
+++ b/src/react/BlocksPage.tsx
@@ -51,7 +51,7 @@ export default ({ astarte }: Props): React.ReactElement => {
           {blocks.map((block, index) => (
             <React.Fragment key={`fragment-${index}`}>
               {index % 2 ? <div className="w-100 d-none d-md-block" /> : null}
-              <BlockCard block={block} onShow={() => navigate(`/blocks/${block.name}`)} />
+              <BlockCard block={block} onShow={() => navigate(`/blocks/${block.name}/edit`)} />
               {index === blocks.length - 1 && blocks.length % 2 === 0 ? (
                 <div className="w-50 d-none d-md-block" />
               ) : null}

--- a/src/react/FlowInstancesPage.tsx
+++ b/src/react/FlowInstancesPage.tsx
@@ -49,7 +49,7 @@ const TableRow = ({ instance, onDelete }: TableRowProps): React.ReactElement => 
       </OverlayTrigger>
     </td>
     <td>
-      <Link to={`/flows/${instance.name}`}>{instance.name}</Link>
+      <Link to={`/flows/${instance.name}/edit`}>{instance.name}</Link>
     </td>
     <td>{instance.pipeline}</td>
     <td>

--- a/src/react/NewBlockPage.tsx
+++ b/src/react/NewBlockPage.tsx
@@ -71,7 +71,7 @@ export default ({ astarte }: Props): React.ReactElement => {
       });
   }, [block, creationAlerts.showError, navigate]);
 
-  const isValidBlockName = /^[a-zA-Z][a-zA-Z0-9-_]*$/.test(block.name) && block.name !== 'new';
+  const isValidBlockName = /^[a-zA-Z][a-zA-Z0-9-_]*$/.test(block.name);
   const isValidBlockSource = block.source !== '';
   const isValidBlockType = ['producer', 'consumer', 'producer_consumer'].includes(block.type);
   const isValidBlockSchema = isJSON(block.schema.trim());

--- a/src/react/NewPipelinePage.tsx
+++ b/src/react/NewPipelinePage.tsx
@@ -169,7 +169,7 @@ export default ({ astarte }: Props): React.ReactElement => {
     }
   };
 
-  const isValidPipelineName = pipeline.name !== '' && pipeline.name !== 'new';
+  const isValidPipelineName = pipeline.name !== '';
   const isValidSource = pipeline.source !== '';
   const isValidForm = isValidPipelineName && isValidSource;
 

--- a/src/react/PipelinesPage.tsx
+++ b/src/react/PipelinesPage.tsx
@@ -91,9 +91,9 @@ export default ({ astarte }: Props): React.ReactElement => {
                 <PipelineCard
                   pipeline={pipeline}
                   onInstantiate={() => {
-                    navigate(`/flows/new/${pipeline.name}`);
+                    navigate(`/flows/new?pipelineId=${pipeline.name}`);
                   }}
-                  showLink={`/pipelines/${pipeline.name}`}
+                  showLink={`/pipelines/${pipeline.name}/edit`}
                 />
                 {index === pipelines.length - 1 && pipelines.length % 2 === 0 ? (
                   <div className="w-50 d-none d-md-block" />

--- a/src/react/Router.jsx
+++ b/src/react/Router.jsx
@@ -17,7 +17,15 @@
 */
 
 import React, { useReducer, useLayoutEffect } from 'react';
-import { Navigate, Router, Routes, Route, useParams, useLocation } from 'react-router-dom';
+import {
+  Navigate,
+  Router,
+  Routes,
+  Route,
+  useParams,
+  useLocation,
+  useSearchParams,
+} from 'react-router-dom';
 
 import LoginPage from './LoginPage';
 import HomePage from './HomePage';
@@ -81,14 +89,14 @@ export default ({ reactHistory: history, astarteClient, sessionManager, config, 
         <Route path="groups/new" element={<NewGroupPage {...pageProps} />} />
         <Route path="groups/:groupName/edit" element={<GroupDevicesSubPath {...pageProps} />} />
         <Route path="flows" element={<FlowInstancesPage {...pageProps} />} />
-        <Route path="flows/new/:pipelineId" element={<FlowConfiguration {...pageProps} />} />
-        <Route path="flows/:flowName" element={<FlowDetails {...pageProps} />} />
+        <Route path="flows/new" element={<FlowConfiguration {...pageProps} />} />
+        <Route path="flows/:flowName/edit" element={<FlowDetails {...pageProps} />} />
         <Route path="pipelines" element={<PipelinesPage {...pageProps} />} />
         <Route path="pipelines/new" element={<NewPipelinePage {...pageProps} />} />
-        <Route path="pipelines/:pipelineId" element={<PipelineSubPath {...pageProps} />} />
+        <Route path="pipelines/:pipelineId/edit" element={<PipelineSubPath {...pageProps} />} />
         <Route path="blocks" element={<BlocksPage {...pageProps} />} />
         <Route path="blocks/new" element={<NewBlockPage {...pageProps} />} />
-        <Route path="blocks/:blockId" element={<BlockSubPath {...pageProps} />} />
+        <Route path="blocks/:blockId/edit" element={<BlockSubPath {...pageProps} />} />
         <Route path="settings" element={<RealmSettingsPage {...pageProps} />} />
         <Route path="*" element={<NoMatch fallback={fallback} />} />
       </Routes>
@@ -147,7 +155,8 @@ function FlowDetails(props) {
 }
 
 function FlowConfiguration(props) {
-  const { pipelineId } = useParams();
+  const [searchParams] = useSearchParams();
+  const pipelineId = searchParams.get('pipelineId') || '';
 
   return <FlowConfigurationPage pipelineId={pipelineId} {...props} />;
 }


### PR DESCRIPTION
This PR changes Flow routes to avoid possible conflicts such as the route to create a pipeline `/pipelines/new` conflicting with the route to show a pipeline `/pipelines/<pipelineId>` when pipelineId = new.
This change affects routes for:
- blocks: `/blocks/<blockId>` -> `/blocks/<blockId>/edit`
- pipelines: `/pipelines/<pipelineId>` -> `/pipelines/<pipelineId>/edit`
- flows:
  - `/flows/<flowName>` -> `/flows/<flowName>/edit`
  - `/flows/new/<pipelineId>` -> `/flows/new?pipelineId=<pipelineId>`