### PR TITLE
Limit triggers type for object interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.5] - Unreleased
+### Changed
+- Enforce IncomingData triggers with /* paths and * match operator on datastream object interfaces
+  (workaround to [astarte-platform/astarte#523](https://github.com/astarte-platform/astarte/issues/523)).
+
 ## [0.11.4] - 2021-01-26
 ### Changed
 - Disable ValueChanged, ValueChangedApplied and PathCreated triggers

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "astarte-dashboard",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astarte-dashboard",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Astarte dashboard",
   "main": "public/index.html",
   "keywords": [


### PR DESCRIPTION
This PR tweaks the Trigger Editor to enforce IncomingData triggers with `/*` paths and `*` match operator on
datastream object interfaces.
This is a workaround for the issue [astarte-platform/astarte#523](https://github.com/astarte-platform/astarte/issues/523)