### PR TITLE
Support target device or group in data triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Initial device introspection during device registration.
 - Pipeline source visual editor.
 - Search filters for devices page.
+- Support target device or group in data triggers.
 
 ### Fixed
 - Fix bug which caused marking triggers as invalid on parametric endpoints containing an underscore.


### PR DESCRIPTION
This PR adds options in the TriggerEditor to be able to specify a target device or target group even for data triggers.
This feature corresponds to setting a specific `device_id` or `group_name` in a Trigger's JSON form when its `type` equals `data_trigger`. For more details, see [the documentation](https://docs.astarte-platform.org/1.0/060-triggers.html#data-triggers).