### PR TITLE
Fix virtual_device_pool's JSON Schema

### DIFF
--- a/src/astarte-client/definitions/blocks/virtual_device_pool.json
+++ b/src/astarte-client/definitions/blocks/virtual_device_pool.json
@@ -190,7 +190,7 @@
         "type": "array"
       }
     },
-    "required": ["pairing_url", "devices"],
+    "required": ["pairing_url", "target_devices"],
     "title": "Virtual Device Pool options",
     "type": "object"
   },


### PR DESCRIPTION
This PR fixes the JSON Schema for the block `virtual_device_pool` which listed non existent required properties.