### PR TITLE
Fix validation of database_retention_ttl in blocks schema

### DIFF
--- a/src/astarte-client/definitions/blocks/dynamic_virtual_device_pool.json
+++ b/src/astarte-client/definitions/blocks/dynamic_virtual_device_pool.json
@@ -117,6 +117,7 @@
           "expiry": {
             "type": "integer",
             "default": 0,
+            "minimum": 0,
             "description": "Useful when retention is stored. Defines after how many seconds a specific data entry should be kept before giving up and erasing it from the persistent cache. A value <= 0 means the persistent cache never expires, and is the default."
           },
           "database_retention_policy": {
@@ -127,7 +128,8 @@
           },
           "database_retention_ttl": {
             "type": "integer",
-            "default": 0,
+            "minimum": 60,
+            "maximum": 630719999,
             "description": "Useful when database_retention_policy is use_ttl. Defines how many seconds a specific data entry should be kept before erasing it from the database."
           },
           "allow_unset": {

--- a/src/astarte-client/definitions/blocks/virtual_device_pool.json
+++ b/src/astarte-client/definitions/blocks/virtual_device_pool.json
@@ -117,6 +117,7 @@
           "expiry": {
             "type": "integer",
             "default": 0,
+            "minimum": 0,
             "description": "Useful when retention is stored. Defines after how many seconds a specific data entry should be kept before giving up and erasing it from the persistent cache. A value <= 0 means the persistent cache never expires, and is the default."
           },
           "database_retention_policy": {
@@ -127,7 +128,8 @@
           },
           "database_retention_ttl": {
             "type": "integer",
-            "default": 0,
+            "minimum": 60,
+            "maximum": 630719999,
             "description": "Useful when database_retention_policy is use_ttl. Defines how many seconds a specific data entry should be kept before erasing it from the database."
           },
           "allow_unset": {


### PR DESCRIPTION
This PR fixes JSON Schema of blocks with proper values for `database_retention_ttl`, avoiding the property to default to 0 which is invalid.
