### PR TITLE
Fix broken links for triggers and interfaces

### DIFF
--- a/cypress/integration/interfaces_page_test.js
+++ b/cypress/integration/interfaces_page_test.js
@@ -22,12 +22,36 @@ describe('Interfaces page tests', () => {
       cy.get('h2').contains('Interfaces');
     });
 
-    it('displays links to available interfaces', function () {
+    it('correctly displays available interfaces', function () {
+      const interfaceMajors = this.interface_majors.data;
       this.interfaces.data.sort().forEach((interfaceName, index) => {
-        cy.get(`.list-group > .list-group-item:nth-child(${index + 2}) .col > a`)
-          .should('have.attr', 'href')
-          .and('contains', interfaceName);
+        const majorMax = Math.max(...interfaceMajors);
+        cy.get('.list-group-item a').contains(interfaceName);
+        cy.get(`.list-group > .list-group-item:nth-child(${index + 2})`).within(() => {
+          cy.contains(interfaceName).should(
+            'have.attr',
+            'href',
+            `/interfaces/${interfaceName}/${majorMax}/edit`,
+          );
+          interfaceMajors.forEach((major) => {
+            cy.get('a')
+              .should('have.attr', 'href', `/interfaces/${interfaceName}/${major}/edit`)
+              .get('.badge')
+              .contains(`v${major}`);
+          });
+        });
       });
+    });
+
+    it('correctly redirects to interface page when clicking on its name', function () {
+      const interfaceMajors = this.interface_majors.data;
+      const sampleInterfaceName = this.interfaces.data[0];
+      const sampleInterfaceMajor = Math.max(...interfaceMajors);
+      cy.get('.list-group-item a').contains(sampleInterfaceName).click();
+      cy.location('pathname').should(
+        'eq',
+        `/interfaces/${sampleInterfaceName}/${sampleInterfaceMajor}/edit`,
+      );
     });
   });
 });

--- a/cypress/integration/triggers_page_test.js
+++ b/cypress/integration/triggers_page_test.js
@@ -7,15 +7,11 @@ describe('Triggers page tests', () => {
   });
 
   context('authenticated', () => {
-    before(() => {
+    beforeEach(() => {
       cy.login();
       cy.fixture('triggers').as('triggers');
-
       cy.server();
       cy.route('GET', '/realmmanagement/v1/*/triggers', '@triggers');
-    });
-
-    beforeEach(() => {
       cy.visit('/triggers');
     });
 
@@ -23,10 +19,19 @@ describe('Triggers page tests', () => {
       cy.location('pathname').should('eq', '/triggers');
 
       cy.get('h2').contains('Triggers');
+      cy.get('.list-group > .list-group-item:nth-child(2) .btn').contains(
+        'test.astarte.FirstTrigger',
+      );
+      cy.get('.list-group > .list-group-item:nth-child(3) .btn').contains(
+        'test.astarte.SecondTrigger',
+      );
+    });
+
+    it('correctly redirects to trigger page when clicking on its name', function () {
       cy.get('.list-group > .list-group-item:nth-child(2) .btn')
-        .contains('test.astarte.FirstTrigger');
-      cy.get('.list-group > .list-group-item:nth-child(3) .btn')
-        .contains('test.astarte.SecondTrigger');
+        .contains('test.astarte.FirstTrigger')
+        .click();
+      cy.location('pathname').should('eq', `/triggers/test.astarte.FirstTrigger/edit`);
     });
   });
 });

--- a/src/react/InterfacesPage.tsx
+++ b/src/react/InterfacesPage.tsx
@@ -28,14 +28,14 @@ const InterfaceRow = ({ name, majors }: InterfaceRowProps): React.ReactElement =
     <Container className="p-0" fluid>
       <Row>
         <Col>
-          <Link to={`/interfaces/${name}/${Math.max(...majors)}`}>
+          <Link to={`/interfaces/${name}/${Math.max(...majors)}/edit`}>
             <i className="fas fa-stream mr-2" />
             {name}
           </Link>
         </Col>
         <Col md="auto">
           {majors.map((major) => (
-            <Link key={major} to={`/interfaces/${name}/${major}`}>
+            <Link key={major} to={`/interfaces/${name}/${major}/edit`}>
               <Badge variant={major > 0 ? 'primary' : 'secondary'} className="mr-1 px-2 py-1">
                 v{major}
               </Badge>

--- a/src/react/TriggersPage.tsx
+++ b/src/react/TriggersPage.tsx
@@ -84,7 +84,7 @@ export default ({ astarte }: Props): React.ReactElement => {
                   key={trigger}
                   name={trigger}
                   onClick={() => {
-                    navigate(`/triggers/${trigger}`);
+                    navigate(`/triggers/${trigger}/edit`);
                   }}
                 />
               ))


### PR DESCRIPTION
This PR fixes some broken links to interfaces and triggers that redirected to non existent paths.
A couple of Cypress tests are added as well to validate the correct behavior when displaying and following these links.