### PR TITLE
Add support for filter params when fetching devices data

### DIFF
--- a/cypress/fixtures/test_aggregated_object_interface_linearized_values.json
+++ b/cypress/fixtures/test_aggregated_object_interface_linearized_values.json
@@ -1,0 +1,338 @@
+[
+  {
+    "endpoint": "/sensors/sensor-1/value/binaryblob",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": "",
+    "type": "binaryblob"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/boolean",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": null,
+    "type": "boolean"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/datetime",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": null,
+    "type": "datetime"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/double",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": 0,
+    "type": "double"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/integer",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": 0,
+    "type": "integer"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/longinteger",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": null,
+    "type": "longinteger"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/string",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": "",
+    "type": "string"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/binaryblobarray",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": [],
+    "type": "binaryblobarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/booleanarray",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": [],
+    "type": "booleanarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/datetimearray",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": [],
+    "type": "datetimearray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/doublearray",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": [],
+    "type": "doublearray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/integerarray",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": [1, 2],
+    "type": "integerarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/longintegerarray",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": [],
+    "type": "longintegerarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/stringarray",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": [],
+    "type": "stringarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/binaryblob",
+    "timestamp": "2020-09-28T13:38:33+0000",
+    "value": "binaryblob1",
+    "type": "binaryblob"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/boolean",
+    "timestamp": "2020-09-28T13:38:33+0000",
+    "value": false,
+    "type": "boolean"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/datetime",
+    "timestamp": "2020-09-28T13:38:33+0000",
+    "value": "2020-01-01T12:13:14+0000",
+    "type": "datetime"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/double",
+    "timestamp": "2020-09-28T13:38:33+0000",
+    "value": 1.2,
+    "type": "double"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/integer",
+    "timestamp": "2020-09-28T13:38:33+0000",
+    "value": 1,
+    "type": "integer"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/longinteger",
+    "timestamp": "2020-09-28T13:38:33+0000",
+    "value": "987654321",
+    "type": "longinteger"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/string",
+    "timestamp": "2020-09-28T13:38:33+0000",
+    "value": "string",
+    "type": "string"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/binaryblobarray",
+    "timestamp": "2020-09-28T13:38:33+0000",
+    "value": ["binaryblobarray1", "binaryblobarray2"],
+    "type": "binaryblobarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/booleanarray",
+    "timestamp": "2020-09-28T13:38:33+0000",
+    "value": [false, true],
+    "type": "booleanarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/datetimearray",
+    "timestamp": "2020-09-28T13:38:33+0000",
+    "value": ["2020-01-01T12:13:14+0000", "2020-01-01T12:13:14+0000"],
+    "type": "datetimearray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/doublearray",
+    "timestamp": "2020-09-28T13:38:33+0000",
+    "value": [1.1, 2.2],
+    "type": "doublearray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/integerarray",
+    "timestamp": "2020-09-28T13:38:33+0000",
+    "value": [1, 2],
+    "type": "integerarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/longintegerarray",
+    "timestamp": "2020-09-28T13:38:33+0000",
+    "value": ["1234", "5678"],
+    "type": "longintegerarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/stringarray",
+    "timestamp": "2020-09-28T13:38:33+0000",
+    "value": ["stringarray1", "stringarray2"],
+    "type": "stringarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/binaryblob",
+    "timestamp": "2020-09-28T13:38:34+0000",
+    "value": "binaryblob2",
+    "type": "binaryblob"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/boolean",
+    "timestamp": "2020-09-28T13:38:34+0000",
+    "value": true,
+    "type": "boolean"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/datetime",
+    "timestamp": "2020-09-28T13:38:34+0000",
+    "value": "2020-01-01T12:13:15+0000",
+    "type": "datetime"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/double",
+    "timestamp": "2020-09-28T13:38:34+0000",
+    "value": 1.3,
+    "type": "double"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/integer",
+    "timestamp": "2020-09-28T13:38:34+0000",
+    "value": 2,
+    "type": "integer"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/longinteger",
+    "timestamp": "2020-09-28T13:38:34+0000",
+    "value": "98765",
+    "type": "longinteger"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/string",
+    "timestamp": "2020-09-28T13:38:34+0000",
+    "value": "string2",
+    "type": "string"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/binaryblobarray",
+    "timestamp": "2020-09-28T13:38:34+0000",
+    "value": ["binaryblobarray3", "binaryblobarray4"],
+    "type": "binaryblobarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/booleanarray",
+    "timestamp": "2020-09-28T13:38:34+0000",
+    "value": [true, true, false, false],
+    "type": "booleanarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/datetimearray",
+    "timestamp": "2020-09-28T13:38:34+0000",
+    "value": ["2020-01-01T12:13:15+0000"],
+    "type": "datetimearray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/doublearray",
+    "timestamp": "2020-09-28T13:38:34+0000",
+    "value": [3.3, 4.4],
+    "type": "doublearray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/integerarray",
+    "timestamp": "2020-09-28T13:38:34+0000",
+    "value": [3, 4],
+    "type": "integerarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/longintegerarray",
+    "timestamp": "2020-09-28T13:38:34+0000",
+    "value": ["4321", "8765"],
+    "type": "longintegerarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-1/value/stringarray",
+    "timestamp": "2020-09-28T13:38:34+0000",
+    "value": ["stringarray3", "stringarray4"],
+    "type": "stringarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-2/value/binaryblob",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": "binaryblob1",
+    "type": "binaryblob"
+  },
+  {
+    "endpoint": "/sensors/sensor-2/value/boolean",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": false,
+    "type": "boolean"
+  },
+  {
+    "endpoint": "/sensors/sensor-2/value/datetime",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": "2020-01-01T12:13:14+0000",
+    "type": "datetime"
+  },
+  {
+    "endpoint": "/sensors/sensor-2/value/double",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": 1.2,
+    "type": "double"
+  },
+  {
+    "endpoint": "/sensors/sensor-2/value/integer",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": 1,
+    "type": "integer"
+  },
+  {
+    "endpoint": "/sensors/sensor-2/value/longinteger",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": "987654321",
+    "type": "longinteger"
+  },
+  {
+    "endpoint": "/sensors/sensor-2/value/string",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": "string",
+    "type": "string"
+  },
+  {
+    "endpoint": "/sensors/sensor-2/value/binaryblobarray",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": ["binaryblobarray1", "binaryblobarray2"],
+    "type": "binaryblobarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-2/value/booleanarray",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": [false, true],
+    "type": "booleanarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-2/value/datetimearray",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": ["2020-01-01T12:13:14+0000", "2020-01-01T12:13:14+0000"],
+    "type": "datetimearray"
+  },
+  {
+    "endpoint": "/sensors/sensor-2/value/doublearray",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": [1.1, 2.2],
+    "type": "doublearray"
+  },
+  {
+    "endpoint": "/sensors/sensor-2/value/integerarray",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": [1, 2],
+    "type": "integerarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-2/value/longintegerarray",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": ["1234", "5678"],
+    "type": "longintegerarray"
+  },
+  {
+    "endpoint": "/sensors/sensor-2/value/stringarray",
+    "timestamp": "2020-09-28T13:38:32+0000",
+    "value": ["stringarray1", "stringarray2"],
+    "type": "stringarray"
+  }
+]

--- a/cypress/fixtures/test_individual_object_interface_linearized_values.json
+++ b/cypress/fixtures/test_individual_object_interface_linearized_values.json
@@ -1,0 +1,32 @@
+[
+  {
+    "endpoint": "/humidity/value/current",
+    "timestamp": "2020-10-14T12:26:36.492Z",
+    "type": "double",
+    "value": 70
+  },
+  {
+    "endpoint": "/sensors/light/estimated",
+    "timestamp": "2020-10-14T12:27:13.200Z",
+    "type": "double",
+    "value": 82
+  },
+  {
+    "endpoint": "/sensors/proximity/estimated",
+    "timestamp": "2020-10-14T12:26:54.305Z",
+    "type": "double",
+    "value": -11
+  },
+  {
+    "endpoint": "/temperature",
+    "timestamp": "2020-10-14T12:26:29.797Z",
+    "type": "double",
+    "value": 23
+  },
+  {
+    "endpoint": "/weekend/time",
+    "timestamp": "2020-10-14T12:27:31.017Z",
+    "type": "boolean",
+    "value": true
+  }
+]

--- a/cypress/fixtures/test_individual_object_interface_path_values.json
+++ b/cypress/fixtures/test_individual_object_interface_path_values.json
@@ -1,0 +1,14 @@
+{
+  "data": [
+    {
+      "reception_timestamp": "2020-10-14T12:27:02.331Z",
+      "timestamp": "2020-10-14T12:27:02.331Z",
+      "value": 81.0
+    },
+    {
+      "reception_timestamp": "2020-10-14T12:27:13.200Z",
+      "timestamp": "2020-10-14T12:27:13.200Z",
+      "value": 82.0
+    }
+  ]
+}

--- a/cypress/fixtures/test_properties_interface_linearized_values.json
+++ b/cypress/fixtures/test_properties_interface_linearized_values.json
@@ -1,0 +1,7 @@
+[
+  { "endpoint": "/bathroom/heating/active", "value": false, "type": "boolean" },
+  { "endpoint": "/bedroom/heating/active", "value": true, "type": "boolean" },
+  { "endpoint": "/kitchen/heating/active", "value": true, "type": "boolean" },
+  { "endpoint": "/lights/bath", "value": [false, false], "type": "booleanarray" },
+  { "endpoint": "/lights/kitchen", "value": false, "type": "boolean" }
+]

--- a/cypress/integration/astarte_client.js
+++ b/cypress/integration/astarte_client.js
@@ -1,0 +1,274 @@
+import AstarteClient from '../../src/astarte-client/index.ts';
+
+const interfaceList = [
+  {
+    interfaceName: 'test.astarte.AggregatedObjectInterface',
+    interfaceValuesFixture: 'test_aggregated_object_interface_values',
+    interfaceLinearizedValuesFixture: 'test_aggregated_object_interface_linearized_values',
+  },
+  {
+    interfaceName: 'test.astarte.IndividualObjectInterface',
+    interfaceValuesFixture: 'test_individual_object_interface_values',
+    interfaceLinearizedValuesFixture: 'test_individual_object_interface_linearized_values',
+  },
+  {
+    interfaceName: 'test.astarte.PropertiesInterface',
+    interfaceValuesFixture: 'test_properties_interface_values',
+    interfaceLinearizedValuesFixture: 'test_properties_interface_linearized_values',
+  },
+];
+
+describe('Astarte-client tests', () => {
+  beforeEach(() => {
+    cy.fixture('config/http').then((config) => {
+      cy.fixture('realm').then((realm) => {
+        cy.wrap(
+          new AstarteClient({
+            appEngineApiUrl: new URL('appengine/', config.astarte_api_url).toString(),
+            pairingApiUrl: new URL('pairing/', config.astarte_api_url).toString(),
+            realmManagementApiUrl: new URL('realmmanagement/', config.astarte_api_url).toString(),
+            flowApiUrl: new URL('flow/', config.astarte_api_url).toString(),
+            realm: realm.name,
+            token: realm.infinite_token,
+          }),
+        ).as('astarteClient');
+      });
+    });
+  });
+
+  context('Devices', () => {
+    beforeEach(() => {
+      cy.fixture('device_detailed').as('device');
+    });
+
+    it("correctly retrieves a device's data and DataTree", function () {
+      const deviceId = this.device.data.id;
+
+      // Get device data for different interface types
+      interfaceList.forEach(({ interfaceName, interfaceValuesFixture }) => {
+        cy.fixture(interfaceValuesFixture).then((interfaceValues) => {
+          cy.intercept(
+            'GET',
+            `/appengine/v1/*/devices/${deviceId}/interfaces/${interfaceName}*`,
+            interfaceValues,
+          ).as(`getDeviceDataRequest-${interfaceName}`);
+          cy.get('@astarteClient')
+            .then((astarteClient) => {
+              return astarteClient.getDeviceData({
+                deviceId,
+                interfaceName,
+              });
+            })
+            .as(`deviceData`);
+          cy.wait(`@getDeviceDataRequest-${interfaceName}`);
+          // Assert expected data from astarte-client
+          cy.get(`@deviceData`).should('deep.eq', interfaceValues.data);
+        });
+      });
+
+      // Get device DataTree for different interface types
+      cy.intercept('GET', `/appengine/v1/*/devices/${deviceId}`, this.device);
+      interfaceList.forEach(
+        ({ interfaceName, interfaceValuesFixture, interfaceLinearizedValuesFixture }) => {
+          cy.fixture(interfaceValuesFixture).then((interfaceValues) => {
+            cy.intercept(
+              'GET',
+              `/appengine/v1/*/devices/${deviceId}/interfaces/${interfaceName}*`,
+              interfaceValues,
+            ).as(`getDeviceDataRequest-${interfaceName}`);
+            cy.intercept('GET', `/realmmanagement/v1/*/interfaces/${interfaceName}/*`, {
+              fixture: interfaceName,
+            });
+            cy.get('@astarteClient')
+              .then((astarteClient) => {
+                return astarteClient.getDeviceDataTree({
+                  deviceId,
+                  interfaceName,
+                });
+              })
+              .as('deviceDataTree');
+            cy.wait(`@getDeviceDataRequest-${interfaceName}`);
+            cy.fixture(interfaceLinearizedValuesFixture).then((interfaceLinearizedValues) => {
+              cy.get('@deviceDataTree').then((dataTree) => {
+                // Assert expected DataTree from astarte-client
+                expect(dataTree.toLinearizedData()).to.deep.eq(interfaceLinearizedValues);
+              });
+            });
+          });
+        },
+      );
+    });
+
+    it("correctly retrieves a device's DataTree on a specific interface path", function () {
+      const deviceId = this.device.data.id;
+      const interfaceName = 'test.astarte.IndividualObjectInterface';
+      const interfacePathValuesFixture = 'test_individual_object_interface_path_values';
+      const interfacePath = '/sensors/light/estimated';
+
+      // Get device DataTree on a specific interface PATH
+      cy.intercept('GET', `/appengine/v1/*/devices/${deviceId}`, this.device);
+      cy.fixture(interfacePathValuesFixture).then((interfacePathValues) => {
+        cy.intercept(
+          'GET',
+          `/appengine/v1/*/devices/${deviceId}/interfaces/${interfaceName}${interfacePath}?keep_milliseconds=true&since=&since_after=&to=&limit=`,
+          interfacePathValues,
+        ).as('getDeviceDataRequest');
+        cy.intercept('GET', `/realmmanagement/v1/*/interfaces/${interfaceName}/*`, {
+          fixture: interfaceName,
+        });
+        cy.get('@astarteClient')
+          .then((astarteClient) => {
+            return astarteClient.getDeviceDataTree({
+              deviceId,
+              interfaceName,
+              path: interfacePath,
+            });
+          })
+          .as('deviceDataTree');
+        cy.wait('@getDeviceDataRequest');
+        cy.get('@deviceDataTree').then((dataTree) => {
+          // Assert expected DataTree from astarte-client
+          expect(dataTree.toLinearizedData()).to.deep.eq([
+            {
+              endpoint: '/sensors/light/estimated',
+              timestamp: '2020-10-14T12:27:02.331Z',
+              type: 'double',
+              value: 81,
+            },
+            {
+              endpoint: '/sensors/light/estimated',
+              timestamp: '2020-10-14T12:27:13.200Z',
+              type: 'double',
+              value: 82,
+            },
+          ]);
+        });
+
+        // Get device DataTree SINCE a specific timestamp
+        const since = '2020-10-14T12:27:13.200Z';
+        const interfacePathValuesSince = {
+          data: interfacePathValues.data.filter((v) => v.timestamp >= since),
+        };
+        cy.intercept(
+          'GET',
+          `/appengine/v1/*/devices/${deviceId}/interfaces/${interfaceName}${interfacePath}?*since=${since}*`,
+          interfacePathValuesSince,
+        ).as('getDeviceDataSinceRequest');
+        cy.get('@astarteClient')
+          .then((astarteClient) => {
+            return astarteClient.getDeviceDataTree({
+              deviceId,
+              interfaceName,
+              path: interfacePath,
+              since,
+            });
+          })
+          .as('deviceDataTree');
+        cy.wait('@getDeviceDataSinceRequest');
+        cy.get('@deviceDataTree').then((dataTree) => {
+          // Assert expected DataTree from astarte-client
+          expect(dataTree.toLinearizedData()).to.deep.eq([
+            {
+              endpoint: '/sensors/light/estimated',
+              timestamp: '2020-10-14T12:27:13.200Z',
+              type: 'double',
+              value: 82,
+            },
+          ]);
+        });
+
+        // Get device DataTree TO a specific timestamp
+        const to = '2020-10-14T12:27:02.331Z';
+        const interfacePathValuesTo = {
+          data: interfacePathValues.data.filter((v) => v.timestamp <= to),
+        };
+        cy.intercept(
+          'GET',
+          `/appengine/v1/*/devices/${deviceId}/interfaces/${interfaceName}${interfacePath}?*to=${to}*`,
+          interfacePathValuesTo,
+        ).as('getDeviceDataToRequest');
+        cy.get('@astarteClient')
+          .then((astarteClient) => {
+            return astarteClient.getDeviceDataTree({
+              deviceId,
+              interfaceName,
+              path: interfacePath,
+              to,
+            });
+          })
+          .as('deviceDataTree');
+        cy.wait('@getDeviceDataToRequest');
+        cy.get('@deviceDataTree').then((dataTree) => {
+          // Assert expected DataTree from astarte-client
+          expect(dataTree.toLinearizedData()).to.deep.eq([
+            {
+              endpoint: '/sensors/light/estimated',
+              timestamp: '2020-10-14T12:27:02.331Z',
+              type: 'double',
+              value: 81,
+            },
+          ]);
+        });
+
+        // Get device DataTree SINCEAFTER a specific timestamp
+        const sinceAfter = '2020-10-14T12:27:13.200Z';
+        const interfacePathValuesSinceAfter = {
+          data: interfacePathValues.data.filter((v) => v.timestamp > sinceAfter),
+        };
+        cy.intercept(
+          'GET',
+          `/appengine/v1/*/devices/${deviceId}/interfaces/${interfaceName}${interfacePath}?*since_after=${sinceAfter}*`,
+          interfacePathValuesSinceAfter,
+        ).as('getDeviceDataSinceAfterRequest');
+        cy.get('@astarteClient')
+          .then((astarteClient) => {
+            return astarteClient.getDeviceDataTree({
+              deviceId,
+              interfaceName,
+              path: interfacePath,
+              sinceAfter,
+            });
+          })
+          .as('deviceDataTree');
+        cy.wait('@getDeviceDataSinceAfterRequest');
+        cy.get('@deviceDataTree').then((dataTree) => {
+          // Assert expected DataTree from astarte-client
+          expect(dataTree.toLinearizedData()).to.deep.eq([]);
+        });
+
+        // Get device DataTree from last LIMIT values
+        const limit = 1;
+        const interfacePathValuesLimit = {
+          data: interfacePathValues.data.slice(-limit),
+        };
+        cy.intercept(
+          'GET',
+          `/appengine/v1/*/devices/${deviceId}/interfaces/${interfaceName}${interfacePath}?*limit=${limit}*`,
+          interfacePathValuesLimit,
+        ).as('getDeviceDataLimitRequest');
+        cy.get('@astarteClient')
+          .then((astarteClient) => {
+            return astarteClient.getDeviceDataTree({
+              deviceId,
+              interfaceName,
+              path: interfacePath,
+              limit,
+            });
+          })
+          .as('deviceDataTree');
+        cy.wait('@getDeviceDataLimitRequest');
+        cy.get('@deviceDataTree').then((dataTree) => {
+          // Assert expected DataTree from astarte-client
+          expect(dataTree.toLinearizedData()).to.deep.eq([
+            {
+              endpoint: '/sensors/light/estimated',
+              timestamp: '2020-10-14T12:27:13.200Z',
+              type: 'double',
+              value: 82,
+            },
+          ]);
+        });
+      });
+    });
+  });
+});

--- a/src/astarte-client/client.test.ts
+++ b/src/astarte-client/client.test.ts
@@ -1,0 +1,158 @@
+/*
+   This file is part of Astarte.
+
+   Copyright 2021 Ispirata Srl
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import _axios from 'axios';
+
+import AstarteClient from './client';
+
+const axios = (_axios as unknown) as jest.Mock; // Set correct Typescript type
+jest.mock('axios');
+
+describe('AstarteClient', () => {
+  const realm = 'testrealm';
+  const token =
+    'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhX2FlYSI6WyIuKjo6LioiXSwiYV9jaCI6WyJKT0lOOjouKiIsIldBVENIOjouKiJdLCJhX3BhIjpbIi4qOjouKiJdLCJhX3JtYSI6WyIuKjo6LioiXSwiaWF0IjoxNjAwNzAxOTQ5fQ.Pj-uHOiIojX2Bn39HbWrhxfXDxLRs2vM1L6JdiGZfcTxUqRQmanM5h3Pbbf3dlVX15GX-S8y-DgfnojgTE1yW8vfXS7P6obFX0JKbNEkaqq0QIgwu2b5dZE3XUA8NjLTkLH63EvHK227okb10kvUn6We3018LInqqGVAGY7kcv-pQDH7MHFz8lFhxj3iCDtxM_5WfqrLhsNXndbQLvwADHoqPzP0kOrvFTGPKwcd8m0JJKrnusFB_lUmgpGLXgAZHAIhhg4wlTCALjLnlvEBcLtxMIs0j-glI8lE1SuCSiWguUwbKnuvoqe3m_Vofq0hUzFZ6_fCy1J__oTw5CkunTQav4xeI9QsyN85xlfwxph9K0yDLK02xbqY5wrV3me9z0RadxsoiNE0lU4mK33hcTfThHyiF3hcxu_A8GBSPwej5gsdetRP16hu2-k_2iVsyiv26MjORb8WAFrJINcf0YD_Yehyqkgv_dN23C8OlmLt90yK8gx05mTVq21rP1Vifrl1RQjuV9BEWjHnpxSDHag7U9UCkjzNmnhg1o7TExBx_owwY1N0kz1B2I7EkmdfUUOFDP80ts4rZwYwTmfiDKriB5DWID-fqpO6IGm_IFKRXoZk_jaovlqdHSpzZqzfescaiVeYrJ_CcVM8HpjASD6UWiI3FHBg0X9cq81lVKw';
+  const astarteUrl = 'http://api.example.com';
+  const appEngineApiUrl = `${astarteUrl}/appengine/`;
+  const pairingApiUrl = `${astarteUrl}/pairing/`;
+  const realmManagementApiUrl = `${astarteUrl}/realmmanagement/`;
+  const flowApiUrl = `${astarteUrl}/flow/`;
+  const astarte = new AstarteClient({
+    appEngineApiUrl,
+    pairingApiUrl,
+    realmManagementApiUrl,
+    flowApiUrl,
+    realm,
+    token,
+  });
+
+  it('correctly performs getDeviceData', async () => {
+    const deviceId = 'deviceId';
+    const interfaceName = 'interfaceName';
+    const deviceData = { some: { property: { value: 42 } } };
+    axios.mockResolvedValue({ data: { data: deviceData } });
+
+    const fetcheData = await astarte.getDeviceData({ deviceId, interfaceName });
+    expect(axios).toHaveBeenCalledTimes(1);
+    expect(axios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        method: 'get',
+      }),
+    );
+    expect(axios.mock.calls[0][0].url.toString()).toBe(
+      `${appEngineApiUrl}v1/${realm}/devices/${deviceId}/interfaces/${interfaceName}?keep_milliseconds=true&since=&since_after=&to=&limit=`,
+    );
+    expect(fetcheData).toEqual(deviceData);
+
+    const path = '/some/property';
+    const since = '2021-03-20T11:32:34.909Z';
+    const sinceAfter = '2021-03-21T11:32:34.909Z';
+    const to = '2021-03-22T11:32:34.909Z';
+    const limit = 5;
+    await astarte.getDeviceData({ deviceId, interfaceName, path, since, sinceAfter, to, limit });
+    expect(axios).toHaveBeenCalledTimes(2);
+    expect(axios.mock.calls[1][0].url.toString()).toBe(
+      `${appEngineApiUrl}v1/${realm}/devices/${deviceId}/interfaces/${interfaceName}${path}?keep_milliseconds=true&since=${since}&since_after=${sinceAfter}&to=${to}&limit=${limit}`,
+    );
+  });
+
+  it('correctly performs getDeviceDataTree', async () => {
+    const deviceId = 'PO6RuqIXQuysOCAJrcedqA';
+    const interfaceName = 'interfaceName';
+    const interfaceMajor = 0;
+    const interfaceMinor = 1;
+    const device = {
+      aliases: {},
+      connected: false,
+      credentials_inhibited: false,
+      first_credentials_request: null,
+      first_registration: '2020-01-01T12:00:00.000Z',
+      groups: [],
+      id: deviceId,
+      introspection: {
+        [interfaceName]: {
+          major: interfaceMajor,
+          minor: interfaceMinor,
+          exchanged_bytes: 0,
+          exchanged_msgs: 0,
+        },
+      },
+      last_connection: null,
+      last_credentials_request_ip: null,
+      last_disconnection: null,
+      last_seen_ip: null,
+      metadata: {},
+      previous_interfaces: [],
+      total_received_bytes: 0,
+      total_received_msgs: 0,
+    };
+    const iface = {
+      interface_name: interfaceName,
+      version_major: interfaceMajor,
+      version_minor: interfaceMinor,
+      type: 'properties',
+      ownership: 'device',
+      mappings: [
+        {
+          endpoint: '/%{room}/heating',
+          type: 'boolean',
+        },
+      ],
+    };
+    const deviceData = { bedroom: { heating: true } };
+    axios.mockImplementationOnce(async () => ({ data: { data: device } })); // Mock first call
+    axios.mockImplementationOnce(async () => ({ data: { data: iface } })); // Mock second call
+    axios.mockImplementationOnce(async () => ({ data: { data: deviceData } })); // Mock third call
+
+    const fetcheDataTree = await astarte.getDeviceDataTree({ deviceId, interfaceName });
+    expect(axios).toHaveBeenCalledTimes(3);
+    // First GET to fetch Device
+    expect(axios.mock.calls[0][0].url.toString()).toBe(
+      `${appEngineApiUrl}v1/${realm}/devices/${deviceId}`,
+    );
+    // Second GET to fetch Interface
+    expect(axios.mock.calls[1][0].url.toString()).toBe(
+      `${realmManagementApiUrl}v1/${realm}/interfaces/${interfaceName}/${interfaceMajor}`,
+    );
+    // Third GET to fetch Device data
+    expect(axios.mock.calls[2][0].url.toString()).toBe(
+      `${appEngineApiUrl}v1/${realm}/devices/${deviceId}/interfaces/${interfaceName}?keep_milliseconds=true&since=&since_after=&to=&limit=`,
+    );
+    expect(fetcheDataTree).toMatchObject({
+      endpoint: '',
+      dataKind: 'properties',
+      children: [
+        {
+          endpoint: '/bedroom',
+          dataKind: 'properties',
+          children: [
+            {
+              endpoint: '/bedroom/heating',
+              dataKind: 'properties',
+              data: { endpoint: '/bedroom/heating', type: 'boolean', value: true },
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/src/astarte-client/client.ts
+++ b/src/astarte-client/client.ts
@@ -471,6 +471,7 @@ class AstarteClient {
     return toAstarteDataTree({
       interface: iface,
       data: interfaceValues,
+      endpoint: params.path,
     });
   }
 

--- a/src/astarte-client/client.ts
+++ b/src/astarte-client/client.ts
@@ -216,7 +216,7 @@ class AstarteClient {
       devicesStats:          astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/stats/devices`,
       devices:               astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/devices`,
       deviceInfo:            astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/devices/${'deviceId'}`,
-      deviceData:            astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/devices/${'deviceId'}/interfaces/${'interfaceName'}`,
+      deviceData:            astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/devices/${'deviceId'}/interfaces/${'interfaceName'}${'path'}?keep_milliseconds=true&since=${'since'}&since_after=${'sinceAfter'}&to=${'to'}&limit=${'limit'}`,
       groups:                astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/groups`,
       groupDevices:          astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/groups/${'groupName'}/devices`,
       deviceInGroup:         astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/groups/${'groupName'}/devices/${'deviceId'}`,
@@ -416,11 +416,15 @@ class AstarteClient {
   async getDeviceData(params: {
     deviceId: AstarteDevice['id'];
     interfaceName: AstarteInterface['name'];
+    path?: string;
+    since?: string;
+    sinceAfter?: string;
+    to?: string;
+    limit?: number;
   }): Promise<AstarteInterfaceValues> {
     const response = await this.$get(
       this.apiConfig.deviceData({
-        deviceId: params.deviceId,
-        interfaceName: params.interfaceName,
+        ...params,
         ...this.config,
       }),
     );
@@ -428,7 +432,14 @@ class AstarteClient {
   }
 
   async getDeviceDataTree(
-    params: { deviceId: AstarteDevice['id'] } & InterfaceOrInterfaceNameParams,
+    params: {
+      deviceId: AstarteDevice['id'];
+      path?: string;
+      since?: string;
+      sinceAfter?: string;
+      to?: string;
+      limit?: number;
+    } & InterfaceOrInterfaceNameParams,
   ): Promise<
     | AstarteDataTreeNode<AstartePropertyData>
     | AstarteDataTreeNode<AstarteDatastreamIndividualData>
@@ -451,6 +462,11 @@ class AstarteClient {
     const interfaceValues = await this.getDeviceData({
       deviceId: params.deviceId,
       interfaceName: iface.name,
+      path: params.path,
+      since: params.since,
+      sinceAfter: params.sinceAfter,
+      to: params.to,
+      limit: params.limit,
     });
     return toAstarteDataTree({
       interface: iface,

--- a/src/astarte-client/client.ts
+++ b/src/astarte-client/client.ts
@@ -257,8 +257,8 @@ class AstarteClient {
   }
 
   setCredentials(params: { realm: string; token: string } | null): void {
-    this.config.realm = params?.realm || '';
-    this.token = params?.token || '';
+    this.config.realm = _.get(params, 'realm') || '';
+    this.token = _.get(params, 'token') || '';
   }
 
   async getConfigAuth(): Promise<{ publicKey: string }> {

--- a/src/astarte-client/transforms/dataTree.test.ts
+++ b/src/astarte-client/transforms/dataTree.test.ts
@@ -1,0 +1,115 @@
+/*
+   This file is part of Astarte.
+
+   Copyright 2021 Ispirata Srl
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import { AstarteInterface } from 'astarte-client';
+
+import { toAstarteDataTree } from './dataTree';
+
+describe('DataTree for properties interface', () => {
+  const iface = new AstarteInterface({
+    name: 'test.astarte.PropertiesInterface',
+    major: 1,
+    minor: 0,
+    type: 'properties',
+    ownership: 'device',
+    mappings: [
+      {
+        endpoint: '/%{room}/heating/active',
+        type: 'boolean',
+      },
+      {
+        endpoint: '/rooms/count',
+        type: 'integer',
+      },
+    ],
+  });
+
+  it('creates an empty DataTree', () => {
+    const data = {};
+    const dataTree = toAstarteDataTree({ interface: iface, data });
+    expect(dataTree).toEqual({
+      dataKind: 'properties',
+      endpoint: '',
+      parent: null,
+      children: [],
+    });
+  });
+});
+
+describe('DataTree for datastream individual interface', () => {
+  const iface = new AstarteInterface({
+    name: 'test.astarte.IndividualObjectInterface',
+    major: 1,
+    minor: 0,
+    type: 'datastream',
+    ownership: 'device',
+    mappings: [
+      {
+        endpoint: '/humidity/value/current',
+        type: 'double',
+      },
+      {
+        endpoint: '/sensors/%{sensor}/estimated',
+        type: 'double',
+      },
+    ],
+  });
+
+  it('creates an empty DataTree', () => {
+    const data = {};
+    const dataTree = toAstarteDataTree({ interface: iface, data });
+    expect(dataTree).toEqual({
+      dataKind: 'datastream_individual',
+      endpoint: '',
+      parent: null,
+      children: [],
+    });
+  });
+});
+
+describe('DataTree for datastream object interface', () => {
+  const iface = new AstarteInterface({
+    name: 'test.astarte.AggregatedObjectInterface',
+    major: 1,
+    minor: 0,
+    type: 'datastream',
+    ownership: 'device',
+    aggregation: 'object',
+    mappings: [
+      {
+        endpoint: '/sensors/%{sensor_id}/value/boolean',
+        type: 'boolean',
+      },
+      {
+        endpoint: '/sensors/%{sensor_id}/value/double',
+        type: 'double',
+      },
+    ],
+  });
+
+  it('creates an empty DataTree', () => {
+    const data = {};
+    const dataTree = toAstarteDataTree({ interface: iface, data });
+    expect(dataTree).toEqual({
+      dataKind: 'datastream_object',
+      endpoint: '',
+      parent: null,
+      children: [],
+    });
+  });
+});

--- a/src/astarte-client/types/interfaceValues.ts
+++ b/src/astarte-client/types/interfaceValues.ts
@@ -26,11 +26,13 @@ export interface AstarteIndividualDatastreamInterfaceValue {
   value: AstarteDataValue;
   timestamp: string;
 }
-export interface AstarteIndividualDatastreamInterfaceValues {
-  [subPath: string]:
-    | AstarteIndividualDatastreamInterfaceValues
-    | AstarteIndividualDatastreamInterfaceValue;
-}
+export type AstarteIndividualDatastreamInterfaceValues =
+  | AstarteIndividualDatastreamInterfaceValue[]
+  | {
+      [subPath: string]:
+        | AstarteIndividualDatastreamInterfaceValues
+        | AstarteIndividualDatastreamInterfaceValue;
+    };
 
 export type AstarteAggregatedDatastreamInterfaceValue = Array<{
   [key: string]: AstarteDataValue;


### PR DESCRIPTION
This PR adds support for filter params in astarte-client's `getDeviceData()` and `getDeviceDataTree()`.
Supported params include: `path`, `since`, `sinceAfter`, `to`, `limit`.