### PR TITLE
Fix login layout on small screen devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.0.0-beta.2] - Unreleased
+### Fixed
+- Hide login image column on small screen devices.
 
 ## [1.0.0-beta.1] - 2021-02-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.2] - Unreleased
+
 ## [1.0.0-beta.1] - 2021-02-15
 ### Added
 - Support device groups in device triggers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "astarte-dashboard",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astarte-dashboard",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Astarte dashboard",
   "main": "dist/index.html",
   "keywords": [

--- a/src/react/LoginPage.tsx
+++ b/src/react/LoginPage.tsx
@@ -225,7 +225,7 @@ const OAuthForm = ({
 };
 
 const LeftColumn = (): React.ReactElement => (
-  <Col lg={6} sm={false} className="p-0 no-gutters">
+  <Col lg={6} className="p-0 no-gutters d-none d-lg-block">
     <div className="d-flex flex-column align-items-center justify-content-center position-relative login-image-container">
       <img
         src="/static/img/background-login-top.svg"
@@ -269,7 +269,7 @@ const RightColumn = ({
     <Col
       lg={6}
       sm={12}
-      className="bg-white d-flex flex-column align-items-center justify-content-center"
+      className="bg-white d-flex flex-column align-items-center justify-content-center min-vh-100"
     >
       <h1>Sign In</h1>
       {loginType === 'oauth' ? (


### PR DESCRIPTION
Hide the image column when the screen is not wide enough for a 2 column layout

![image](https://user-images.githubusercontent.com/5071605/108507982-67bfb580-72bb-11eb-890e-32229bfed2b7.png)
