### PR TITLE
Add missing fallbacks for loading errors in pages

### DIFF
--- a/src/react/DeviceStatusPage/index.tsx
+++ b/src/react/DeviceStatusPage/index.tsx
@@ -19,11 +19,11 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { Col, Container, Row, Spinner } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
-import _ from 'lodash';
 
 import AstarteClient from 'astarte-client';
 import type { AstarteDevice } from 'astarte-client';
 import BackButton from '../ui/BackButton';
+import Empty from '../components/Empty';
 import WaitForData from '../components/WaitForData';
 import useFetch from '../hooks/useFetch';
 import { useAlerts } from '../AlertManager';
@@ -291,7 +291,12 @@ export default ({ astarte, deviceId }: Props): React.ReactElement => {
         data={deviceFetcher.value}
         status={deviceFetcher.status}
         fallback={
-          _.isEmpty(deviceFetcher.error) ? <Spinner animation="border" role="status" /> : <></>
+          <Container fluid className="text-center">
+            <Spinner animation="border" role="status" />
+          </Container>
+        }
+        errorFallback={
+          <Empty title="Couldn't load device details" onRetry={deviceFetcher.refresh} />
         }
       >
         {(device: AstarteDevice) => {

--- a/src/react/InterfacePage.tsx
+++ b/src/react/InterfacePage.tsx
@@ -23,6 +23,7 @@ import AstarteClient, { AstarteInterface } from 'astarte-client';
 
 import { useAlerts } from './AlertManager';
 import InterfaceEditor from './components/InterfaceEditor';
+import Empty from './components/Empty';
 import WaitForData from './components/WaitForData';
 import ConfirmModal from './components/modals/Confirm';
 import BackButton from './ui/BackButton';
@@ -178,8 +179,14 @@ export default ({ astarte, interfaceName, interfaceMajor }: Props): React.ReactE
         <WaitForData
           data={interfaceFetcher.value}
           status={interfaceFetcher.status}
-          fallback={<Spinner animation="border" role="status" />}
-          errorFallback={<p>Couldn&apos;t load interface properties.</p>}
+          fallback={
+            <Container fluid className="text-center">
+              <Spinner animation="border" role="status" />
+            </Container>
+          }
+          errorFallback={
+            <Empty title="Couldn't load interface properties" onRetry={interfaceFetcher.refresh} />
+          }
         >
           {(iface) => (
             <>


### PR DESCRIPTION
This PR adds `<Empty />` component fallbacks that were still missing for loading errors in Interface page and DeviceStatus page.

Interface page before:

![Screenshot from 2021-02-25 18-33-49](https://user-images.githubusercontent.com/60540759/109192970-2be38f00-7798-11eb-8acd-4c23f7bc6b54.png)

Interface page after:

![Screenshot from 2021-02-25 18-30-37](https://user-images.githubusercontent.com/60540759/109192988-33a33380-7798-11eb-805d-2a841d762367.png)

DeviceStatus page before:

![Screenshot from 2021-02-25 18-34-07](https://user-images.githubusercontent.com/60540759/109193055-4453a980-7798-11eb-8cbf-3cc53972314d.png)

DeviceStatus page after:

![Screenshot from 2021-02-25 18-37-36](https://user-images.githubusercontent.com/60540759/109193391-998fbb00-7798-11eb-822b-81476247798a.png)

