### PR TITLE
Add Remove icon for Pipeline Editor blocks

### DIFF
--- a/src/react/components/NativeBlockFactory.tsx
+++ b/src/react/components/NativeBlockFactory.tsx
@@ -32,6 +32,7 @@ import NativeBlockWidget from './NativeBlockWidget';
 type GenerateModelEvent = Parameters<AbstractReactFactory['generateModel']>['0'] & {
   name: AstarteBlock['name'];
   type: AstarteBlock['type'];
+  onRemoveClick?: (node: NativeBlockModel) => void;
   onSettingsClick?: (...args: any[]) => void;
 };
 
@@ -54,11 +55,17 @@ class NativeBlockFactory extends AbstractReactFactory<BaseModel, DiagramEngine> 
     return <NativeBlockWidget engine={this.engine} node={node} hasSettings={hasSettings} />;
   }
 
-  generateModel({ name, type, onSettingsClick }: GenerateModelEvent): NativeBlockModel {
+  generateModel({
+    name,
+    type,
+    onRemoveClick,
+    onSettingsClick,
+  }: GenerateModelEvent): NativeBlockModel {
     const block = this.blockDefinitions.get(`${type}-${name}`);
     return new NativeBlockModel({
       name: block ? block.name : name,
       blockType: block ? block.type : type,
+      onRemoveClick,
       onSettingsClick,
     });
   }

--- a/src/react/components/NativeBlockWidget.tsx
+++ b/src/react/components/NativeBlockWidget.tsx
@@ -41,11 +41,16 @@ const NativeBlockWidget = ({ engine, node, hasSettings }: Props): React.ReactEle
     <div className={classes.join(' ')} data-default-node-name={name}>
       <div className="node-header">
         <div className="node-title">{name}</div>
-        {hasSettings && (
-          <div className="settings-icon" onClick={(e) => node.onSettingsClick(e, node)}>
-            <i className="fas fa-cog" />
+        <div className="node-header-icons">
+          {hasSettings && (
+            <div className="node-header-icon" onClick={(e) => node.onSettingsClick(e, node)}>
+              <i className="fas fa-cog" />
+            </div>
+          )}
+          <div className="node-header-icon" onClick={() => node.onRemoveClick(node)}>
+            <i className="fas fa-times" />
           </div>
-        )}
+        </div>
       </div>
       <div className="ports">
         <div className="port-container">

--- a/src/react/components/VisualFlowEditor.tsx
+++ b/src/react/components/VisualFlowEditor.tsx
@@ -104,6 +104,10 @@ const VisualFlowEditor = ({
         name,
         type,
         onSettingsClick: onNodeSettingsClick,
+        onRemoveClick: () => {
+          newNode.remove();
+          engine.repaintCanvas();
+        },
       });
       newNode.setPosition(position.x - 30, position.y - 20);
       model.addNode(newNode);

--- a/src/react/models/NativeBlockModel.ts
+++ b/src/react/models/NativeBlockModel.ts
@@ -53,6 +53,7 @@ function encodeValue(value: unknown): any {
 interface NativeBlockModelConfig {
   name: AstarteBlock['name'];
   blockType: AstarteBlock['type'];
+  onRemoveClick?: (node: NativeBlockModel) => void;
   onSettingsClick?: (...args: any[]) => void;
 }
 
@@ -60,6 +61,8 @@ class NativeBlockModel extends NodeModel {
   name: AstarteBlock['name'];
 
   blockType: AstarteBlock['type'];
+
+  onRemoveClick: (node: NativeBlockModel) => void;
 
   onSettingsClick: (...args: any[]) => void;
 
@@ -69,7 +72,12 @@ class NativeBlockModel extends NodeModel {
 
   outPorts: DefaultPortModel[];
 
-  constructor({ name, blockType, onSettingsClick = () => {} }: NativeBlockModelConfig) {
+  constructor({
+    name,
+    blockType,
+    onRemoveClick = () => {},
+    onSettingsClick = () => {},
+  }: NativeBlockModelConfig) {
     super({
       type: 'astarte-native',
     });
@@ -101,6 +109,7 @@ class NativeBlockModel extends NodeModel {
     this.name = name;
     this.blockType = blockType;
     this.properties = {};
+    this.onRemoveClick = onRemoveClick;
     this.onSettingsClick = onSettingsClick;
   }
 

--- a/src/static/styles/flow-editor.scss
+++ b/src/static/styles/flow-editor.scss
@@ -104,17 +104,24 @@ $block-radius: 5px;
       background: rgba(0, 0, 0, 0.3);
       border-radius: $block-radius $block-radius 0 0;
       display: flex;
+      align-items: center;
       white-space: nowrap;
+      padding: 0.3em;
     }
 
     .node-title {
       flex-grow: 1;
-      padding: 0.35em;
+      padding: 0 0.3em;
     }
 
-    .settings-icon {
-      padding: 0.3em;
-      padding-left: 1em;
+    .node-header-icons {
+      display: flex;
+      align-items: center;
+      padding: 0 0.3em;
+    }
+
+    .node-header-icon {
+      padding-left: 0.7em;
       cursor: pointer;
     }
 


### PR DESCRIPTION
This PR adds an icon to visual blocks in Pipeline Editor so that they can be removed without using keyboard input.

Before:

![Screenshot from 2021-03-01 18-54-50](https://user-images.githubusercontent.com/60540759/109537811-a45f8e00-7abf-11eb-97e9-748440f0341b.png)

After:

![Screenshot from 2021-03-01 18-54-39](https://user-images.githubusercontent.com/60540759/109537834-a9bcd880-7abf-11eb-9ee0-ea4e10805261.png)
