### PR TITLE
Add reusable Icon component

### DIFF
--- a/cypress/integration/devices_page_test.js
+++ b/cypress/integration/devices_page_test.js
@@ -57,7 +57,7 @@ describe('Devices page tests', () => {
       cy.get('table tbody tr i')
         .should('have.length', 1)
         .each(($icon) => {
-          expect($icon).to.have.class('icon-connected');
+          expect($icon).to.have.class('color-green');
         });
     });
 

--- a/src/react/App.tsx
+++ b/src/react/App.tsx
@@ -67,25 +67,25 @@ const DashboardSidebar = () => {
         <Sidebar.Brand />
         <Sidebar.Item label="Home" link="/" icon="home" />
         <Sidebar.Separator />
-        <Sidebar.Item label="Interfaces" link="/interfaces" icon="stream" />
-        <Sidebar.Item label="Triggers" link="/triggers" icon="bolt" />
+        <Sidebar.Item label="Interfaces" link="/interfaces" icon="interfaces" />
+        <Sidebar.Item label="Triggers" link="/triggers" icon="triggers" />
         <Sidebar.Separator />
-        <Sidebar.Item label="Devices" link="/devices" icon="cube" />
-        <Sidebar.Item label="Groups" link="/groups" icon="object-group" />
+        <Sidebar.Item label="Devices" link="/devices" icon="devices" />
+        <Sidebar.Item label="Groups" link="/groups" icon="groups" />
         <Sidebar.Separator />
         {config.features.flow && (
           <>
-            <Sidebar.Item label="Flows" link="/flows" icon="wind" />
-            <Sidebar.Item label="Pipelines" link="/pipelines" icon="code-branch" />
-            <Sidebar.Item label="Blocks" link="/blocks" icon="shapes" />
+            <Sidebar.Item label="Flows" link="/flows" icon="flows" />
+            <Sidebar.Item label="Pipelines" link="/pipelines" icon="pipelines" />
+            <Sidebar.Item label="Blocks" link="/blocks" icon="blocks" />
             <Sidebar.Separator />
           </>
         )}
-        <Sidebar.Item label="Realm settings" link="/settings" icon="cog" />
+        <Sidebar.Item label="Realm settings" link="/settings" icon="settings" />
         <Sidebar.Separator />
         <Sidebar.ApiStatus healthy={isApiHealthy} realm={astarte.realm} />
         <Sidebar.Separator />
-        <Sidebar.Item label="Logout" link="/logout" icon="sign-out-alt" />
+        <Sidebar.Item label="Logout" link="/logout" icon="logout" />
       </Sidebar>
     </Col>
   );
@@ -108,7 +108,7 @@ const StandaloneEditor = () => (
       <Col id="main-navbar" className="col-auto nav-col">
         <Sidebar>
           <Sidebar.Brand />
-          <Sidebar.Item label="Interface Editor" link="/" icon="stream" />
+          <Sidebar.Item label="Interface Editor" link="/" icon="interfaces" />
         </Sidebar>
       </Col>
       <Col className="main-content vh-100 overflow-auto">

--- a/src/react/DeviceStatusPage/AddToGroupModal.tsx
+++ b/src/react/DeviceStatusPage/AddToGroupModal.tsx
@@ -19,6 +19,8 @@
 import React, { useState } from 'react';
 import { Button, Modal, Spinner } from 'react-bootstrap';
 
+import Icon from '../components/Icon';
+
 interface AddToGroupModalProps {
   onCancel: () => void;
   onConfirm: (groupName: string) => void;
@@ -47,7 +49,7 @@ const AddToGroupModal = ({
               className={groupName === selectedGroup ? 'p-2 bg-success text-white' : 'p-2'}
             >
               <span onClick={() => setSelectedGroup(groupName)}>
-                <i className="fas fa-plus mr-2" />
+                <Icon icon="add" className="mr-2" />
                 {groupName}
               </span>
             </li>

--- a/src/react/DeviceStatusPage/AliasesCard.tsx
+++ b/src/react/DeviceStatusPage/AliasesCard.tsx
@@ -21,6 +21,7 @@ import { Button, Card, Table } from 'react-bootstrap';
 
 import type { AstarteDevice } from 'astarte-client';
 import FullHeightCard from '../components/FullHeightCard';
+import Icon from '../components/Icon';
 
 interface AliasKeyValuePair {
   key: string;
@@ -52,14 +53,8 @@ const AliasesTable = ({
           <td>{key}</td>
           <td>{value}</td>
           <td className="text-center">
-            <i
-              className="fas fa-pencil-alt color-grey action-icon mr-2"
-              onClick={() => onEditAliasClick(key)}
-            />
-            <i
-              className="fas fa-eraser color-red action-icon"
-              onClick={() => onRemoveAliasClick({ key, value })}
-            />
+            <Icon icon="edit" className="color-grey mr-2" onClick={() => onEditAliasClick(key)} />
+            <Icon icon="erase" onClick={() => onRemoveAliasClick({ key, value })} />
           </td>
         </tr>
       ))}

--- a/src/react/DeviceStatusPage/DeviceInfoCard.tsx
+++ b/src/react/DeviceStatusPage/DeviceInfoCard.tsx
@@ -21,6 +21,7 @@ import { Button, Card } from 'react-bootstrap';
 
 import type { AstarteDevice } from 'astarte-client';
 import FullHeightCard from '../components/FullHeightCard';
+import Icon from '../components/Icon';
 
 interface ConnectionStatusProps {
   status: AstarteDevice['connectionStatus'];
@@ -33,24 +34,24 @@ const ConnectionStatus = ({ status }: ConnectionStatusProps): React.ReactElement
   switch (status) {
     case 'connected':
       statusString = 'Connected';
-      icon = 'icon-connected';
+      icon = 'statusConnected' as const;
       break;
 
     case 'disconnected':
       statusString = 'Disconnected';
-      icon = 'icon-disconnected';
+      icon = 'statusDisconnected' as const;
       break;
 
     case 'never_connected':
     default:
       statusString = 'Never connected';
-      icon = 'icon-never-connected';
+      icon = 'statusNeverConnected' as const;
       break;
   }
 
   return (
     <>
-      <i className={['fas fa-circle mr-1', icon].join(' ')} />
+      <Icon icon={icon} className="mr-1" />
       <span>{statusString}</span>
     </>
   );

--- a/src/react/DeviceStatusPage/MetadataCard.tsx
+++ b/src/react/DeviceStatusPage/MetadataCard.tsx
@@ -18,9 +18,10 @@
 
 import React from 'react';
 import { Button, Card, Table } from 'react-bootstrap';
-
 import type { AstarteDevice } from 'astarte-client';
+
 import FullHeightCard from '../components/FullHeightCard';
+import Icon from '../components/Icon';
 
 interface MetadataKeyValuePair {
   key: string;
@@ -52,14 +53,12 @@ const MetadataTable = ({
           <td>{key}</td>
           <td>{value}</td>
           <td className="text-center">
-            <i
-              className="fas fa-pencil-alt color-grey action-icon mr-2"
+            <Icon
+              icon="edit"
+              className="color-grey mr-2"
               onClick={() => onEditMetadataClick(key)}
             />
-            <i
-              className="fas fa-eraser color-red action-icon"
-              onClick={() => onRemoveMetadataClick({ key, value })}
-            />
+            <Icon icon="erase" onClick={() => onRemoveMetadataClick({ key, value })} />
           </td>
         </tr>
       ))}

--- a/src/react/DevicesPage.tsx
+++ b/src/react/DevicesPage.tsx
@@ -17,18 +17,7 @@
 */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import {
-  Button,
-  Col,
-  Container,
-  Form,
-  OverlayTrigger,
-  Pagination,
-  Row,
-  Spinner,
-  Table,
-  Tooltip,
-} from 'react-bootstrap';
+import { Button, Col, Container, Form, Pagination, Row, Spinner, Table } from 'react-bootstrap';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import _ from 'lodash';
@@ -39,6 +28,7 @@ import SingleCardPage from './ui/SingleCardPage';
 import { useAlerts } from './AlertManager';
 import Empty from './components/Empty';
 import Highlight from './components/Highlight';
+import Icon from './components/Icon';
 import WaitForData from './components/WaitForData';
 import useFetch from './hooks/useFetch';
 import { useAstarte } from './AstarteManager';
@@ -102,48 +92,34 @@ const MatchedMetadata = ({
   );
 };
 
-const CircleIcon = React.forwardRef<HTMLElement, React.HTMLProps<HTMLElement>>(
-  ({ children, className, ...props }, ref) => (
-    <i ref={ref} {...props} className={`fas fa-circle ${className}`}>
-      {children}
-    </i>
-  ),
-);
-
 interface DeviceRowProps {
   device: AstarteDevice;
   filters: DeviceFilters;
 }
 
 const DeviceRow = ({ device, filters }: DeviceRowProps): React.ReactElement => {
-  let colorClass;
   let lastEvent;
-  let tooltipText;
+  let icon;
+  let iconTooltip;
 
   if (device.isConnected) {
-    tooltipText = 'Connected';
-    colorClass = 'icon-connected';
+    icon = 'statusConnected' as const;
+    iconTooltip = 'Connected';
     lastEvent = `Connected on ${(device.lastConnection as Date).toLocaleString()}`;
   } else if (device.lastConnection) {
-    tooltipText = 'Disconnected';
-    colorClass = 'icon-disconnected';
+    icon = 'statusDisconnected' as const;
+    iconTooltip = 'Disconnected';
     lastEvent = `Disconnected on ${(device.lastDisconnection as Date).toLocaleString()}`;
   } else {
-    tooltipText = 'Never connected';
-    colorClass = 'icon-never-connected';
+    icon = 'statusNeverConnected' as const;
+    iconTooltip = 'Never connected';
     lastEvent = 'Never connected';
   }
 
   return (
     <tr>
       <td>
-        <OverlayTrigger
-          placement="right"
-          delay={{ show: 150, hide: 400 }}
-          overlay={<Tooltip id={device.id}>{tooltipText}</Tooltip>}
-        >
-          <CircleIcon className={colorClass} />
-        </OverlayTrigger>
+        <Icon icon={icon} tooltip={iconTooltip} tooltipPlacement="right" />
       </td>
       <td className={device.hasNameAlias ? '' : 'text-monospace'}>
         <Link to={`/devices/${device.id}/edit`}>{device.name}</Link>
@@ -499,7 +475,7 @@ export default (): React.ReactElement => {
                   </Col>
                   <Col xs="auto" className="p-1">
                     <div className="p-2 mb-2" onClick={() => setShowSidebar(!showSidebar)}>
-                      <i className="fas fa-filter mr-1" />
+                      <Icon icon="filter" className="mr-1" />
                       {showSidebar && <b>Filters</b>}
                     </div>
                     {showSidebar && (

--- a/src/react/FlowInstancesPage.tsx
+++ b/src/react/FlowInstancesPage.tsx
@@ -18,22 +18,17 @@
 
 import React, { useCallback, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Button, Container, OverlayTrigger, Spinner, Table, Tooltip } from 'react-bootstrap';
+import { Button, Container, Spinner, Table } from 'react-bootstrap';
 import type { AstarteFlow } from 'astarte-client';
 
 import { useAlerts } from './AlertManager';
+import Icon from './components/Icon';
 import ConfirmModal from './components/modals/Confirm';
 import SingleCardPage from './ui/SingleCardPage';
 import Empty from './components/Empty';
 import WaitForData from './components/WaitForData';
 import useFetch from './hooks/useFetch';
 import { useAstarte } from './AstarteManager';
-
-const CircleIcon = React.forwardRef<HTMLElement, React.HTMLProps<HTMLElement>>((props, ref) => (
-  <i ref={ref} {...props} className={`fas fa-circle ${props.className}`}>
-    {props.children}
-  </i>
-));
 
 interface TableRowProps {
   instance: AstarteFlow;
@@ -43,31 +38,20 @@ interface TableRowProps {
 const TableRow = ({ instance, onDelete }: TableRowProps): React.ReactElement => (
   <tr>
     <td>
-      <OverlayTrigger
-        placement="right"
-        delay={{ show: 150, hide: 400 }}
-        overlay={<Tooltip id={`flow-state-${instance.name}`}>Running</Tooltip>}
-      >
-        <CircleIcon className="color-green" />
-      </OverlayTrigger>
+      <Icon icon="statusConnected" tooltip="Running" tooltipPlacement="right" />
     </td>
     <td>
       <Link to={`/flows/${instance.name}/edit`}>{instance.name}</Link>
     </td>
     <td>{instance.pipeline}</td>
     <td>
-      <OverlayTrigger
-        placement="left"
-        delay={{ show: 150, hide: 400 }}
-        overlay={<Tooltip id={`delete-flow-${instance.name}`}>Delete instance</Tooltip>}
-      >
-        <Button
-          as="i"
-          variant="danger"
-          className="fas fa-times"
-          onClick={() => onDelete(instance)}
-        />
-      </OverlayTrigger>
+      <Icon
+        icon="delete"
+        as="button"
+        tooltip="Delete instance"
+        tooltipPlacement="left"
+        onClick={() => onDelete(instance)}
+      />
     </td>
   </tr>
 );

--- a/src/react/GroupDevicesPage.tsx
+++ b/src/react/GroupDevicesPage.tsx
@@ -17,74 +17,58 @@
 */
 
 import React, { useState, useCallback } from 'react';
-import { Button, Container, OverlayTrigger, Spinner, Table, Tooltip } from 'react-bootstrap';
+import { Container, Spinner, Table } from 'react-bootstrap';
 import type { AstarteDevice } from 'astarte-client';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import Empty from './components/Empty';
+import Icon from './components/Icon';
 import ConfirmModal from './components/modals/Confirm';
 import SingleCardPage from './ui/SingleCardPage';
 import WaitForData from './components/WaitForData';
 import useFetch from './hooks/useFetch';
 import { useAstarte } from './AstarteManager';
 
-const CircleIcon = React.forwardRef<HTMLElement, React.HTMLProps<HTMLElement>>((props, ref) => (
-  <i ref={ref} {...props} className={`fas fa-circle ${props.className}`}>
-    {props.children}
-  </i>
-));
-
 const deviceTableRow = (
   device: AstarteDevice,
   index: number,
   showModal: (d: AstarteDevice) => void,
 ) => {
-  let colorClass;
+  let icon;
+  let iconTooltip;
   let lastEvent;
-  let tooltipText;
 
   if (device.isConnected) {
-    tooltipText = 'Connected';
-    colorClass = 'icon-connected';
+    icon = 'statusConnected' as const;
+    iconTooltip = 'Connected';
     lastEvent = `Connected on ${(device.lastConnection as Date).toLocaleString()}`;
   } else if (device.lastConnection) {
-    tooltipText = 'Disconnected';
-    colorClass = 'icon-disconnected';
+    icon = 'statusDisconnected' as const;
+    iconTooltip = 'Disconnected';
     lastEvent = `Disconnected on ${(device.lastDisconnection as Date).toLocaleString()}`;
   } else {
-    tooltipText = 'Never connected';
-    colorClass = 'icon-never-connected';
+    icon = 'statusNeverConnected' as const;
+    iconTooltip = 'Never connected';
     lastEvent = 'Never connected';
   }
 
   return (
     <tr key={index}>
       <td>
-        <OverlayTrigger
-          placement="right"
-          delay={{ show: 150, hide: 400 }}
-          overlay={<Tooltip id={`tooltip-icon-${index}`}>{tooltipText}</Tooltip>}
-        >
-          <CircleIcon className={colorClass} />
-        </OverlayTrigger>
+        <Icon icon={icon} tooltip={iconTooltip} tooltipPlacement="right" />
       </td>
       <td className={device.hasNameAlias ? '' : 'text-monospace'}>
         <Link to={`/devices/${device.id}/edit`}>{device.name}</Link>
       </td>
       <td>{lastEvent}</td>
       <td>
-        <OverlayTrigger
-          placement="left"
-          delay={{ show: 150, hide: 400 }}
-          overlay={<Tooltip id={`tooltip-remove-button-${index}`}>Remove from group</Tooltip>}
-        >
-          <Button
-            as="i"
-            variant="danger"
-            className="fas fa-times"
-            onClick={() => showModal(device)}
-          />
-        </OverlayTrigger>
+        <Icon
+          icon="delete"
+          as="button"
+          tooltip="Remove from group"
+          tooltipPlacement="left"
+          onClick={() => showModal(device)}
+        />
       </td>
     </tr>
   );

--- a/src/react/HomePage.tsx
+++ b/src/react/HomePage.tsx
@@ -25,6 +25,7 @@ import { ConnectedDevicesChart } from 'astarte-charts/react';
 import { useConfig } from './ConfigManager';
 import { useAstarte } from './AstarteManager';
 import useFetch from './hooks/useFetch';
+import Icon from './components/Icon';
 import WaitForData from './components/WaitForData';
 
 type ServiceStatus = 'loading' | 'ok' | 'err';
@@ -46,14 +47,14 @@ const ServiceStatusRow = ({ service, status }: ServiceStatusRowProps): React.Rea
   } else if (status === 'ok') {
     messageCell = (
       <td className="color-green">
-        <i className="fas fa-check-circle mr-1" />
+        <Icon icon="statusOK" className="mr-1" />
         This service is operating normally
       </td>
     );
   } else {
     messageCell = (
       <td className="color-red">
-        <i className="fas fa-times-circle mr-1" />
+        <Icon icon="statusKO" className="mr-1" />
         This service appears offline
       </td>
     );
@@ -161,7 +162,7 @@ const InterfaceList = ({
               onInterfaceClick(e, interfaceName);
             }}
           >
-            <i className="fas fa-stream mr-1" />
+            <Icon icon="interfaces" className="mr-1" />
             {interfaceName}
           </a>
         </li>
@@ -243,7 +244,7 @@ const TriggerList = ({ triggers, maxShownTriggers }: TriggerListProps): React.Re
       {shownTriggers.map((triggerName) => (
         <li key={triggerName} className="my-1">
           <Link to={`/triggers/${triggerName}/edit`}>
-            <i className="fas fa-bolt mr-1" />
+            <Icon icon="triggers" className="mr-1" />
             {triggerName}
           </Link>
         </li>

--- a/src/react/InterfacesPage.tsx
+++ b/src/react/InterfacesPage.tsx
@@ -19,6 +19,7 @@ import _ from 'lodash';
 
 import { useAstarte } from './AstarteManager';
 import Empty from './components/Empty';
+import Icon from './components/Icon';
 import WaitForData from './components/WaitForData';
 import useFetch from './hooks/useFetch';
 import useInterval from './hooks/useInterval';
@@ -34,7 +35,7 @@ const InterfaceRow = ({ name, majors }: InterfaceRowProps): React.ReactElement =
       <Row>
         <Col>
           <Link to={`/interfaces/${name}/${Math.max(...majors)}/edit`}>
-            <i className="fas fa-stream mr-2" />
+            <Icon icon="interfaces" className="mr-2" />
             {name}
           </Link>
         </Col>
@@ -109,7 +110,7 @@ export default (): React.ReactElement => {
           <ListGroup>
             <ListGroup.Item>
               <Button variant="link" className="p-0" onClick={() => navigate('/interfaces/new')}>
-                <i className="fas fa-plus mr-2" />
+                <Icon icon="add" className="mr-2" />
                 Install a new interface...
               </Button>
             </ListGroup.Item>

--- a/src/react/NewGroupPage.tsx
+++ b/src/react/NewGroupPage.tsx
@@ -24,6 +24,7 @@ import type { AstarteDevice } from 'astarte-client';
 import { useAlerts } from './AlertManager';
 import { useAstarte } from './AstarteManager';
 import Empty from './components/Empty';
+import Icon from './components/Icon';
 import WaitForData from './components/WaitForData';
 import useFetch from './hooks/useFetch';
 import SingleCardPage from './ui/SingleCardPage';
@@ -72,7 +73,7 @@ const FilterInputBox = ({ filter, onFilterChange }: FilterInputBoxProps): React.
     <InputGroup>
       <InputGroup.Prepend>
         <InputGroup.Text>
-          <i className="fas fa-filter" />
+          <Icon icon="filter" />
         </InputGroup.Text>
       </InputGroup.Prepend>
       <Form.Control

--- a/src/react/RegisterDevicePage.tsx
+++ b/src/react/RegisterDevicePage.tsx
@@ -24,6 +24,7 @@ import { v4 as uuidv4, v5 as uuidv5 } from 'uuid';
 import { Button, Col, Form, Spinner, Table } from 'react-bootstrap';
 import type { AstarteDevice, AstarteInterfaceDescriptor } from 'astarte-client';
 
+import Icon from './components/Icon';
 import ConfirmModal from './components/modals/Confirm';
 import FormModal from './components/modals/Form';
 import SingleCardPage from './ui/SingleCardPage';
@@ -76,7 +77,7 @@ const InterfaceIntrospectionRow = ({
     <td>{interfaceDescriptor.major}</td>
     <td>{interfaceDescriptor.minor}</td>
     <td>
-      <i className="fas fa-eraser color-red action-icon" onClick={onRemove} />
+      <Icon icon="erase" onClick={onRemove} />
     </td>
   </tr>
 );
@@ -400,7 +401,7 @@ export default (): React.ReactElement => {
             <code id="secret-code" className="m-1 p-2 bg-light" style={{ fontSize: '1.2em' }}>
               {deviceSecret}
             </code>
-            <i className="fas fa-paste" onClick={pasteSecret} style={{ cursor: 'copy' }} />
+            <Icon icon="copyPaste" onClick={pasteSecret} style={{ cursor: 'copy' }} />
           </pre>
           <span>
             Please don&apos;t share the Credentials Secret, and ensure it is transferred securely to

--- a/src/react/Sidebar.tsx
+++ b/src/react/Sidebar.tsx
@@ -20,6 +20,8 @@ import React, { useMemo } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Nav, NavItem, NavLink } from 'react-bootstrap';
 
+import Icon from './components/Icon';
+
 interface SidebarApiStatusProps {
   healthy: boolean;
   realm: React.ReactNode;
@@ -35,7 +37,7 @@ const SidebarApiStatus = ({ healthy, realm }: SidebarApiStatusProps) => (
       <b>API Status</b>
     </div>
     <p className="my-1">
-      <i className={`fas fa-circle mr-2 ${healthy ? 'color-green' : 'color-red'}`} />
+      <Icon icon={healthy ? 'statusConnected' : 'statusDisconnected'} className="mr-2" />
       {healthy ? 'Up and running' : 'Degraded'}
     </p>
   </NavItem>
@@ -48,7 +50,7 @@ const SidebarBrand = () => (
 );
 
 interface SidebarItemProps {
-  icon: string;
+  icon: React.ComponentProps<typeof Icon>['icon'];
   label: string;
   link: string;
 }
@@ -65,7 +67,7 @@ const SidebarItem = ({ icon, label, link }: SidebarItemProps) => {
 
   return (
     <NavLink as={Link} to={link} active={isSelected}>
-      <i className={`fas fa-${icon} mr-2`} />
+      <Icon icon={icon} className="mr-2" />
       {label}
     </NavLink>
   );

--- a/src/react/TriggersPage.tsx
+++ b/src/react/TriggersPage.tsx
@@ -22,6 +22,7 @@ import { Button, Col, Container, ListGroup, Row, Spinner } from 'react-bootstrap
 
 import { useAstarte } from './AstarteManager';
 import Empty from './components/Empty';
+import Icon from './components/Icon';
 import WaitForData from './components/WaitForData';
 import useFetch from './hooks/useFetch';
 import useInterval from './hooks/useInterval';
@@ -34,7 +35,7 @@ interface TriggerRowProps {
 const TriggerRow = ({ name, onClick }: TriggerRowProps): React.ReactElement => (
   <ListGroup.Item>
     <Button variant="link" className="p-0" onClick={onClick}>
-      <i className="fas fa-bolt mr-2" />
+      <Icon icon="triggers" className="mr-2" />
       {name}
     </Button>
   </ListGroup.Item>
@@ -83,7 +84,7 @@ export default (): React.ReactElement => {
                   navigate('/triggers/new');
                 }}
               >
-                <i className="fas fa-plus mr-2" />
+                <Icon icon="add" className="mr-2" />
                 Install a new trigger...
               </Button>
             </ListGroup.Item>

--- a/src/react/components/Icon.tsx
+++ b/src/react/components/Icon.tsx
@@ -1,0 +1,107 @@
+/*
+   This file is part of Astarte.
+
+   Copyright 2021 Ispirata Srl
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import React from 'react';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+
+const iconToClassName = {
+  add: 'fas fa-plus',
+  arrowLeft: 'fas fa-chevron-left',
+  blocks: 'fas fa-shapes',
+  copyPaste: 'fas fa-paste',
+  delete: 'fas fa-times',
+  devices: 'fas fa-cube',
+  documentation: 'fa fa-book',
+  edit: 'fas fa-pencil-alt',
+  erase: 'fas fa-eraser',
+  filter: 'fas fa-filter',
+  flows: 'fas fa-wind',
+  groups: 'fas fa-object-group',
+  home: 'fas fa-home',
+  interfaces: 'fas fa-stream',
+  logout: 'fas fa-sign-out-alt',
+  pipelines: 'fas fa-code-branch',
+  settings: 'fas fa-cog',
+  statusOK: 'fas fa-check-circle color-green',
+  statusConnected: 'fas fa-circle color-green',
+  statusDisconnected: 'fas fa-circle color-red',
+  statusKO: 'fas fa-times-circle color-red',
+  statusNeverConnected: 'fas fa-circle color-grey',
+  triggers: 'fas fa-bolt',
+};
+
+type Icon = keyof typeof iconToClassName;
+
+const dangerIcons: Icon[] = ['delete', 'erase'];
+
+interface Props {
+  as?: 'default' | 'button';
+  className?: string;
+  icon: Icon;
+  onClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+  style?: React.CSSProperties;
+  tooltip?: string;
+  tooltipPlacement?: React.ComponentProps<typeof OverlayTrigger>['placement'];
+}
+
+export default ({
+  as = 'default',
+  className,
+  icon,
+  onClick,
+  style = {},
+  tooltip,
+  tooltipPlacement,
+}: Props): React.ReactElement => {
+  const iconStyle = { ...style };
+  const iconClassNames: string[] = [];
+  iconClassNames.push(iconToClassName[icon]);
+
+  if (onClick) {
+    iconStyle.cursor = 'pointer';
+  }
+  if (as === 'button') {
+    iconClassNames.push('btn');
+  }
+  if (dangerIcons.includes(icon)) {
+    if (iconClassNames.includes('btn')) {
+      iconClassNames.push('btn-danger');
+    } else {
+      iconClassNames.push('color-red');
+    }
+  }
+  if (className) {
+    iconClassNames.push(className);
+  }
+
+  const iconElement = (
+    <i className={iconClassNames.join(' ')} style={iconStyle} onClick={onClick} />
+  );
+
+  return tooltip ? (
+    <OverlayTrigger
+      delay={{ show: 150, hide: 400 }}
+      overlay={<Tooltip id="tooltip">{tooltip}</Tooltip>}
+      placement={tooltipPlacement}
+    >
+      {iconElement}
+    </OverlayTrigger>
+  ) : (
+    iconElement
+  );
+};

--- a/src/react/components/InterfaceEditor.tsx
+++ b/src/react/components/InterfaceEditor.tsx
@@ -32,6 +32,7 @@ import {
 import { AstarteInterface, AstarteMapping } from 'astarte-client';
 import _ from 'lodash';
 
+import Icon from './Icon';
 import MappingEditor from './MappingEditor';
 
 interface FormControlWarningProps {
@@ -939,7 +940,7 @@ export default ({
                     className="btn accordion-button w-100 mb-2"
                     onClick={handleAddMapping}
                   >
-                    <i className="fas fa-plus mr-2" /> Add new mapping...
+                    <Icon icon="add" className="mr-2" /> Add new mapping...
                   </button>
                   {interfaceDraft.mappings.map((mapping, index) => {
                     const isExistingMapping = (initialData?.mappings || []).some(

--- a/src/react/components/NativeBlockWidget.tsx
+++ b/src/react/components/NativeBlockWidget.tsx
@@ -19,6 +19,7 @@
 import React from 'react';
 import { DefaultPortLabel, DiagramEngine } from '@projectstorm/react-diagrams';
 
+import Icon from './Icon';
 import NativeBlockModel from '../models/NativeBlockModel';
 
 interface Props {
@@ -43,7 +44,7 @@ const NativeBlockWidget = ({ engine, node, hasSettings }: Props): React.ReactEle
         <div className="node-title">{name}</div>
         {hasSettings && (
           <div className="settings-icon" onClick={(e) => node.onSettingsClick(e, node)}>
-            <i className="fas fa-cog" />
+            <Icon icon="settings" />
           </div>
         )}
       </div>

--- a/src/react/components/TriggerEditor/TriggerActionForm.tsx
+++ b/src/react/components/TriggerEditor/TriggerActionForm.tsx
@@ -21,6 +21,8 @@ import { Button, Col, Form, InputGroup, Table } from 'react-bootstrap';
 import { AstarteTrigger, AstarteTriggerHTTPAction, AstarteTriggerAMQPAction } from 'astarte-client';
 import _ from 'lodash';
 
+import Icon from '../Icon';
+
 const defaultTriggerHttpAction: AstarteTriggerHTTPAction = {
   httpUrl: '',
   httpMethod: 'post',
@@ -298,7 +300,7 @@ const TriggerActionForm = ({
               <Form.Group controlId="actionHttpHeaders">
                 {!isReadOnly && (
                   <Button variant="link" className="p-0" onClick={() => onAddHttpHeader()}>
-                    <i className="fas fa-plus mr-2" />
+                    <Icon icon="add" className="mr-2" />
                     Add custom HTTP headers
                   </Button>
                 )}
@@ -318,14 +320,12 @@ const TriggerActionForm = ({
                           <td>{headerValue as string}</td>
                           {!isReadOnly && (
                             <td className="text-center">
-                              <i
-                                className="fas fa-pencil-alt color-grey action-icon mr-2"
+                              <Icon
+                                icon="edit"
                                 onClick={() => onEditHttpHeader(headerName)}
+                                className="color-grey mr-2"
                               />
-                              <i
-                                className="fas fa-eraser color-red action-icon"
-                                onClick={() => onRemoveHttpHeader(headerName)}
-                              />
+                              <Icon icon="erase" onClick={() => onRemoveHttpHeader(headerName)} />
                             </td>
                           )}
                         </tr>
@@ -454,7 +454,7 @@ const TriggerActionForm = ({
               <Form.Group controlId="actionAmqpHeaders">
                 {!isReadOnly && (
                   <Button variant="link" className="p-0" onClick={() => onAddAmqpHeader()}>
-                    <i className="fas fa-plus mr-2" />
+                    <Icon icon="add" className="mr-2" />
                     Add static AMQP headers
                   </Button>
                 )}
@@ -474,14 +474,12 @@ const TriggerActionForm = ({
                           <td>{headerValue as string}</td>
                           {!isReadOnly && (
                             <td className="text-center">
-                              <i
-                                className="fas fa-pencil-alt color-grey action-icon mr-2"
+                              <Icon
+                                icon="edit"
                                 onClick={() => onEditAmqpHeader(headerName)}
+                                className="color-grey mr-2"
                               />
-                              <i
-                                className="fas fa-eraser color-red action-icon"
-                                onClick={() => onRemoveAmqpHeader(headerName)}
-                              />
+                              <Icon icon="erase" onClick={() => onRemoveAmqpHeader(headerName)} />
                             </td>
                           )}
                         </tr>

--- a/src/react/ui/BackButton.tsx
+++ b/src/react/ui/BackButton.tsx
@@ -19,14 +19,16 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
+import Icon from '../components/Icon';
+
 interface Props {
   href: string;
 }
 
 export default function BackButton({ href }: Props): React.ReactElement {
   return (
-    <Link to={href} className="align-bottom mr-2" aria-label="Back">
-      <i className="fas fa-chevron-left align-text-bottom" />
+    <Link to={href} className="mr-2" aria-label="Back">
+      <Icon icon="arrowLeft" />
     </Link>
   );
 }

--- a/src/react/ui/SingleCardPage.tsx
+++ b/src/react/ui/SingleCardPage.tsx
@@ -18,7 +18,9 @@
 
 import React from 'react';
 import { Container } from 'react-bootstrap';
+
 import BackButton from './BackButton';
+import Icon from '../components/Icon';
 
 interface Props {
   backLink?: string;
@@ -43,7 +45,7 @@ export default function SingleCardPage({
         {docsLink && (
           <div className="float-right">
             <a target="_blank" rel="noreferrer" href={docsLink}>
-              <i className="fa fa-book mr-2" />
+              <Icon icon="documentation" className="mr-2" />
               Documentation
             </a>
           </div>

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -57,10 +57,6 @@ $fa-font-path: '../../../node_modules/@fortawesome/fontawesome-free/webfonts';
 
 // Custom components
 
-$connected-color: $green;
-$disconnected-color: $red;
-$never-connected-color: $grey;
-
 h1,
 h2,
 h3,
@@ -255,18 +251,6 @@ h6,
   background-color: rgba(0, 0, 0, 0.03);
   color: $primary;
   text-align: left;
-}
-
-.icon-connected {
-  color: $connected-color;
-}
-
-.icon-disconnected {
-  color: $disconnected-color;
-}
-
-.icon-never-connected {
-  color: $never-connected-color;
 }
 
 .device-data-piechart {


### PR DESCRIPTION
This PR adds a reusable Icon component to improve icon usage:
- details about FontAwesome are extracted away from the codebase
- a well-defined list of icons is now available and type-checked with Typescript
- a single clear way to use Tooltips on icons is provided
