### PR TITLE
Fix Eslint linting warnings

### DIFF
--- a/src/AstarteManager.tsx
+++ b/src/AstarteManager.tsx
@@ -99,7 +99,7 @@ type AstarteContextValue = {
   logout: () => void;
 };
 
-const AstarteContext: React.Context<AstarteContextValue> = createContext(null) as any;
+const AstarteContext = createContext<AstarteContextValue | null>(null);
 
 interface AstarteProviderProps {
   children: React.ReactNode;
@@ -166,7 +166,13 @@ const AstarteProvider = ({
   );
 };
 
-const useAstarte = (): AstarteContextValue => useContext(AstarteContext);
+const useAstarte = (): AstarteContextValue => {
+  const contextValue = useContext(AstarteContext);
+  if (contextValue == null) {
+    throw new Error('AstarteContext has not been Provided');
+  }
+  return contextValue;
+};
 
 export { useAstarte };
 

--- a/src/ConfigManager.tsx
+++ b/src/ConfigManager.tsx
@@ -47,7 +47,7 @@ type ConfigContextValue = {
   };
 };
 
-const ConfigContext: React.Context<ConfigContextValue> = createContext(null) as any;
+const ConfigContext = createContext<ConfigContextValue | null>(null);
 
 interface ConfigProviderProps {
   children: React.ReactNode;
@@ -98,7 +98,13 @@ const ConfigProvider = ({
   );
 };
 
-const useConfig = (): ConfigContextValue => useContext(ConfigContext);
+const useConfig = (): ConfigContextValue => {
+  const contextValue = useContext(ConfigContext);
+  if (contextValue == null) {
+    throw new Error('ConfigContext has not been Provided');
+  }
+  return contextValue;
+};
 
 export { useConfig };
 

--- a/src/DeviceStatusPage/DeviceLiveEventsCard.tsx
+++ b/src/DeviceStatusPage/DeviceLiveEventsCard.tsx
@@ -75,7 +75,7 @@ function watchDeviceEvents({
           on: 'device_connected',
           device_id: deviceId,
         },
-      };
+      } as const;
 
       const disconnectionTriggerPayload = {
         name: `disconnectiontrigger-${deviceId}`,
@@ -85,7 +85,7 @@ function watchDeviceEvents({
           on: 'device_disconnected',
           device_id: deviceId,
         },
-      };
+      } as const;
 
       const errorTriggerPayload = {
         name: `errortrigger-${deviceId}`,
@@ -95,7 +95,7 @@ function watchDeviceEvents({
           on: 'device_error',
           device_id: deviceId,
         },
-      };
+      } as const;
 
       const dataTriggerPayload = {
         name: `datatrigger-${deviceId}`,
@@ -107,7 +107,7 @@ function watchDeviceEvents({
           value_match_operator: '*',
           match_path: '/*',
         },
-      };
+      } as const;
 
       astarte
         .registerVolatileTrigger(roomName, connectionTriggerPayload)

--- a/src/DeviceStatusPage/PreviousInterfacesCard.tsx
+++ b/src/DeviceStatusPage/PreviousInterfacesCard.tsx
@@ -1,7 +1,7 @@
 /*
    This file is part of Astarte.
 
-   Copyright 2020 Ispirata Srl
+   Copyright 2020-2021 Ispirata Srl
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -22,11 +22,13 @@ import { Card, Table } from 'react-bootstrap';
 import type { AstarteDevice, AstarteDeviceInterfaceStats } from 'astarte-client';
 import FullHeightCard from '../components/FullHeightCard';
 
-interface PreviousInterfacesTable {
+interface PreviousInterfacesTableProps {
   interfaces: AstarteDeviceInterfaceStats[];
 }
 
-const PreviousInterfacesTable = ({ interfaces }: PreviousInterfacesTable): React.ReactElement => (
+const PreviousInterfacesTable = ({
+  interfaces,
+}: PreviousInterfacesTableProps): React.ReactElement => (
   <Table responsive>
     <thead>
       <tr>

--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -372,7 +372,7 @@ export default (): React.ReactElement => {
           />
         </Col>
         <WaitForData data={devicesStats.value} status={devicesStats.status}>
-          {({ connected_devices: connectedDevices, total_devices: totalDevices }) => (
+          {({ connectedDevices, totalDevices }) => (
             <Col xs={6} className={cellSpacingClass}>
               <DevicesCard
                 connectedDevices={connectedDevices}

--- a/src/NewPipelinePage.tsx
+++ b/src/NewPipelinePage.tsx
@@ -1,7 +1,7 @@
 /*
    This file is part of Astarte.
 
-   Copyright 2020 Ispirata Srl
+   Copyright 2020-2021 Ispirata Srl
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -134,7 +134,7 @@ export default (): React.ReactElement => {
   }, [schemaObject, ajv]);
 
   const blockSettingsClickHandler = useCallback(
-    (e, node: NativeBlockModel) => {
+    (node: NativeBlockModel) => {
       const blockDefinition = blocks.find(
         (block) => node.name === block.name && node.blockType === block.type,
       );

--- a/src/astarte-charts/providers/connectedDevices.ts
+++ b/src/astarte-charts/providers/connectedDevices.ts
@@ -38,11 +38,11 @@ const generateConnectedDevicesProvider = (
       return {
         data: {
           connected: {
-            value: Number(devicesStats.connected_devices),
+            value: Number(devicesStats.connectedDevices),
             type: 'integer',
           },
           disconnected: {
-            value: Number(devicesStats.total_devices - devicesStats.connected_devices),
+            value: Number(devicesStats.totalDevices - devicesStats.connectedDevices),
             type: 'integer',
           },
         },

--- a/src/astarte-client/models/Flow/index.ts
+++ b/src/astarte-client/models/Flow/index.ts
@@ -23,9 +23,7 @@ export class AstarteFlow {
 
   pipeline: string;
 
-  config?: {
-    [key: string]: any;
-  };
+  config?: Record<string, unknown>;
 
   constructor(flow: AstarteFlowDTO) {
     this.name = flow.name;

--- a/src/astarte-client/models/Pipeline/index.ts
+++ b/src/astarte-client/models/Pipeline/index.ts
@@ -23,9 +23,7 @@ export class AstartePipeline {
 
   description: string;
 
-  schema: {
-    [key: string]: any;
-  };
+  schema: Record<string, unknown>;
 
   source: string;
 

--- a/src/astarte-client/transforms/device.ts
+++ b/src/astarte-client/transforms/device.ts
@@ -19,12 +19,14 @@ import { AstarteDevice } from '../models/Device';
 import type { AstarteDeviceInterfaceStats } from '../models/Device';
 import type { AstarteDeviceDTO } from '../types';
 
-const fromInterfaceStatsDTO = (iface: any): AstarteDeviceInterfaceStats => ({
+const fromInterfaceStatsDTO = (
+  iface: NonNullable<AstarteDeviceDTO['previous_interfaces']>[number],
+): AstarteDeviceInterfaceStats => ({
   name: iface.name,
   major: iface.major,
   minor: iface.minor,
-  exchangedMessages: iface.exchanged_msgs,
-  exchangedBytes: iface.exchanged_bytes,
+  exchangedMessages: iface.exchanged_msgs || 0,
+  exchangedBytes: iface.exchanged_bytes || 0,
 });
 
 const toInterfaceStatsDTO = (iface: AstarteDeviceInterfaceStats) => ({

--- a/src/astarte-client/types/dto/index.ts
+++ b/src/astarte-client/types/dto/index.ts
@@ -25,6 +25,7 @@ export type { AstartePipelineDTO } from './pipeline.d';
 export type { AstarteMappingDTO } from './mapping.d';
 export type { AstarteInterfaceDTO } from './interface.d';
 export type {
+  AstarteTransientTriggerDTO,
   AstarteTriggerDTO,
   AstarteTriggerHTTPActionDTO,
   AstarteTriggerAMQPActionDTO,

--- a/src/astarte-client/types/dto/trigger.d.ts
+++ b/src/astarte-client/types/dto/trigger.d.ts
@@ -72,4 +72,16 @@ interface AstarteTriggerDTO {
   simple_triggers: AstarteSimpleTriggerDTO[];
 }
 
-export { AstarteTriggerDTO, AstarteTriggerHTTPActionDTO, AstarteTriggerAMQPActionDTO };
+interface AstarteTransientTriggerDTO {
+  name: string;
+  device_id?: string;
+  group_name?: string;
+  simple_trigger: AstarteSimpleTriggerDTO;
+}
+
+export {
+  AstarteTransientTriggerDTO,
+  AstarteTriggerDTO,
+  AstarteTriggerHTTPActionDTO,
+  AstarteTriggerAMQPActionDTO,
+};

--- a/src/astarte-client/types/events/AstarteDeviceDisconnectedEvent.ts
+++ b/src/astarte-client/types/events/AstarteDeviceDisconnectedEvent.ts
@@ -1,7 +1,7 @@
 /*
   This file is part of Astarte.
 
-  Copyright 2020 Ispirata Srl
+  Copyright 2020-2021 Ispirata Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,19 +17,29 @@
 */
 
 import _ from 'lodash';
-import { AstarteDeviceEvent } from './AstarteDeviceEvent';
+import * as yup from 'yup';
+
+import { AstarteDeviceEvent, AstarteDeviceEventDTO } from './AstarteDeviceEvent';
+
+type AstarteDeviceDisconnectedEventDTO = AstarteDeviceEventDTO & {
+  event: {
+    type: 'device_disconnected';
+  };
+};
+
+const validationSchema: yup.ObjectSchema<AstarteDeviceDisconnectedEventDTO['event']> = yup
+  .object({
+    type: yup.string().oneOf(['device_disconnected']).required(),
+  })
+  .required();
 
 export class AstarteDeviceDisconnectedEvent extends AstarteDeviceEvent {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private constructor(arg: any) {
+  private constructor(arg: unknown) {
     super(arg);
-    if (!arg.event || !_.isPlainObject(arg.event) || arg.event.type !== 'device_disconnected') {
-      throw new Error('Invalid event');
-    }
+    validationSchema.validateSync(_.get(arg, 'event'));
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  static fromJSON(arg: any): AstarteDeviceDisconnectedEvent {
+  static fromJSON(arg: unknown): AstarteDeviceDisconnectedEvent {
     return new AstarteDeviceDisconnectedEvent(arg);
   }
 }

--- a/src/astarte-client/types/events/index.ts
+++ b/src/astarte-client/types/events/index.ts
@@ -1,7 +1,7 @@
 /*
   This file is part of Astarte.
 
-  Copyright 2020 Ispirata Srl
+  Copyright 2020-2021 Ispirata Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,8 +23,7 @@ import { AstarteDeviceErrorEvent } from './AstarteDeviceErrorEvent';
 import { AstarteDeviceIncomingDataEvent } from './AstarteDeviceIncomingDataEvent';
 import { AstarteDeviceUnsetPropertyEvent } from './AstarteDeviceUnsetPropertyEvent';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function decodeEvent(arg: any): AstarteDeviceEvent | null {
+function decodeEvent(arg: unknown): AstarteDeviceEvent | null {
   return decodeAnyOf(
     [
       AstarteDeviceConnectedEvent.fromJSON,
@@ -37,11 +36,9 @@ function decodeEvent(arg: any): AstarteDeviceEvent | null {
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type EventDecoder = (arg: any) => AstarteDeviceEvent;
+type EventDecoder = (arg: unknown) => AstarteDeviceEvent;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function decodeAnyOf(decoders: EventDecoder[], value: any): AstarteDeviceEvent | null {
+function decodeAnyOf(decoders: EventDecoder[], value: unknown): AstarteDeviceEvent | null {
   let decodedValue = null;
 
   for (let i = 0; i < decoders.length && decodedValue === null; i += 1) {

--- a/src/components/InterfaceEditor.tsx
+++ b/src/components/InterfaceEditor.tsx
@@ -361,10 +361,10 @@ export default ({
   const [mappingToEditIndex, setMappingToEditIndex] = useState(0);
 
   const parseAstarteInterfaceJSON = useCallback(
-    (json: any): AstarteInterface | null => {
+    (json: unknown): AstarteInterface | null => {
       let parsedInterface: AstarteInterface;
       try {
-        parsedInterface = AstarteInterface.fromJSON(json);
+        parsedInterface = AstarteInterface.fromJSON(json as any);
       } catch {
         throw new Error('Invalid interface');
       }

--- a/src/components/NativeBlockFactory.tsx
+++ b/src/components/NativeBlockFactory.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Astarte.
 
-  Copyright 2020 Ispirata Srl
+  Copyright 2020-2021 Ispirata Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ type GenerateModelEvent = Parameters<AbstractReactFactory['generateModel']>['0']
   name: AstarteBlock['name'];
   type: AstarteBlock['type'];
   onRemoveClick?: (node: NativeBlockModel) => void;
-  onSettingsClick?: (...args: any[]) => void;
+  onSettingsClick?: (node: NativeBlockModel) => void;
 };
 
 class NativeBlockFactory extends AbstractReactFactory<BaseModel, DiagramEngine> {

--- a/src/components/NativeBlockWidget.tsx
+++ b/src/components/NativeBlockWidget.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Astarte.
 
-  Copyright 2020 Ispirata Srl
+  Copyright 2020-2021 Ispirata Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ const NativeBlockWidget = ({ engine, node, hasSettings }: Props): React.ReactEle
         <div className="node-title">{name}</div>
         <div className="node-header-icons">
           {hasSettings && (
-            <div className="node-header-icon" onClick={(e) => node.onSettingsClick(e, node)}>
+            <div className="node-header-icon" onClick={() => node.onSettingsClick(node)}>
               <Icon icon="settings" />
             </div>
           )}

--- a/src/components/VisualFlowEditor.tsx
+++ b/src/components/VisualFlowEditor.tsx
@@ -33,11 +33,11 @@ const filterSortBlocks = (blocks: AstarteBlock[], type: AstarteBlock['type']) =>
     .sort((block1, block2) => (block1.name > block2.name ? 1 : -1));
 };
 
-interface BlockMenuItem {
+interface BlockMenuItemProps {
   block: AstarteBlock;
 }
 
-const BlockMenuItem = ({ block }: BlockMenuItem) => (
+const BlockMenuItem = ({ block }: BlockMenuItemProps) => (
   <div
     className={`block-item ${block.type}`}
     onDragStart={(e) => {

--- a/src/components/VisualFlowEditor.tsx
+++ b/src/components/VisualFlowEditor.tsx
@@ -1,7 +1,7 @@
 /*
   This file is part of Astarte.
 
-  Copyright 2020 Ispirata Srl
+  Copyright 2020-2021 Ispirata Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ interface VisualFlowEditorProps {
   className?: string;
   blocks: AstarteBlock[];
   model: DiagramModel;
-  onNodeSettingsClick?: (...args: any[]) => void;
+  onNodeSettingsClick?: (node: NativeBlockModel) => void;
 }
 
 const VisualFlowEditor = ({

--- a/src/components/WaitForData.ts
+++ b/src/components/WaitForData.ts
@@ -1,7 +1,7 @@
 /*
    This file is part of Astarte.
 
-   Copyright 2020 Ispirata Srl
+   Copyright 2020-2021 Ispirata Srl
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ interface Props<Data> {
   children: (data: Data) => React.ReactElement;
 }
 
-const WaitForData = <Data = any>({
+const WaitForData = <Data = unknown>({
   data,
   status,
   showRefreshing = false,

--- a/src/components/modals/Form.tsx
+++ b/src/components/modals/Form.tsx
@@ -1,7 +1,7 @@
 /*
    This file is part of Astarte.
 
-   Copyright 2020 Ispirata Srl
+   Copyright 2020-2021 Ispirata Srl
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import { Button, Form, Modal, Spinner } from 'react-bootstrap';
 import type { ModalProps } from 'react-bootstrap';
 import metaSchemaDraft04 from 'ajv/lib/refs/json-schema-draft-04.json';
 import JsonSchemaForm from '@rjsf/bootstrap-4';
-import type { WidgetProps } from '@rjsf/core';
+import type { WidgetProps, IChangeEvent } from '@rjsf/core';
 import type { ComponentProps } from 'react';
 
 const additionalMetaSchemas = [metaSchemaDraft04];
@@ -78,7 +78,7 @@ const TextWidget = ({
         <datalist id={`examples_${id}`}>
           {(schema.examples as string[])
             .concat(schema.default ? ([schema.default] as string[]) : [])
-            .map((example: any) => (
+            .map((example) => (
               // eslint-disable-next-line jsx-a11y/control-has-associated-label
               <option key={example} value={example} />
             ))}
@@ -115,7 +115,7 @@ interface Props {
   isConfirming?: boolean;
   liveValidate?: boolean;
   onCancel: () => void;
-  onConfirm: (formData: any) => void;
+  onConfirm: (formData: IChangeEvent['formData']) => void;
   schema: JsonSchemaFormProps['schema'];
   size?: ModalProps['size'];
   title: React.ReactNode;

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -1,7 +1,7 @@
 /*
    This file is part of Astarte.
 
-   Copyright 2020 Ispirata Srl
+   Copyright 2020-2021 Ispirata Srl
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 type Status = 'loading' | 'ok' | 'err';
 
-type FetchState<Data, FetchParams extends any[]> =
+type FetchState<Data, FetchParams extends unknown[]> =
   | {
       status: 'loading';
       value: Data | null;
@@ -40,7 +40,7 @@ type FetchState<Data, FetchParams extends any[]> =
       refresh: (...params: FetchParams) => Promise<void>;
     };
 
-const useFetch = <Data = any, FetchParams extends any[] = any[]>(
+const useFetch = <Data = unknown, FetchParams extends unknown[] = unknown[]>(
   fetchData: (...params: FetchParams) => Promise<Data>,
   ...initialFetchParams: FetchParams
 ): FetchState<Data, FetchParams> => {

--- a/src/models/NativeBlockModel.ts
+++ b/src/models/NativeBlockModel.ts
@@ -1,7 +1,7 @@
 /*
   This file is part of Astarte.
 
-  Copyright 2020 Ispirata Srl
+  Copyright 2020-2021 Ispirata Srl
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -33,13 +33,13 @@ function isEmptyValue(value: unknown): boolean {
   return !value;
 }
 
-function encodeValue(value: unknown): any {
+function encodeValue(value: unknown): string {
   if (Array.isArray(value)) {
-    const encodedValues: any[] = value.map((v) => encodeValue(v));
+    const encodedValues = value.map((v) => encodeValue(v));
     return `[${encodedValues.join(',')}]`;
   }
   if (typeof value === 'object' && value != null) {
-    const encodedValues: any[] = Object.entries(value).map(
+    const encodedValues = Object.entries(value).map(
       ([key, innerValue]) => `${key}: ${encodeValue(innerValue)}`,
     );
     return `{${encodedValues.join(',')}}`;
@@ -47,14 +47,14 @@ function encodeValue(value: unknown): any {
   if (typeof value === 'string') {
     return `"${value}"`;
   }
-  return value;
+  return `${value}`;
 }
 
 interface NativeBlockModelConfig {
   name: AstarteBlock['name'];
   blockType: AstarteBlock['type'];
   onRemoveClick?: (node: NativeBlockModel) => void;
-  onSettingsClick?: (...args: any[]) => void;
+  onSettingsClick?: (node: NativeBlockModel) => void;
 }
 
 class NativeBlockModel extends NodeModel {
@@ -64,7 +64,7 @@ class NativeBlockModel extends NodeModel {
 
   onRemoveClick: (node: NativeBlockModel) => void;
 
-  onSettingsClick: (...args: any[]) => void;
+  onSettingsClick: (node: NativeBlockModel) => void;
 
   properties: Record<string, unknown>;
 

--- a/src/types/dashboardConfig.ts
+++ b/src/types/dashboardConfig.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /*
    This file is part of Astarte.
 


### PR DESCRIPTION
Here are some changes to avoid warnings about:
- variables typed as `any`, where a more specific type should be used instead
- redeclared expressions
- third-party objects with non-camelcase properties
