### PR TITLE
Fix Blocks sidebar menu overflowing Pipeline Editor

### DIFF
--- a/src/static/styles/flow-editor.scss
+++ b/src/static/styles/flow-editor.scss
@@ -28,12 +28,14 @@ $block-radius: 5px;
   height: 40em;
   display: flex;
   min-height: 100%;
+  max-height: 60vh;
 
   .flow-editor-sidebar {
     display: flex;
     flex-direction: column;
     padding: 0.5em;
     border-right: 1px solid lightgrey;
+    overflow-y: auto;
 
     .block-label {
       margin-top: 1em;


### PR DESCRIPTION
Fix overflow issue with the Blocks sidebar menu inside the Pipeline Editor that was not contained within the page boundaries.

Pipeline Editor before:

![Screenshot from 2021-04-07 17-57-42](https://user-images.githubusercontent.com/60540759/113904881-d3f66a00-97d2-11eb-88a4-2eea77e8e161.png)

Pipeline Editor after:

![Screenshot from 2021-04-07 18-52-05](https://user-images.githubusercontent.com/60540759/113904907-d9ec4b00-97d2-11eb-805b-df7f1f2cc111.png)
