### PR TITLE
Force Astarte values to string during render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - Unreleased
+### Fixed
+- Visualization of boolean mappings in the device values page.
+
 ## [1.0.0] - 2021-06-30
 
 ## [1.0.0-rc.0] - 2021-05-05

--- a/src/react/DeviceInterfaceValues.jsx
+++ b/src/react/DeviceInterfaceValues.jsx
@@ -175,7 +175,7 @@ const IndividualDatastreamTable = ({ data }) => {
 const IndividualDatastreamRow = ({ path, value, timestamp }) => (
   <tr>
     <td>{path}</td>
-    <td>{value}</td>
+    <td>{value.toString()}</td>
     <td>{new Date(timestamp).toLocaleString()}</td>
   </tr>
 );


### PR DESCRIPTION
Values like booleans are not converted to string
when rendered in a react node
Fix #320

Signed-off-by: Mattia <mattia.pavinati@secomind.com>