### PR TITLE
Update version number to 1.0.1 and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ For example, to run it locally on port 4040, you can use the following command:
 docker run \
   -p 4040:80 \
   -v /absolute/path/to/config.json:/usr/share/nginx/html/user-config/config.json \
-  astarte/astarte-dashboard:1.0.0-beta.1
+  astarte/astarte-dashboard:1.0-snapshot
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astarte-dashboard",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Astarte dashboard",
   "main": "dist/index.html",
   "keywords": [


### PR DESCRIPTION
- Bump version number to 1.0.1, which will be the next release.
- README.md: s/1.0.0-beta.1/snapshot-1.0/g.https://github.com/bettio/astarte-dashboard/pull/new/prepare-next-dev-cycle