### PR TITLE
Fix crash while parsing values of an Astarte interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - Unreleased
+## Fixed
+- Fix crash while displaying values of an Astarte interface.
+
 ## [1.0.4] - 2022-10-24
 
 ## [1.0.3] - 2022-07-04

--- a/src/react/DeviceInterfaceValues.jsx
+++ b/src/react/DeviceInterfaceValues.jsx
@@ -77,6 +77,22 @@ function linearizePathTree(path, data, timestamp) {
   return [];
 }
 
+function formatAstarteValue(value) {
+  if (value == null) {
+    return '';
+  }
+  if (_.isArray(value)) {
+    return JSON.stringify(value);
+  }
+  if (_.isBoolean(value)) {
+    return value ? 'true' : 'false';
+  }
+  if (_.isNumber(value)) {
+    return value.toString();
+  }
+  return String(value);
+}
+
 const DeviceInterfaceValues = ({ astarte, deviceId, interfaceName }) => {
   const [interfaceType, setInterfaceType] = useState(null);
   const deviceData = useFetch(() =>
@@ -181,6 +197,10 @@ const PropertyTree = ({ data }) => (
 const IndividualDatastreamTable = ({ data }) => {
   const paths = linearizePathTree('', data);
 
+  if (paths.length === 0) {
+    return <p>No data sent by the device.</p>;
+  }
+
   return (
     <Table responsive>
       <thead>
@@ -202,7 +222,7 @@ const IndividualDatastreamTable = ({ data }) => {
 const IndividualDatastreamRow = ({ path, value, timestamp }) => (
   <tr>
     <td>{path}</td>
-    <td>{value.toString()}</td>
+    <td>{formatAstarteValue(value)}</td>
     <td>{new Date(timestamp).toLocaleString()}</td>
   </tr>
 );
@@ -220,7 +240,7 @@ const ObjectDatastreamTable = ({ path, values }) => {
   return (
     <>
       <h5 className="mb-1">Path</h5>
-      <p>{path}</p>
+      <p>{path || '/'}</p>
       <Table responsive>
         <thead>
           <tr>
@@ -243,7 +263,7 @@ const ObjectDatastreamTable = ({ path, values }) => {
 const ObjectDatastreamRow = ({ labels, obj }) => (
   <tr>
     {labels.map((label) => (
-      <td key={label}>{obj[label]}</td>
+      <td key={label}>{formatAstarteValue(obj[label])}</td>
     ))}
     <td>{new Date(obj.timestamp).toLocaleString()}</td>
   </tr>


### PR DESCRIPTION
When opening the page to display interface values for a certain device, the app crashes for some kind of data, such as datastream object.

The PR updates the data parsing logic to perform more precise parsing so that object datastream values are correctly handled on each interface path.
