### PR TITLE
Fix duplicate devices on filter change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.5] - Unreleased
 ## Fixed
 - Fix crash while displaying values of an Astarte interface.
+- Fix duplicate items on device list when changing search filters
+([#341](https://github.com/astarte-platform/astarte-dashboard/issues/341)).
 
 ## [1.0.4] - 2022-10-24
 


### PR DESCRIPTION
On the Devices page, changing the filter settings would trigger a series of queries to fetch all devices not already loaded when the page is first opened.
However, when the user keeps changing the filters then duplicate series of queries are triggered and would load duplicate devices in parallel.

This PR fixes the issue by ensuring that the queries to fetch all remaining devices are only triggered once: when the filters are first changed.

Closes #341 
