### PR TITLE
Fix Cypress tests doing flaky checks on route redirection

### DIFF
--- a/cypress/integration/trigger_builder_test.js
+++ b/cypress/integration/trigger_builder_test.js
@@ -757,6 +757,7 @@ describe('Trigger builder tests', () => {
             .its('request.body.data')
             .should('deep.eq', trigger.data);
           cy.location('pathname').should('eq', '/triggers');
+          cy.get('[data-testid="triggers-page"]').should('be.visible');
           cy.get('h2').contains('Triggers');
         });
       });
@@ -810,6 +811,7 @@ describe('Trigger builder tests', () => {
         });
         cy.wait('@deleteTriggerRequest');
         cy.location('pathname').should('eq', '/triggers');
+        cy.get('[data-testid="triggers-page"]').should('be.visible');
         cy.get('h2').contains('Triggers');
       });
     });

--- a/src/react/TriggersPage.tsx
+++ b/src/react/TriggersPage.tsx
@@ -57,7 +57,7 @@ export default ({ astarte }: Props): React.ReactElement => {
   }, []);
 
   return (
-    <Container fluid className="p-3">
+    <Container fluid className="p-3" data-testid="triggers-page">
       <Row>
         <Col>
           <h2>Triggers</h2>


### PR DESCRIPTION
During a Cypress tests that involves a change of route, i.e. redirecting the user to another page, the check for successful redirection is performed as `cy.get('h2').contains(newPageTitle)`. Such a check is bound to fail since `cy.get('h2')` instantly selects the page title before the router has a chance to actually conclude the route change; then the check `.contains(newPageTitle)` times out since the old title is selected.

The issue is fixed by adding a unique `data-testid` DOM attribute to the page and expecting that ID to become visible before attempting to select the title of the page.
