### PR TITLE
Fix Cypress tests on Blocks that have flaky assertions

### DIFF
--- a/cypress/integration/blocks_page_test.js
+++ b/cypress/integration/blocks_page_test.js
@@ -35,7 +35,7 @@ describe('Blocks page tests', () => {
     it('displays the list of blocks', function () {
       cy.get('.main-content').within(() => {
         this.blocks.data.forEach((block) => {
-          cy.get('.card button').contains(block.name);
+          cy.get(`.card[data-testid="${block.name}"]`).get('button').contains(block.name);
         });
       });
     });
@@ -43,16 +43,13 @@ describe('Blocks page tests', () => {
     it("native blocks have a Native badge, custom blocks don't", function () {
       cy.get('.main-content').within(() => {
         this.blocks.data.forEach((block) => {
-          cy.get('.card button')
-            .contains(block.name)
-            .parents('.card')
-            .within(() => {
-              if (block.beam_module) {
-                cy.get('.badge').contains('native');
-              } else {
-                cy.get('.badge').should('not.exist');
-              }
-            });
+          cy.get(`.card[data-testid="${block.name}"]`).within(() => {
+            if (block.beam_module) {
+              cy.get('.badge').contains('native');
+            } else {
+              cy.get('.badge').should('not.exist');
+            }
+          });
         });
       });
     });

--- a/src/react/BlocksPage.tsx
+++ b/src/react/BlocksPage.tsx
@@ -109,7 +109,7 @@ interface BlockCardProps {
 
 function BlockCard({ block, onShow }: BlockCardProps) {
   return (
-    <Card className="mb-4">
+    <Card className="mb-4" data-testid={block.name}>
       <Card.Header as="h5" className="d-flex justify-content-between align-items-center">
         <Button variant="link" className="p-0" onClick={onShow}>
           {block.name}


### PR DESCRIPTION
The tests select all `<button />`s inside cards, and then check if one of them contains the name of the expected block.
However, if the block list is still being fetched, the selection logic will resolve right away with the static card that contains the button to create new blocks; the tests will then fail.

The issue is solved by adding a unique `data-testid` DOM attribute to the card of each block, so that it can be easily and precisely selected by Cypress.
