### PR TITLE
Support for referencing trigger policies in a Trigger

### DIFF
--- a/src/NewTriggerPage.tsx
+++ b/src/NewTriggerPage.tsx
@@ -80,6 +80,7 @@ export default (): React.ReactElement => {
           onChange={handleTriggerChange}
           onError={handleTriggerEditorError}
           isSourceVisible={isSourceVisible}
+          fetchPoliciesName={astarte.client.getPolicyNames}
           fetchInterfacesName={astarte.client.getInterfaceNames}
           fetchInterfaceMajors={astarte.client.getInterfaceMajors}
           fetchInterface={astarte.client.getInterface}

--- a/src/TriggerPage.tsx
+++ b/src/TriggerPage.tsx
@@ -142,6 +142,7 @@ export default (): React.ReactElement => {
                 isReadOnly
                 onError={handleTriggerEditorError}
                 isSourceVisible={isSourceVisible}
+                fetchPoliciesName={astarte.client.getPolicyNames}
                 fetchInterfacesName={astarte.client.getInterfaceNames}
                 fetchInterfaceMajors={astarte.client.getInterfaceMajors}
                 fetchInterface={astarte.client.getInterface}

--- a/src/astarte-client/client.ts
+++ b/src/astarte-client/client.ts
@@ -323,12 +323,16 @@ class AstarteClient {
   }
 
   async getTrigger(triggerName: string): Promise<AstarteTrigger> {
-    const response = await this.$get(this.apiConfig.trigger({ ...this.config, triggerName }));
+    const encodedTriggerName = encodeURIComponent(triggerName);
+    const response = await this.$get(
+      this.apiConfig.trigger({ ...this.config, triggerName: encodedTriggerName }),
+    );
     return fromAstarteTriggerDTO(response.data);
   }
 
   async deleteTrigger(triggerName: string): Promise<void> {
-    await this.$delete(this.apiConfig.trigger({ ...this.config, triggerName }));
+    const encodedTriggerName = encodeURIComponent(triggerName);
+    await this.$delete(this.apiConfig.trigger({ ...this.config, triggerName: encodedTriggerName }));
   }
 
   async installTrigger(trigger: AstarteTrigger): Promise<void> {

--- a/src/astarte-client/client.ts
+++ b/src/astarte-client/client.ts
@@ -190,6 +190,7 @@ class AstarteClient {
     this.getFlowHealth = this.getFlowHealth.bind(this);
     this.getPipeline = this.getPipeline.bind(this);
     this.getPipelines = this.getPipelines.bind(this);
+    this.getPolicyNames = this.getPolicyNames.bind(this);
 
     // prettier-ignore
     this.apiConfig = {
@@ -200,7 +201,8 @@ class AstarteClient {
       interface:             astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/interfaces/${'interfaceName'}/${'interfaceMajor'}`,
       interfaceData:         astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/interfaces/${'interfaceName'}/${'interfaceMajor'}`,
       trigger:               astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/triggers/${'triggerName'}`,
-      triggers:              astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/triggers`,
+      triggers:              astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/triggers`, 
+      policies:              astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/policies`,
       appengineHealth:       astarteAPIurl`${config.appEngineApiUrl}health`,
       devicesStats:          astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/stats/devices`,
       devices:               astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/devices`,
@@ -259,6 +261,11 @@ class AstarteClient {
     await this.$put(this.apiConfig.auth(this.config), {
       jwt_public_key_pem: params.publicKey,
     });
+  }
+
+  async getPolicyNames(): Promise<string[]> {
+    const response = await this.$get(this.apiConfig.policies(this.config));
+    return response.data;
   }
 
   async getInterfaceNames(): Promise<string[]> {

--- a/src/astarte-client/models/Trigger/index.ts
+++ b/src/astarte-client/models/Trigger/index.ts
@@ -80,6 +80,7 @@ interface AstarteTriggerObject {
   name: string;
   action: AstarteTriggerHTTPActionObject | AstarteTriggerAMQPActionObject;
   simpleTriggers: AstarteSimpleTriggerObject[];
+  policy?: string;
 }
 
 const reservedHttpHeaders = [
@@ -357,6 +358,7 @@ const astarteTriggerObjectSchema: yup.ObjectSchema<AstarteTriggerObject> = yup
     name: yup.string().required(),
     action: astarteTriggerActionObjectSchema,
     simpleTriggers: yup.array(astarteSimpleTriggerObjectSchema).required(),
+    policy: yup.string(),
   })
   .required();
 
@@ -373,11 +375,14 @@ class AstarteTrigger {
 
   simpleTriggers: AstarteSimpleTrigger[];
 
+  policy?: string;
+
   constructor(obj: AstarteTriggerObject) {
     const validatedObj = AstarteTrigger.validation.validateSync(obj, { abortEarly: false });
     this.name = validatedObj.name;
     this.action = validatedObj.action;
     this.simpleTriggers = validatedObj.simpleTriggers;
+    this.policy = validatedObj.policy;
   }
 
   static validation = astarteTriggerObjectSchema;

--- a/src/astarte-client/transforms/trigger.ts
+++ b/src/astarte-client/transforms/trigger.ts
@@ -73,6 +73,7 @@ export const fromAstarteTriggerDTO = (dto: AstarteTriggerDTO): AstarteTrigger =>
             knownValue: simpleTriggerDTO.known_value,
           },
     ),
+    policy: dto.policy,
   });
 };
 
@@ -122,5 +123,6 @@ export const toAstarteTriggerDTO = (trigger: AstarteTrigger): AstarteTriggerDTO 
             known_value: simpleTrigger.knownValue,
           },
     ),
+    policy: trigger.policy,
   };
 };

--- a/src/astarte-client/types/dto/trigger.d.ts
+++ b/src/astarte-client/types/dto/trigger.d.ts
@@ -70,6 +70,7 @@ interface AstarteTriggerDTO {
   name: string;
   action: AstarteTriggerHTTPActionDTO | AstarteTriggerAMQPActionDTO;
   simple_triggers: AstarteSimpleTriggerDTO[];
+  policy?: string;
 }
 
 interface AstarteTransientTriggerDTO {
@@ -77,6 +78,7 @@ interface AstarteTransientTriggerDTO {
   device_id?: string;
   group_name?: string;
   simple_trigger: AstarteSimpleTriggerDTO;
+  policy?: string;
 }
 
 export {


### PR DESCRIPTION
On Astarte Dashboard, added dropdown for Trigger delivery policy in a Trigger Editor.
In Trigger Editor added functionality for listing existing Trigger delivery policies and adding to a Trigger.
In Trigger Editor added functionality for referencing Trigger delivery policy to a Trigger.

Closes #369 
Fix #373 