### PR TITLE
Prepare 1.1.0-rc.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0-rc.0] - 2023-06-08
+### Added
+- Trigger Delivery Policy Editor to manage delivery policies for triggers
+([#365](https://github.com/astarte-platform/astarte-dashboard/issues/365)).
+
 ## [1.1.0-alpha.0] - 2022-11-24
 ### Added
 - Custom library to render graphic charts for data coming from Astarte.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astarte-dashboard",
-  "version": "1.1.0-alpha.0",
+  "version": "1.1.0-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "astarte-dashboard",
-      "version": "1.1.0-alpha.0",
+      "version": "1.1.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/core": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astarte-dashboard",
-  "version": "1.1.0-alpha.0",
+  "version": "1.1.0-rc.0",
   "description": "Astarte dashboard",
   "keywords": [
     "astarte",


### PR DESCRIPTION
Prepare codebase for the 1.1.0-rc.0 release.

- Bump the version in package.json to 1.1.0-rc.0
- Note down occurred changes for the release in CHANGELOG.md