### PR TITLE
Show error metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ([#375](https://github.com/astarte-platform/astarte-dashboard/issues/375))
 - Improve history navigation by replacing the browser's location.
 ([#385](https://github.com/astarte-platform/astarte-dashboard/issues/385))
+- Show error metadata in live events when AstarteDeviceErrorEvent is received.
+([#377](https://github.com/astarte-platform/astarte-dashboard/issues/377))
 
 ## [1.1.0] - 2023-06-20
 

--- a/src/DeviceStatusPage/DeviceLiveEventsCard.tsx
+++ b/src/DeviceStatusPage/DeviceLiveEventsCard.tsx
@@ -266,6 +266,18 @@ const astarteDeviceEventBody = (event: AstarteDeviceEvent) => {
           device error
         </Badge>
         <span>{deviceErrorNameToString(event.errorName)}</span>
+        {event.metadata && (
+          <>
+            <br />
+            <div style={{ paddingLeft: '6.3em' }}>
+              {Object.entries(event.metadata).map(([key, value]) => (
+                <span key={key}>
+                  {key}:<span className="text-secondary pl-2 pr-4">{value}</span>
+                </span>
+              ))}
+            </div>
+          </>
+        )}
       </>
     );
   }

--- a/src/astarte-client/types/events/AstarteDeviceErrorEvent.ts
+++ b/src/astarte-client/types/events/AstarteDeviceErrorEvent.ts
@@ -46,7 +46,7 @@ type AstarteDeviceErrorEventDTO = AstarteDeviceEventDTO & {
     type: 'device_error';
     // eslint-disable-next-line camelcase
     error_name: DeviceErrorName;
-    metadata: unknown;
+    metadata: Record<string, string> | null | undefined;
   };
 };
 
@@ -61,7 +61,7 @@ const validationSchema: yup.ObjectSchema<AstarteDeviceErrorEventDTO['event']> = 
 export class AstarteDeviceErrorEvent extends AstarteDeviceEvent {
   readonly errorName: DeviceErrorName;
 
-  readonly metadata: unknown;
+  readonly metadata: Record<string, string> | null | undefined;
 
   private constructor(arg: unknown) {
     super(arg);


### PR DESCRIPTION
- Show error metadata in live events when AstarteDeviceErrorEvent is received. 
- Documented the changes in CHANGELOG.md

Closes #377