### PR TITLE
Fix discarded trigger known value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.1.2] - Unreleased
+### Fixed
+- The known_value filter property for triggers is correctly considered when relevant.
+([#393](https://github.com/astarte-platform/astarte-dashboard/issues/393))
 
 ## [1.1.1] - 2023-11-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - Unreleased
+
 ## [1.1.1] - 2023-11-15
 ### Added
 - Revalidate token when dashboard is reloaded or opened from different tab.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astarte-dashboard",
-  "version": "1.1.1",
+  "version": "1.1.2-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "astarte-dashboard",
-      "version": "1.1.1",
+      "version": "1.1.2-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/core": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astarte-dashboard",
-  "version": "1.1.1",
+  "version": "1.1.2-dev",
   "description": "Astarte dashboard",
   "keywords": [
     "astarte",

--- a/src/astarte-client/models/Trigger/index.ts
+++ b/src/astarte-client/models/Trigger/index.ts
@@ -321,8 +321,11 @@ const astarteSimpleDataTriggerObjectSchema: yup.ObjectSchema<AstarteSimpleDataTr
           valueMatchOperator: string | undefined,
           iface: AstarteInterface | null,
         ) => {
-          if (!iface || !matchPath) {
+          if (!matchPath) {
             return yup.mixed<string | boolean | number>().strip(true);
+          }
+          if (!iface) {
+            return yup.mixed<string | boolean | number>();
           }
           const matchMapping = iface.mappings.find((m) =>
             AstarteMapping.matchEndpoint(m.endpoint, matchPath),


### PR DESCRIPTION
The `known_value` field was wrongly discarded by the trigger validation logic since the latter expects the interface definition as an additional argument when validating trigger fields that relate to the interface.
When the interface definition is not provided, the validation defaulted to discarding the `known_value` field.

The issue is fixed by not discarding the field in such cases where the exact field type cannot be retrieved. Instead, the field is just allowed to have several types: i.e. one JSON type between `number`, `string`, or `boolean`.