### PR TITLE
Fix data parsing on datastream object interfaces with parametric endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - The known_value filter property for triggers is correctly considered when relevant.
 ([#393](https://github.com/astarte-platform/astarte-dashboard/issues/393))
+- Correctly parse and display device data for datastream object interfaces with parametric endpoints.
+([#376](https://github.com/astarte-platform/astarte-dashboard/issues/376))
 
 ## [1.1.1] - 2023-11-15
 ### Added

--- a/cypress/integration/astarte_client.js
+++ b/cypress/integration/astarte_client.js
@@ -110,7 +110,7 @@ describe('Astarte-client tests', () => {
       cy.fixture(interfacePathValuesFixture).then((interfacePathValues) => {
         cy.intercept(
           'GET',
-          `/appengine/v1/*/devices/${deviceId}/interfaces/${interfaceName}${interfacePath}?keep_milliseconds=true&since=&since_after=&to=&limit=`,
+          `/appengine/v1/*/devices/${deviceId}/interfaces/${interfaceName}${interfacePath}?since=&since_after=&to=&limit=`,
           interfacePathValues,
         ).as('getDeviceDataRequest');
         cy.intercept('GET', `/realmmanagement/v1/*/interfaces/${interfaceName}/*`, {

--- a/src/astarte-client/client.test.ts
+++ b/src/astarte-client/client.test.ts
@@ -59,7 +59,7 @@ describe('AstarteClient', () => {
       }),
     );
     expect(axios.mock.calls[0][0].url.toString()).toBe(
-      `${appEngineApiUrl}v1/${realm}/devices/${deviceId}/interfaces/${interfaceName}?keep_milliseconds=true&since=&since_after=&to=&limit=`,
+      `${appEngineApiUrl}v1/${realm}/devices/${deviceId}/interfaces/${interfaceName}?since=&since_after=&to=&limit=`,
     );
     expect(fetcheData).toEqual(deviceData);
 
@@ -71,7 +71,7 @@ describe('AstarteClient', () => {
     await astarte.getDeviceData({ deviceId, interfaceName, path, since, sinceAfter, to, limit });
     expect(axios).toHaveBeenCalledTimes(2);
     expect(axios.mock.calls[1][0].url.toString()).toBe(
-      `${appEngineApiUrl}v1/${realm}/devices/${deviceId}/interfaces/${interfaceName}${path}?keep_milliseconds=true&since=${since}&since_after=${sinceAfter}&to=${to}&limit=${limit}`,
+      `${appEngineApiUrl}v1/${realm}/devices/${deviceId}/interfaces/${interfaceName}${path}?since=${since}&since_after=${sinceAfter}&to=${to}&limit=${limit}`,
     );
   });
 
@@ -135,7 +135,7 @@ describe('AstarteClient', () => {
     );
     // Third GET to fetch Device data
     expect(axios.mock.calls[2][0].url.toString()).toBe(
-      `${appEngineApiUrl}v1/${realm}/devices/${deviceId}/interfaces/${interfaceName}?keep_milliseconds=true&since=&since_after=&to=&limit=`,
+      `${appEngineApiUrl}v1/${realm}/devices/${deviceId}/interfaces/${interfaceName}?since=&since_after=&to=&limit=`,
     );
     expect(fetcheDataTree).toMatchObject({
       endpoint: '',

--- a/src/astarte-client/client.ts
+++ b/src/astarte-client/client.ts
@@ -210,7 +210,7 @@ class AstarteClient {
       devicesStats:          astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/stats/devices`,
       devices:               astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/devices`,
       deviceInfo:            astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/devices/${'deviceId'}`,
-      deviceData:            astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/devices/${'deviceId'}/interfaces/${'interfaceName'}${'path'}?keep_milliseconds=true&since=${'since'}&since_after=${'sinceAfter'}&to=${'to'}&limit=${'limit'}`,
+      deviceData:            astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/devices/${'deviceId'}/interfaces/${'interfaceName'}${'path'}?since=${'since'}&since_after=${'sinceAfter'}&to=${'to'}&limit=${'limit'}`,
       groups:                astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/groups`,
       groupDevices:          astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/groups/${'groupName'}/devices`,
       deviceInGroup:         astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/groups/${'groupName'}/devices/${'deviceId'}`,

--- a/src/astarte-client/types/interfaceValues.ts
+++ b/src/astarte-client/types/interfaceValues.ts
@@ -1,7 +1,7 @@
 /*
    This file is part of Astarte.
 
-   Copyright 2020 Ispirata Srl
+   Copyright 2020-24 SECO Mind Srl
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+   SPDX-License-Identifier: Apache-2.0
 */
 
 import type { AstarteDataValue } from './dataType';
@@ -34,12 +36,13 @@ export type AstarteIndividualDatastreamInterfaceValues =
         | AstarteIndividualDatastreamInterfaceValue;
     };
 
-export type AstarteAggregatedDatastreamInterfaceValue = Array<{
+export type AstarteAggregatedDatastreamInterfaceValue = {
   [key: string]: AstarteDataValue;
   timestamp: string;
-}>;
+};
 export type AstarteAggregatedDatastreamInterfaceValues =
   | AstarteAggregatedDatastreamInterfaceValue
+  | AstarteAggregatedDatastreamInterfaceValue[]
   | { [subPath: string]: AstarteAggregatedDatastreamInterfaceValues };
 
 export type AstarteInterfaceValues =


### PR DESCRIPTION
The parsing logic didn't properly support the shape of data the are returned when querying datastream object interfaces that have parametric endpoints.
This is because when the endpoints are parametric, instead of accessing the history of published objects for each endpoint, each endpoint key in the resulting data correspond to a single object, which is the latest snapshot of the values for that endpoint object.

The issue is solved by recognizing both arrays and single instances of object values, which are the objects in the resulting data that contain a `timestamp` key besides the other value keys.

With this change, we also make sure that the timestamps returned by Appengine are indeed of type string as expected: the 'keep_milliseconds' query option is thus removed from API calls to Appengine.

Closes #376