### PR TITLE
Update Bootstrap from v4 to v5

### DIFF
--- a/cypress/e2e/interface_builder.cy.js
+++ b/cypress/e2e/interface_builder.cy.js
@@ -561,7 +561,7 @@ describe('Interface builder tests', () => {
         cy.get('#interfaceName').clear().paste('name');
         cy.get('#interfaceName').should('not.have.class', 'is-invalid');
         cy.get('#interfaceName')
-          .parents('.form-group')
+          .parents()
           .get('.warning-feedback')
           .should('be.visible')
           .and('not.empty');
@@ -570,7 +570,7 @@ describe('Interface builder tests', () => {
         cy.get('#interfaceName').clear().paste('com.sample.Name');
         cy.get('#interfaceName').should('not.have.class', 'is-invalid');
         cy.get('#interfaceName')
-          .parents('.form-group')
+          .parents()
           .get('.warning-feedback')
           .should('not.exist');
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.2.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
+        "@astarte-platform/react-bootstrap": "^5.15.0",
         "@emotion/core": "^11.0.0",
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
@@ -16,7 +17,6 @@
         "@projectstorm/react-canvas-core": "^7.0.2",
         "@projectstorm/react-diagrams": "^7.0.3",
         "@reduxjs/toolkit": "^2.1.0",
-        "@rjsf/bootstrap-4": "^5.17.0",
         "@rjsf/core": "^5.17.0",
         "@rjsf/validator-ajv8": "^5.17.0",
         "@testing-library/react": "^14.2.1",
@@ -35,7 +35,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "ajv": "^8.12.0",
         "axios": "^1.6.7",
-        "bootstrap": "^4.6.0",
+        "bootstrap": "^5.3.2",
         "chart.js": "^4.4.1",
         "closest": "^0.0.1",
         "color": "^4.2.3",
@@ -55,7 +55,7 @@
         "paths-js": "^0.4.11",
         "phoenix": "^1.7.11",
         "react": "^18.2.0",
-        "react-bootstrap": "^1.5.0",
+        "react-bootstrap": "^2.10.1",
         "react-chartjs-2": "^5.2.0",
         "react-datepicker": "^6.1.0",
         "react-dom": "^18.2.0",
@@ -96,6 +96,23 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@astarte-platform/react-bootstrap": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@astarte-platform/react-bootstrap/-/react-bootstrap-5.15.0.tgz",
+      "integrity": "sha512-+aladR1tYXTrIhfW7rP0fGFbqLW4LbeeD/apm0elnhBTLV4sqn171A1xlgq5dXqIKFM6nioyNCxZpbvuOGR9zw==",
+      "dependencies": {
+        "@react-icons/all-files": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@rjsf/core": "^5.12.x",
+        "@rjsf/utils": "^5.12.x",
+        "react": "^16.14.0 || >=17",
+        "react-bootstrap": "^2.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1962,11 +1979,11 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1980,6 +1997,11 @@
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.4"
       }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/@babel/template": {
       "version": "7.23.9",
@@ -3015,6 +3037,20 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.2.tgz",
+      "integrity": "sha512-0gKkgDYdnq1w+ey8KzG9l+H5Z821qh9vVjztk55rUg71vTk/Eaebeir+WtzcLLwTjw3m/asIjx8Y59y1lJZhBw==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
     "node_modules/@react-icons/all-files": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@react-icons/all-files/-/all-files-4.1.0.tgz",
@@ -3054,18 +3090,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@restart/context": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
-      "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q==",
-      "peerDependencies": {
-        "react": ">=16.3.2"
-      }
-    },
     "node_modules/@restart/hooks": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.15.tgz",
-      "integrity": "sha512-cZFXYTxbpzYcieq/mBwSyXgqnGMHoBVh3J7MU0CCoIB4NRZxV9/TuwTBAaLMqpNhC3zTPMCgkQ5Ey07L02Xmcw==",
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
+      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
       "dependencies": {
         "dequal": "^2.0.3"
       },
@@ -3073,21 +3101,32 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@rjsf/bootstrap-4": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/bootstrap-4/-/bootstrap-4-5.17.0.tgz",
-      "integrity": "sha512-JrwfZv5R+nC0gpfRC83VbWfemOMsM94dAuRUJZGUMg9IeQnSXH4hxoKXkypRUpJjpkNCi52YQhJKyo1ALgf6pg==",
+    "node_modules/@restart/ui": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.6.6.tgz",
+      "integrity": "sha512-eC3puKuWE1SRYbojWHXnvCNHGgf3uzHCb6JOhnF4OXPibOIPEkR1sqDSkL643ydigxwh+ruCa1CmYHlzk7ikKA==",
       "dependencies": {
-        "@react-icons/all-files": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=14"
+        "@babel/runtime": "^7.21.0",
+        "@popperjs/core": "^2.11.6",
+        "@react-aria/ssr": "^3.5.0",
+        "@restart/hooks": "^0.4.9",
+        "@types/warning": "^3.0.0",
+        "dequal": "^2.0.3",
+        "dom-helpers": "^5.2.0",
+        "uncontrollable": "^8.0.1",
+        "warning": "^4.0.3"
       },
       "peerDependencies": {
-        "@rjsf/core": "^5.16.x",
-        "@rjsf/utils": "^5.16.x",
-        "react": "^16.14.0 || >=17",
-        "react-bootstrap": "^1.6.5"
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      }
+    },
+    "node_modules/@restart/ui/node_modules/uncontrollable": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
+      "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
+      "peerDependencies": {
+        "react": ">=16.14.0"
       }
     },
     "node_modules/@rjsf/core": {
@@ -3317,6 +3356,14 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.6.tgz",
+      "integrity": "sha512-aYX01Ke9hunpoCexYAgQucEpARGQ5w/cqHFrIR+e9gdKb1QWTsVJuTJ2ozQzIAxLyRQe/m+2RqzkyOOGiMKRQA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "9.3.4",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
@@ -3516,11 +3563,6 @@
         "hoist-non-react-statics": "^3.3.0"
       }
     },
-    "node_modules/@types/invariant": {
-      "version": "2.2.34",
-      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.34.tgz",
-      "integrity": "sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg=="
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -3622,9 +3664,9 @@
       }
     },
     "node_modules/@types/react-transition-group": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.1.tgz",
-      "integrity": "sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
+      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -4683,16 +4725,21 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
-      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.2.tgz",
+      "integrity": "sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
       "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/brace-expansion": {
@@ -7614,12 +7661,6 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
-    "node_modules/jquery": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
-      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
-      "peer": true
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8794,17 +8835,6 @@
         "pathe": "^1.1.0"
       }
     },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8982,31 +9012,32 @@
       }
     },
     "node_modules/react-bootstrap": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.6.8.tgz",
-      "integrity": "sha512-yD6uN78XlFOkETQp6GRuVe0s5509x3XYx8PfPbirwFTYCj5/RfmSs9YZGCwkUrhZNFzj7tZPdpb+3k50mK1E4g==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.1.tgz",
+      "integrity": "sha512-J3OpRZIvCTQK+Tg/jOkRUvpYLHMdGeU9KqFUBQrV0d/Qr/3nsINpiOJyZMWnM5SJ3ctZdhPA6eCIKpEJR3Ellg==",
       "dependencies": {
-        "@babel/runtime": "^7.14.0",
-        "@restart/context": "^2.1.4",
-        "@restart/hooks": "^0.4.7",
-        "@types/invariant": "^2.2.33",
-        "@types/prop-types": "^15.7.3",
-        "@types/react": ">=16.14.8",
-        "@types/react-transition-group": "^4.4.1",
-        "@types/warning": "^3.0.0",
-        "classnames": "^2.3.1",
+        "@babel/runtime": "^7.22.5",
+        "@restart/hooks": "^0.4.9",
+        "@restart/ui": "^1.6.6",
+        "@types/react-transition-group": "^4.4.6",
+        "classnames": "^2.3.2",
         "dom-helpers": "^5.2.1",
         "invariant": "^2.2.4",
-        "prop-types": "^15.7.2",
+        "prop-types": "^15.8.1",
         "prop-types-extra": "^1.1.0",
-        "react-overlays": "^5.1.2",
-        "react-transition-group": "^4.4.1",
+        "react-transition-group": "^4.4.5",
         "uncontrollable": "^7.2.1",
         "warning": "^4.0.3"
       },
       "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "@types/react": ">=16.14.8",
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-chartjs-2": {
@@ -9081,25 +9112,6 @@
       "peerDependencies": {
         "react": "^15.5.x || ^16.x || ^17.x || ^18.x",
         "react-dom": "^15.5.x || ^16.x || ^17.x || ^18.x"
-      }
-    },
-    "node_modules/react-overlays": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
-      "integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.8",
-        "@popperjs/core": "^2.11.6",
-        "@restart/hooks": "^0.4.7",
-        "@types/warning": "^3.0.0",
-        "dom-helpers": "^5.2.0",
-        "prop-types": "^15.7.2",
-        "uncontrollable": "^7.2.1",
-        "warning": "^4.0.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
       }
     },
     "node_modules/react-popper": {
@@ -10097,10 +10109,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-      "dev": true
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -11199,6 +11210,14 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@astarte-platform/react-bootstrap": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@astarte-platform/react-bootstrap/-/react-bootstrap-5.15.0.tgz",
+      "integrity": "sha512-+aladR1tYXTrIhfW7rP0fGFbqLW4LbeeD/apm0elnhBTLV4sqn171A1xlgq5dXqIKFM6nioyNCxZpbvuOGR9zw==",
+      "requires": {
+        "@react-icons/all-files": "^4.1.0"
       }
     },
     "@babel/code-frame": {
@@ -12426,11 +12445,18 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
       "requires": {
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.14.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+          "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+        }
       }
     },
     "@babel/runtime-corejs3": {
@@ -13147,6 +13173,14 @@
         "react": "^18.2.0"
       }
     },
+    "@react-aria/ssr": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.2.tgz",
+      "integrity": "sha512-0gKkgDYdnq1w+ey8KzG9l+H5Z821qh9vVjztk55rUg71vTk/Eaebeir+WtzcLLwTjw3m/asIjx8Y59y1lJZhBw==",
+      "requires": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
     "@react-icons/all-files": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@react-icons/all-files/-/all-files-4.1.0.tgz",
@@ -13169,26 +13203,36 @@
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.0.tgz",
       "integrity": "sha512-HOil5aFtme37dVQTB6M34G95kPM3MMuqSmIRVCC52eKV+Y/tGSqw9P3rWhlAx6A+mz+MoX+XxsGsNJbaI5qCgQ=="
     },
-    "@restart/context": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
-      "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q==",
-      "requires": {}
-    },
     "@restart/hooks": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.15.tgz",
-      "integrity": "sha512-cZFXYTxbpzYcieq/mBwSyXgqnGMHoBVh3J7MU0CCoIB4NRZxV9/TuwTBAaLMqpNhC3zTPMCgkQ5Ey07L02Xmcw==",
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
+      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
       "requires": {
         "dequal": "^2.0.3"
       }
     },
-    "@rjsf/bootstrap-4": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/bootstrap-4/-/bootstrap-4-5.17.0.tgz",
-      "integrity": "sha512-JrwfZv5R+nC0gpfRC83VbWfemOMsM94dAuRUJZGUMg9IeQnSXH4hxoKXkypRUpJjpkNCi52YQhJKyo1ALgf6pg==",
+    "@restart/ui": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.6.6.tgz",
+      "integrity": "sha512-eC3puKuWE1SRYbojWHXnvCNHGgf3uzHCb6JOhnF4OXPibOIPEkR1sqDSkL643ydigxwh+ruCa1CmYHlzk7ikKA==",
       "requires": {
-        "@react-icons/all-files": "^4.1.0"
+        "@babel/runtime": "^7.21.0",
+        "@popperjs/core": "^2.11.6",
+        "@react-aria/ssr": "^3.5.0",
+        "@restart/hooks": "^0.4.9",
+        "@types/warning": "^3.0.0",
+        "dequal": "^2.0.3",
+        "dom-helpers": "^5.2.0",
+        "uncontrollable": "^8.0.1",
+        "warning": "^4.0.3"
+      },
+      "dependencies": {
+        "uncontrollable": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
+          "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
+          "requires": {}
+        }
       }
     },
     "@rjsf/core": {
@@ -13322,6 +13366,14 @@
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
+    },
+    "@swc/helpers": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.6.tgz",
+      "integrity": "sha512-aYX01Ke9hunpoCexYAgQucEpARGQ5w/cqHFrIR+e9gdKb1QWTsVJuTJ2ozQzIAxLyRQe/m+2RqzkyOOGiMKRQA==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
     },
     "@testing-library/dom": {
       "version": "9.3.4",
@@ -13487,11 +13539,6 @@
         "hoist-non-react-statics": "^3.3.0"
       }
     },
-    "@types/invariant": {
-      "version": "2.2.34",
-      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.34.tgz",
-      "integrity": "sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg=="
-    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -13595,9 +13642,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.1.tgz",
-      "integrity": "sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
+      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
       "requires": {
         "@types/react": "*"
       }
@@ -14340,9 +14387,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
-      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.2.tgz",
+      "integrity": "sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==",
       "requires": {}
     },
     "brace-expansion": {
@@ -16450,12 +16497,6 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
-    "jquery": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
-      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
-      "peer": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -17319,12 +17360,6 @@
         "pathe": "^1.1.0"
       }
     },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "peer": true
-    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -17447,25 +17482,20 @@
       }
     },
     "react-bootstrap": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.6.8.tgz",
-      "integrity": "sha512-yD6uN78XlFOkETQp6GRuVe0s5509x3XYx8PfPbirwFTYCj5/RfmSs9YZGCwkUrhZNFzj7tZPdpb+3k50mK1E4g==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.1.tgz",
+      "integrity": "sha512-J3OpRZIvCTQK+Tg/jOkRUvpYLHMdGeU9KqFUBQrV0d/Qr/3nsINpiOJyZMWnM5SJ3ctZdhPA6eCIKpEJR3Ellg==",
       "requires": {
-        "@babel/runtime": "^7.14.0",
-        "@restart/context": "^2.1.4",
-        "@restart/hooks": "^0.4.7",
-        "@types/invariant": "^2.2.33",
-        "@types/prop-types": "^15.7.3",
-        "@types/react": ">=16.14.8",
-        "@types/react-transition-group": "^4.4.1",
-        "@types/warning": "^3.0.0",
-        "classnames": "^2.3.1",
+        "@babel/runtime": "^7.22.5",
+        "@restart/hooks": "^0.4.9",
+        "@restart/ui": "^1.6.6",
+        "@types/react-transition-group": "^4.4.6",
+        "classnames": "^2.3.2",
         "dom-helpers": "^5.2.1",
         "invariant": "^2.2.4",
-        "prop-types": "^15.7.2",
+        "prop-types": "^15.8.1",
         "prop-types-extra": "^1.1.0",
-        "react-overlays": "^5.1.2",
-        "react-transition-group": "^4.4.1",
+        "react-transition-group": "^4.4.5",
         "uncontrollable": "^7.2.1",
         "warning": "^4.0.3"
       }
@@ -17524,21 +17554,6 @@
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz",
       "integrity": "sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==",
       "requires": {}
-    },
-    "react-overlays": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
-      "integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
-      "requires": {
-        "@babel/runtime": "^7.13.8",
-        "@popperjs/core": "^2.11.6",
-        "@restart/hooks": "^0.4.7",
-        "@types/warning": "^3.0.0",
-        "dom-helpers": "^5.2.0",
-        "prop-types": "^15.7.2",
-        "uncontrollable": "^7.2.1",
-        "warning": "^4.0.3"
-      }
     },
     "react-popper": {
       "version": "2.3.0",
@@ -18290,10 +18305,9 @@
       }
     },
     "tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-      "dev": true
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "prettier": "^3.2.5"
   },
   "dependencies": {
+    "@astarte-platform/react-bootstrap": "^5.15.0",
     "@emotion/core": "^11.0.0",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
@@ -51,7 +52,6 @@
     "@projectstorm/react-canvas-core": "^7.0.2",
     "@projectstorm/react-diagrams": "^7.0.3",
     "@reduxjs/toolkit": "^2.1.0",
-    "@rjsf/bootstrap-4": "^5.17.0",
     "@rjsf/core": "^5.17.0",
     "@rjsf/validator-ajv8": "^5.17.0",
     "@testing-library/react": "^14.2.1",
@@ -70,7 +70,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "ajv": "^8.12.0",
     "axios": "^1.6.7",
-    "bootstrap": "^4.6.0",
+    "bootstrap": "^5.3.2",
     "chart.js": "^4.4.1",
     "closest": "^0.0.1",
     "color": "^4.2.3",
@@ -90,7 +90,7 @@
     "paths-js": "^0.4.11",
     "phoenix": "^1.7.11",
     "react": "^18.2.0",
-    "react-bootstrap": "^1.5.0",
+    "react-bootstrap": "^2.10.1",
     "react-chartjs-2": "^5.2.0",
     "react-datepicker": "^6.1.0",
     "react-dom": "^18.2.0",

--- a/src/AlertManager.tsx
+++ b/src/AlertManager.tsx
@@ -221,7 +221,7 @@ const AlertBanner = ({ alert }: AlertBannerProps) => {
         className="d-flex justify-content-between flex-wrap"
       >
         {alert.message}
-        <div className="col text-right">{alertRelativeTime}</div>
+        <div className="col text-end">{alertRelativeTime}</div>
       </Alert>
     </Col>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,7 +77,7 @@ const Dashboard = () => {
   return (
     <ReduxProvider store={reduxStore}>
       <Container fluid className="px-0">
-        <Row className="no-gutters">
+        <Row className="g-0">
           <DashboardSidebar />
           <Col className="main-content vh-100 overflow-auto">
             <PageRouter />
@@ -90,7 +90,7 @@ const Dashboard = () => {
 
 const StandaloneEditor = () => (
   <Container fluid className="px-0">
-    <Row className="no-gutters">
+    <Row className="g-0">
       <Col id="main-navbar" className="col-auto nav-col">
         <Sidebar>
           <Sidebar.Brand />

--- a/src/BlockSourcePage.tsx
+++ b/src/BlockSourcePage.tsx
@@ -114,7 +114,7 @@ export default (): React.ReactElement => {
             disabled={isDeletingBlock}
           >
             {isDeletingBlock && (
-              <Spinner as="span" size="sm" animation="border" role="status" className="mr-2" />
+              <Spinner as="span" size="sm" animation="border" role="status" className="me-2" />
             )}
             Delete block
           </Button>

--- a/src/BlocksPage.tsx
+++ b/src/BlocksPage.tsx
@@ -18,7 +18,7 @@
 
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Badge, Button, Card, CardDeck, Container, Spinner } from 'react-bootstrap';
+import { Badge, Button, Card, Col, Container, Row, Spinner } from 'react-bootstrap';
 import { AstarteNativeBlock } from 'astarte-client';
 import type { AstarteBlock } from 'astarte-client';
 
@@ -32,13 +32,15 @@ interface NewBlockCardProps {
 
 function NewBlockCard({ onCreate }: NewBlockCardProps) {
   return (
-    <Card className="mb-4">
+    <Card className="mb-4 h-100">
       <Card.Header as="h5">New Block</Card.Header>
-      <Card.Body>
+      <Card.Body className="d-flex flex-column">
         <Card.Text>Create your custom block</Card.Text>
-        <Button variant="secondary" onClick={onCreate}>
-          Create
-        </Button>
+        <div className="mt-auto d-flex flex-column flex-md-row">
+          <Button variant="secondary" onClick={onCreate}>
+            Create
+          </Button>
+        </div>
       </Card.Body>
     </Card>
   );
@@ -57,22 +59,24 @@ interface BlockCardProps {
 
 function BlockCard({ block, onShow }: BlockCardProps) {
   return (
-    <Card className="mb-4" data-testid={block.name}>
+    <Card className="mb-4 h-100" data-testid={block.name}>
       <Card.Header as="h5" className="d-flex justify-content-between align-items-center">
         <Button variant="link" className="p-0" onClick={onShow}>
           {block.name}
         </Button>
         {block instanceof AstarteNativeBlock && (
-          <Badge variant="secondary" className="h6 text-light">
+          <Badge bg="secondary" className="h6 text-light">
             native
           </Badge>
         )}
       </Card.Header>
-      <Card.Body>
+      <Card.Body className="d-flex flex-column">
         <Card.Text>{blockTypeToLabel[block.type]}</Card.Text>
-        <Button variant="primary" onClick={onShow}>
-          Show
-        </Button>
+        <div className="mt-auto d-flex flex-column flex-md-row">
+          <Button variant="primary" onClick={onShow}>
+            Show
+          </Button>
+        </div>
       </Card.Body>
     </Card>
   );
@@ -91,8 +95,10 @@ export default (): React.ReactElement => {
   return (
     <Container fluid className="p-3">
       <h2>Blocks</h2>
-      <CardDeck className="mt-4">
-        <NewBlockCard onCreate={() => navigate('/blocks/new')} />
+      <Row xs={1} lg={2} xxl={3} className="mt-4 g-4">
+        <Col>
+          <NewBlockCard onCreate={() => navigate('/blocks/new')} />
+        </Col>
         <WaitForData
           data={blocksData}
           status={blocksStatus}
@@ -110,19 +116,15 @@ export default (): React.ReactElement => {
         >
           {(blocks) => (
             <>
-              {blocks.map((block, index) => (
-                <React.Fragment key={`fragment-${index}`}>
-                  {index % 2 ? <div className="w-100 d-none d-md-block" /> : null}
+              {blocks.map((block) => (
+                <Col key={block.name}>
                   <BlockCard block={block} onShow={() => navigate(`/blocks/${block.name}/edit`)} />
-                  {index === blocks.length - 1 && blocks.length % 2 === 0 ? (
-                    <div className="w-50 d-none d-md-block" />
-                  ) : null}
-                </React.Fragment>
+                </Col>
               ))}
             </>
           )}
         </WaitForData>
-      </CardDeck>
+      </Row>
     </Container>
   );
 };

--- a/src/DeviceInterfaceValues.tsx
+++ b/src/DeviceInterfaceValues.tsx
@@ -202,7 +202,7 @@ export default (): React.ReactElement => {
       </h2>
       <Card className="mt-4">
         <Card.Header>
-          <span className="text-monospace">{deviceId}</span> /{interfaceName}
+          <span className="font-monospace">{deviceId}</span> /{interfaceName}
         </Card.Header>
         <Card.Body>
           <WaitForData

--- a/src/DeviceStatusPage/AddToGroupModal.tsx
+++ b/src/DeviceStatusPage/AddToGroupModal.tsx
@@ -49,7 +49,7 @@ const AddToGroupModal = ({
               className={groupName === selectedGroup ? 'p-2 bg-success text-white' : 'p-2'}
             >
               <span onClick={() => setSelectedGroup(groupName)}>
-                <Icon icon="add" className="mr-2" />
+                <Icon icon="add" className="me-2" />
                 {groupName}
               </span>
             </li>
@@ -73,7 +73,7 @@ const AddToGroupModal = ({
           style={{ minWidth: '5em' }}
         >
           {isAddingToGroup && (
-            <Spinner className="mr-2" size="sm" animation="border" role="status" />
+            <Spinner className="me-2" size="sm" animation="border" role="status" />
           )}
           Add to group
         </Button>

--- a/src/DeviceStatusPage/AliasesCard.tsx
+++ b/src/DeviceStatusPage/AliasesCard.tsx
@@ -53,7 +53,7 @@ const AliasesTable = ({
           <td>{key}</td>
           <td>{value}</td>
           <td className="text-center">
-            <Icon icon="edit" className="color-grey mr-2" onClick={() => onEditAliasClick(key)} />
+            <Icon icon="edit" className="color-grey me-2" onClick={() => onEditAliasClick(key)} />
             <Icon icon="erase" onClick={() => onRemoveAliasClick({ key, value })} />
           </td>
         </tr>

--- a/src/DeviceStatusPage/AttributesCard.tsx
+++ b/src/DeviceStatusPage/AttributesCard.tsx
@@ -55,7 +55,7 @@ const AttributesTable = ({
           <td className="text-center">
             <Icon
               icon="edit"
-              className="color-grey mr-2"
+              className="color-grey me-2"
               onClick={() => onEditAttributeClick(key)}
             />
             <Icon icon="erase" onClick={() => onRemoveAttributeClick({ key, value })} />

--- a/src/DeviceStatusPage/DeviceInfoCard.tsx
+++ b/src/DeviceStatusPage/DeviceInfoCard.tsx
@@ -56,7 +56,7 @@ const DeviceStatus = ({ status }: DeviceStatusProps): React.ReactElement => {
 
   return (
     <>
-      <Icon icon={icon} className="mr-1" />
+      <Icon icon={icon} className="me-1" />
       <span>{statusString}</span>
     </>
   );
@@ -81,7 +81,7 @@ const DeviceInfoCard = ({
     <Card.Header as="h5">Device Info</Card.Header>
     <Card.Body className="d-flex flex-column">
       <h6>Device ID</h6>
-      <p className="text-monospace">{device.id}</p>
+      <p className="font-monospace">{device.id}</p>
       <h6>Device name</h6>
       <p>{device.hasNameAlias ? device.name : 'No name alias set'}</p>
       <h6>Status</h6>
@@ -94,7 +94,7 @@ const DeviceInfoCard = ({
         {device.hasCredentialsInhibited ? (
           <Button
             variant="success text-white"
-            className="mr-1"
+            className="me-1"
             onClick={onEnableCredentialsClick}
             disabled={device.deletionInProgress}
           >
@@ -103,7 +103,7 @@ const DeviceInfoCard = ({
         ) : (
           <Button
             variant="danger"
-            className="mr-1"
+            className="me-1"
             onClick={onInhibitCredentialsClick}
             disabled={device.deletionInProgress}
           >
@@ -119,7 +119,7 @@ const DeviceInfoCard = ({
         </Button>
         <Button
           variant="danger"
-          className="ml-1"
+          className="ms-1"
           onClick={onDeleteDeviceClick}
           disabled={device.deletionInProgress}
         >

--- a/src/DeviceStatusPage/DeviceLiveEventsCard.tsx
+++ b/src/DeviceStatusPage/DeviceLiveEventsCard.tsx
@@ -217,7 +217,7 @@ const astarteDeviceEventBody = (event: AstarteDeviceEvent) => {
   if (event instanceof AstarteDeviceConnectedEvent) {
     return (
       <>
-        <Badge variant="success" className="me-2">
+        <Badge bg="success" className="me-2">
           device connected
         </Badge>
         <span>IP : {event.ip}</span>
@@ -227,7 +227,7 @@ const astarteDeviceEventBody = (event: AstarteDeviceEvent) => {
   if (event instanceof AstarteDeviceDisconnectedEvent) {
     return (
       <>
-        <Badge variant="warning" className="me-2">
+        <Badge bg="warning" className="me-2">
           device disconnected
         </Badge>
         <span>Device disconnected</span>
@@ -237,7 +237,7 @@ const astarteDeviceEventBody = (event: AstarteDeviceEvent) => {
   if (event instanceof AstarteDeviceIncomingDataEvent) {
     return (
       <>
-        <Badge variant="info" className="me-2">
+        <Badge bg="info" className="me-2">
           incoming data
         </Badge>
         <span className="me-2">{event.interfaceName}</span>
@@ -251,7 +251,7 @@ const astarteDeviceEventBody = (event: AstarteDeviceEvent) => {
   if (event instanceof AstarteDeviceUnsetPropertyEvent) {
     return (
       <>
-        <Badge variant="info" className="me-2">
+        <Badge bg="info" className="me-2">
           unset property
         </Badge>
         <span className="me-2">{event.interfaceName}</span>
@@ -262,7 +262,7 @@ const astarteDeviceEventBody = (event: AstarteDeviceEvent) => {
   if (event instanceof AstarteDeviceErrorEvent) {
     return (
       <>
-        <Badge variant="danger" className="me-2">
+        <Badge bg="danger" className="me-2">
           device error
         </Badge>
         <span>{deviceErrorNameToString(event.errorName)}</span>
@@ -305,7 +305,7 @@ const SystemEventDelegate = ({ event }: SystemEventDelegateProps) => {
       return (
         <li className="px-2">
           <Timestamp>{new Date(event.timestamp)}</Timestamp>
-          <Badge variant="secondary" className="me-2">
+          <Badge bg="secondary" className="me-2">
             channel
           </Badge>
           <span className="text-danger">{event.message}</span>
@@ -317,7 +317,7 @@ const SystemEventDelegate = ({ event }: SystemEventDelegateProps) => {
       return (
         <li className="px-2">
           <Timestamp>{new Date(event.timestamp)}</Timestamp>
-          <Badge variant="secondary" className="me-2">
+          <Badge bg="secondary" className="me-2">
             channel
           </Badge>
           <span className="text-secondary">{event.message}</span>

--- a/src/DeviceStatusPage/DeviceLiveEventsCard.tsx
+++ b/src/DeviceStatusPage/DeviceLiveEventsCard.tsx
@@ -158,7 +158,7 @@ interface TimestampProps {
 const Timestamp = ({ children }: TimestampProps): React.ReactElement => {
   const formattedTimestamp = children.toISOString().substring(11, 23);
 
-  return <small className="text-secondary text-monospace mr-2">{`[${formattedTimestamp}]`}</small>;
+  return <small className="text-secondary font-monospace me-2">{`[${formattedTimestamp}]`}</small>;
 };
 
 const deviceErrorNameToString = (errorName: string): string => {
@@ -217,7 +217,7 @@ const astarteDeviceEventBody = (event: AstarteDeviceEvent) => {
   if (event instanceof AstarteDeviceConnectedEvent) {
     return (
       <>
-        <Badge variant="success" className="mr-2">
+        <Badge variant="success" className="me-2">
           device connected
         </Badge>
         <span>IP : {event.ip}</span>
@@ -227,7 +227,7 @@ const astarteDeviceEventBody = (event: AstarteDeviceEvent) => {
   if (event instanceof AstarteDeviceDisconnectedEvent) {
     return (
       <>
-        <Badge variant="warning" className="mr-2">
+        <Badge variant="warning" className="me-2">
           device disconnected
         </Badge>
         <span>Device disconnected</span>
@@ -237,12 +237,12 @@ const astarteDeviceEventBody = (event: AstarteDeviceEvent) => {
   if (event instanceof AstarteDeviceIncomingDataEvent) {
     return (
       <>
-        <Badge variant="info" className="mr-2">
+        <Badge variant="info" className="me-2">
           incoming data
         </Badge>
-        <span className="mr-2">{event.interfaceName}</span>
-        <span className="mr-2">{event.path}</span>
-        <span className="mr-2 text-monospace">
+        <span className="me-2">{event.interfaceName}</span>
+        <span className="me-2">{event.path}</span>
+        <span className="me-2 font-monospace">
           {_.isObject(event.value) ? JSON.stringify(event.value) : event.value}
         </span>
       </>
@@ -251,10 +251,10 @@ const astarteDeviceEventBody = (event: AstarteDeviceEvent) => {
   if (event instanceof AstarteDeviceUnsetPropertyEvent) {
     return (
       <>
-        <Badge variant="info" className="mr-2">
+        <Badge variant="info" className="me-2">
           unset property
         </Badge>
-        <span className="mr-2">{event.interfaceName}</span>
+        <span className="me-2">{event.interfaceName}</span>
         <span>{event.path}</span>
       </>
     );
@@ -262,7 +262,7 @@ const astarteDeviceEventBody = (event: AstarteDeviceEvent) => {
   if (event instanceof AstarteDeviceErrorEvent) {
     return (
       <>
-        <Badge variant="danger" className="mr-2">
+        <Badge variant="danger" className="me-2">
           device error
         </Badge>
         <span>{deviceErrorNameToString(event.errorName)}</span>
@@ -272,7 +272,7 @@ const astarteDeviceEventBody = (event: AstarteDeviceEvent) => {
             <div style={{ paddingLeft: '6.3em' }}>
               {Object.entries(event.metadata).map(([key, value]) => (
                 <span key={key}>
-                  {key}:<span className="text-secondary pl-2 pr-4">{value}</span>
+                  {key}:<span className="text-secondary ps-2 pe-4">{value}</span>
                 </span>
               ))}
             </div>
@@ -305,7 +305,7 @@ const SystemEventDelegate = ({ event }: SystemEventDelegateProps) => {
       return (
         <li className="px-2">
           <Timestamp>{new Date(event.timestamp)}</Timestamp>
-          <Badge variant="secondary" className="mr-2">
+          <Badge variant="secondary" className="me-2">
             channel
           </Badge>
           <span className="text-danger">{event.message}</span>
@@ -317,7 +317,7 @@ const SystemEventDelegate = ({ event }: SystemEventDelegateProps) => {
       return (
         <li className="px-2">
           <Timestamp>{new Date(event.timestamp)}</Timestamp>
-          <Badge variant="secondary" className="mr-2">
+          <Badge variant="secondary" className="me-2">
             channel
           </Badge>
           <span className="text-secondary">{event.message}</span>

--- a/src/DeviceStatusPage/ExchangedBytesCard.tsx
+++ b/src/DeviceStatusPage/ExchangedBytesCard.tsx
@@ -49,10 +49,10 @@ interface StatsTableRowProps {
 const StatsTableRow = ({ stats }: StatsTableRowProps): React.ReactElement => (
   <tr>
     <td>{stats.name}</td>
-    <td className="text-right">{formatBytes(stats.bytes)}</td>
-    <td className="d-xl-table-cell d-none text-right">{`${stats.bytesPercent.toFixed(2)}%`}</td>
-    <td className="text-right">{stats.messages}</td>
-    <td className="d-xl-table-cell d-none text-right">{`${stats.messagesPercent.toFixed(2)}%`}</td>
+    <td className="text-end">{formatBytes(stats.bytes)}</td>
+    <td className="d-xl-table-cell d-none text-end">{`${stats.bytesPercent.toFixed(2)}%`}</td>
+    <td className="text-end">{stats.messages}</td>
+    <td className="d-xl-table-cell d-none text-end">{`${stats.messagesPercent.toFixed(2)}%`}</td>
   </tr>
 );
 
@@ -113,10 +113,10 @@ const ExchangedBytesCard = ({ astarte, device }: ExchangedBytesCardProps): React
               <thead>
                 <tr>
                   <th>Interface</th>
-                  <th className="text-right">Bytes</th>
-                  <th className="d-xl-table-cell d-none text-right">Bytes (%)</th>
-                  <th className="text-right">Messages</th>
-                  <th className="d-xl-table-cell d-none text-right">Messages (%)</th>
+                  <th className="text-end">Bytes</th>
+                  <th className="d-xl-table-cell d-none text-end">Bytes (%)</th>
+                  <th className="text-end">Messages</th>
+                  <th className="d-xl-table-cell d-none text-end">Messages (%)</th>
                 </tr>
               </thead>
               <tbody>

--- a/src/DeviceStatusPage/index.tsx
+++ b/src/DeviceStatusPage/index.tsx
@@ -303,7 +303,7 @@ const DeviceStatusPage = (): React.ReactElement => {
     <Container fluid className="p-3">
       <Row>
         <Col>
-          <h2 className="pl-2">
+          <h2 className="ps-2">
             <BackButton href="/devices" />
             Device
           </h2>

--- a/src/DevicesPage.tsx
+++ b/src/DevicesPage.tsx
@@ -129,10 +129,10 @@ const DeviceRow = ({ device, filters }: DeviceRowProps): React.ReactElement => {
   return (
     <tr>
       <td>
-        <Icon className="mr-2" icon={icon} tooltip={iconTooltip} tooltipPlacement="right" />
+        <Icon className="me-2" icon={icon} tooltip={iconTooltip} tooltipPlacement="right" />
         <span>{statusLabel}</span>
       </td>
-      <td className={device.hasNameAlias ? '' : 'text-monospace'}>
+      <td className={device.hasNameAlias ? '' : 'font-monospace'}>
         <Link to={`/devices/${device.id}/edit`}>{device.name}</Link>
         <MatchedAttributes filters={filters} attributes={device.attributes} />
       </td>
@@ -503,7 +503,7 @@ export default (): React.ReactElement => {
                   </Col>
                   <Col xs="auto" className="p-1">
                     <div className="p-2 mb-2" onClick={() => setShowSidebar(!showSidebar)}>
-                      <Icon icon="filter" className="mr-1" />
+                      <Icon icon="filter" className="me-1" />
                       {showSidebar && <b>Filters</b>}
                     </div>
                     {showSidebar && (

--- a/src/FlowConfigurationPage.tsx
+++ b/src/FlowConfigurationPage.tsx
@@ -99,7 +99,7 @@ export default (): React.ReactElement => {
         />
       </Form.Group>
       <Button variant="primary" disabled={!isValidForm || isCreatingFlow} onClick={createFlow}>
-        {isCreatingFlow && <Spinner className="mr-2" size="sm" animation="border" role="status" />}
+        {isCreatingFlow && <Spinner className="me-2" size="sm" animation="border" role="status" />}
         Instantiate Flow
       </Button>
     </Form>

--- a/src/GroupDevicesPage.tsx
+++ b/src/GroupDevicesPage.tsx
@@ -65,10 +65,10 @@ const deviceTableRow = (
   return (
     <tr key={index}>
       <td>
-        <Icon className="mr-2" icon={icon} tooltip={iconTooltip} tooltipPlacement="right" />
+        <Icon className="me-2" icon={icon} tooltip={iconTooltip} tooltipPlacement="right" />
         <span>{statusLabel}</span>
       </td>
-      <td className={device.hasNameAlias ? '' : 'text-monospace'}>
+      <td className={device.hasNameAlias ? '' : 'font-monospace'}>
         <Link to={`/devices/${device.id}/edit`}>{device.name}</Link>
       </td>
       <td>{lastEvent}</td>

--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -48,14 +48,14 @@ const ServiceStatusRow = ({ service, status }: ServiceStatusRowProps): React.Rea
   } else if (status === 'ok') {
     messageCell = (
       <td className="color-green">
-        <Icon icon="statusOK" className="mr-1" />
+        <Icon icon="statusOK" className="me-1" />
         This service is operating normally
       </td>
     );
   } else {
     messageCell = (
       <td className="color-red">
-        <Icon icon="statusKO" className="mr-1" />
+        <Icon icon="statusKO" className="me-1" />
         This service appears offline
       </td>
     );
@@ -171,7 +171,7 @@ const InterfaceList = ({
               onInterfaceClick(e, interfaceName);
             }}
           >
-            <Icon icon="interfaces" className="mr-1" />
+            <Icon icon="interfaces" className="me-1" />
             {interfaceName}
           </a>
         </li>
@@ -253,7 +253,7 @@ const TriggerList = ({ triggers, maxShownTriggers }: TriggerListProps): React.Re
       {shownTriggers.map((triggerName) => (
         <li key={triggerName} className="my-1">
           <Link to={`/triggers/${triggerName}/edit`}>
-            <Icon icon="triggers" className="mr-1" />
+            <Icon icon="triggers" className="me-1" />
             {triggerName}
           </Link>
         </li>

--- a/src/InterfacePage.tsx
+++ b/src/InterfacePage.tsx
@@ -206,12 +206,12 @@ export default (): React.ReactElement => {
                 denyMajorChanges
               />
               <Row className="justify-content-end m-3">
-                <Button variant="secondary" className="mr-2" onClick={handleToggleSourceVisibility}>
+                <Button variant="secondary" className="me-2" onClick={handleToggleSourceVisibility}>
                   {isSourceVisible ? 'Hide' : 'Show'} source
                 </Button>
                 {iface.major === 0 && (
                   <Button
-                    className="mr-2"
+                    className="me-2"
                     variant="danger"
                     onClick={isDeletingInterface ? undefined : showConfirmDeleteModal}
                     disabled={isDeletingInterface}
@@ -222,7 +222,7 @@ export default (): React.ReactElement => {
                         size="sm"
                         animation="border"
                         role="status"
-                        className="mr-2"
+                        className="me-2"
                       />
                     )}
                     Delete interface
@@ -239,7 +239,7 @@ export default (): React.ReactElement => {
                       size="sm"
                       animation="border"
                       role="status"
-                      className="mr-2"
+                      className="me-2"
                     />
                   )}
                   Apply changes

--- a/src/InterfacesPage.tsx
+++ b/src/InterfacesPage.tsx
@@ -42,7 +42,7 @@ const InterfaceRow = ({ name, majors }: InterfaceRowProps): React.ReactElement =
         <Col md="auto">
           {majors.map((major) => (
             <Link key={major} to={`/interfaces/${name}/${major}/edit`}>
-              <Badge variant={major > 0 ? 'primary' : 'secondary'} className="me-1 px-2 py-1">
+              <Badge bg={major > 0 ? 'primary' : 'secondary'} className="me-1 px-2 py-1">
                 v{major}
               </Badge>
             </Link>

--- a/src/InterfacesPage.tsx
+++ b/src/InterfacesPage.tsx
@@ -35,14 +35,14 @@ const InterfaceRow = ({ name, majors }: InterfaceRowProps): React.ReactElement =
       <Row>
         <Col>
           <Link to={`/interfaces/${name}/${Math.max(...majors)}/edit`}>
-            <Icon icon="interfaces" className="mr-2" />
+            <Icon icon="interfaces" className="me-2" />
             {name}
           </Link>
         </Col>
         <Col md="auto">
           {majors.map((major) => (
             <Link key={major} to={`/interfaces/${name}/${major}/edit`}>
-              <Badge variant={major > 0 ? 'primary' : 'secondary'} className="mr-1 px-2 py-1">
+              <Badge variant={major > 0 ? 'primary' : 'secondary'} className="me-1 px-2 py-1">
                 v{major}
               </Badge>
             </Link>
@@ -110,7 +110,7 @@ export default (): React.ReactElement => {
           <ListGroup>
             <ListGroup.Item>
               <Button variant="link" className="p-0" onClick={() => navigate('/interfaces/new')}>
-                <Icon icon="add" className="mr-2" />
+                <Icon icon="add" className="me-2" />
                 Install a new interface...
               </Button>
             </ListGroup.Item>

--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -232,7 +232,7 @@ const OAuthForm = ({
 };
 
 const LeftColumn = (): React.ReactElement => (
-  <Col lg={6} className="p-0 no-gutters d-none d-lg-block">
+  <Col lg={6} className="p-0 g-0 d-none d-lg-block">
     <div className="d-flex flex-column align-items-center justify-content-center position-relative login-image-container">
       <img
         src="/static/img/background-login-top.svg"

--- a/src/NewBlockPage.tsx
+++ b/src/NewBlockPage.tsx
@@ -104,9 +104,7 @@ export default (): React.ReactElement => {
           </Form.Group>
           <Form.Group controlId="block-type">
             <Form.Label>Type</Form.Label>
-            <Form.Control
-              as="select"
-              custom
+            <Form.Select
               value={block.type}
               onChange={(e) =>
                 setBlock({ ...block, type: e.target.value as AstarteCustomBlock['type'] })
@@ -117,7 +115,7 @@ export default (): React.ReactElement => {
               <option value="producer">Producer</option>
               <option value="consumer">Consumer</option>
               <option value="producer_consumer">Producer &amp; Consumer</option>
-            </Form.Control>
+            </Form.Select>
           </Form.Group>
           <Form.Group controlId="block-source">
             <Form.Label>Source</Form.Label>

--- a/src/NewBlockPage.tsx
+++ b/src/NewBlockPage.tsx
@@ -150,7 +150,7 @@ export default (): React.ReactElement => {
           disabled={isRegisteringBlock || !isValidBlock}
         >
           {isRegisteringBlock && (
-            <Spinner as="span" size="sm" animation="border" role="status" className="mr-2" />
+            <Spinner as="span" size="sm" animation="border" role="status" className="me-2" />
           )}
           Create new block
         </Button>

--- a/src/NewGroupPage.tsx
+++ b/src/NewGroupPage.tsx
@@ -18,7 +18,7 @@
 
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Button, Container, Form, InputGroup, Spinner } from 'react-bootstrap';
+import { Button, Container, Form, InputGroup, Row, Spinner } from 'react-bootstrap';
 import type { AstarteDevice } from 'astarte-client';
 
 import { AlertsBanner, useAlerts } from './AlertManager';
@@ -69,13 +69,11 @@ interface FilterInputBoxProps {
 
 const FilterInputBox = ({ filter, onFilterChange }: FilterInputBoxProps): React.ReactElement => (
   <Form.Group>
-    <Form.Label srOnly>Table filter</Form.Label>
+    <Form.Label visuallyHidden>Table filter</Form.Label>
     <InputGroup>
-      <InputGroup.Prepend>
-        <InputGroup.Text>
-          <Icon icon="filter" />
-        </InputGroup.Text>
-      </InputGroup.Prepend>
+      <InputGroup.Text>
+        <Icon icon="filter" />
+      </InputGroup.Text>
       <Form.Control
         type="text"
         value={filter}
@@ -169,14 +167,14 @@ export default (): React.ReactElement => {
               selectedDevices={selectedDevices}
               onToggleDevice={handleDeviceToggle}
             />
-            <Form.Row className="flex-row-reverse pe-2">
+            <Row className="flex-row-reverse pe-2">
               <Button variant="primary" type="submit" disabled={!isValidForm || isCreatingGroup}>
                 {isCreatingGroup && (
                   <Spinner as="span" size="sm" animation="border" role="status" className="me-2" />
                 )}
                 Create group
               </Button>
-            </Form.Row>
+            </Row>
           </Form>
         )}
       </WaitForData>

--- a/src/NewGroupPage.tsx
+++ b/src/NewGroupPage.tsx
@@ -159,7 +159,7 @@ export default (): React.ReactElement => {
                     } selected.`
                   : 'Please select at least one device.'}
               </span>
-              <div className="float-right">
+              <div className="float-end">
                 <FilterInputBox filter={deviceFilter} onFilterChange={setDeviceFilter} />
               </div>
             </div>
@@ -169,10 +169,10 @@ export default (): React.ReactElement => {
               selectedDevices={selectedDevices}
               onToggleDevice={handleDeviceToggle}
             />
-            <Form.Row className="flex-row-reverse pr-2">
+            <Form.Row className="flex-row-reverse pe-2">
               <Button variant="primary" type="submit" disabled={!isValidForm || isCreatingGroup}>
                 {isCreatingGroup && (
-                  <Spinner as="span" size="sm" animation="border" role="status" className="mr-2" />
+                  <Spinner as="span" size="sm" animation="border" role="status" className="me-2" />
                 )}
                 Create group
               </Button>

--- a/src/NewInterfacePage.tsx
+++ b/src/NewInterfacePage.tsx
@@ -135,7 +135,7 @@ export default (): React.ReactElement => {
         <AlertsBanner alerts={installationAlerts} />
         <InterfaceEditor onChange={handleInterfaceChange} isSourceVisible={isSourceVisible} />
         <Row className="justify-content-end m-0 mt-3">
-          <Button variant="secondary" className="mr-2" onClick={handleToggleSourceVisibility}>
+          <Button variant="secondary" className="me-2" onClick={handleToggleSourceVisibility}>
             {isSourceVisible ? 'Hide' : 'Show'} source
           </Button>
           <Button
@@ -144,7 +144,7 @@ export default (): React.ReactElement => {
             disabled={isInstallingInterface || !isValidInterface}
           >
             {isInstallingInterface && (
-              <Spinner as="span" size="sm" animation="border" role="status" className="mr-2" />
+              <Spinner as="span" size="sm" animation="border" role="status" className="me-2" />
             )}
             Install interface
           </Button>

--- a/src/NewPipelinePage.tsx
+++ b/src/NewPipelinePage.tsx
@@ -256,7 +256,7 @@ const NewPipelinePage = (): React.ReactElement => {
                 disabled={!isValidForm || isCreatingPipeline}
               >
                 {isCreatingPipeline && (
-                  <Spinner as="span" size="sm" animation="border" role="status" className="mr-2" />
+                  <Spinner as="span" size="sm" animation="border" role="status" className="me-2" />
                 )}
                 Create new pipeline
               </Button>

--- a/src/NewTriggerDeliveryPolicyPage.tsx
+++ b/src/NewTriggerDeliveryPolicyPage.tsx
@@ -97,7 +97,7 @@ export default (): React.ReactElement => {
       <div className="mt-4">
         <AlertsBanner alerts={installationAlerts} />
         <Row className="justify-content-end m-0 mt-3">
-          <Button variant="secondary" className="mr-2" onClick={handleToggleSourceVisibility}>
+          <Button variant="secondary" className="me-2" onClick={handleToggleSourceVisibility}>
             {isSourceVisible ? 'Hide' : 'Show'} source
           </Button>
           <Button
@@ -106,7 +106,7 @@ export default (): React.ReactElement => {
             disabled={isInstallingPolicy || !isValidPolicy}
           >
             {isInstallingPolicy && (
-              <Spinner as="span" size="sm" animation="border" role="status" className="mr-2" />
+              <Spinner as="span" size="sm" animation="border" role="status" className="me-2" />
             )}
             Install Trigger Delivery Policy
           </Button>

--- a/src/NewTriggerPage.tsx
+++ b/src/NewTriggerPage.tsx
@@ -86,7 +86,7 @@ export default (): React.ReactElement => {
           fetchInterface={astarte.client.getInterface}
         />
         <Row className="justify-content-end m-0 mt-3">
-          <Button variant="secondary" className="mr-2" onClick={handleToggleSourceVisibility}>
+          <Button variant="secondary" className="me-2" onClick={handleToggleSourceVisibility}>
             {isSourceVisible ? 'Hide' : 'Show'} source
           </Button>
           <Button
@@ -95,7 +95,7 @@ export default (): React.ReactElement => {
             disabled={isInstallingTrigger || !isValidTrigger}
           >
             {isInstallingTrigger && (
-              <Spinner as="span" size="sm" animation="border" role="status" className="mr-2" />
+              <Spinner as="span" size="sm" animation="border" role="status" className="me-2" />
             )}
             Install Trigger
           </Button>

--- a/src/PipelineSourcePage.tsx
+++ b/src/PipelineSourcePage.tsx
@@ -103,7 +103,7 @@ export default (): React.ReactElement => {
             disabled={isDeletingPipeline}
           >
             {isDeletingPipeline && (
-              <Spinner as="span" size="sm" animation="border" role="status" className="mr-2" />
+              <Spinner as="span" size="sm" animation="border" role="status" className="me-2" />
             )}
             Delete pipeline
           </Button>

--- a/src/PipelinesPage.tsx
+++ b/src/PipelinesPage.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Button, Card, CardDeck, Container, Spinner } from 'react-bootstrap';
+import { Button, Card, Col, Container, Row, Spinner } from 'react-bootstrap';
 import type { AstartePipeline } from 'astarte-client';
 
 import { useAstarte } from './AstarteManager';
@@ -31,13 +31,15 @@ interface NewPipelineCardProps {
 }
 
 const NewPipelineCard = ({ onCreate }: NewPipelineCardProps): React.ReactElement => (
-  <Card className="mb-4">
+  <Card className="mb-4 h-100">
     <Card.Header as="h5">New Pipeline</Card.Header>
-    <Card.Body>
+    <Card.Body className="d-flex flex-column">
       <Card.Text>Create your custom pipeline</Card.Text>
-      <Button variant="secondary" onClick={onCreate}>
-        Create
-      </Button>
+      <div className="mt-auto d-flex flex-column flex-md-row">
+        <Button variant="secondary" onClick={onCreate}>
+          Create
+        </Button>
+      </div>
     </Card.Body>
   </Card>
 );
@@ -53,15 +55,17 @@ const PipelineCard = ({
   onInstantiate,
   showLink,
 }: PipelineCardProps): React.ReactElement => (
-  <Card className="mb-4">
+  <Card className="mb-4 h-100">
     <Card.Header as="h5">
       <Link to={showLink}>{pipeline.name}</Link>
     </Card.Header>
-    <Card.Body>
+    <Card.Body className="d-flex flex-column">
       <Card.Text>{pipeline.description}</Card.Text>
-      <Button variant="primary" onClick={onInstantiate}>
-        Instantiate
-      </Button>
+      <div className="mt-auto d-flex flex-column flex-md-row">
+        <Button variant="primary" onClick={onInstantiate}>
+          Instantiate
+        </Button>
+      </div>
     </Card.Body>
   </Card>
 );
@@ -74,8 +78,10 @@ export default (): React.ReactElement => {
   return (
     <Container fluid className="p-3">
       <h2>Pipelines</h2>
-      <CardDeck className="mt-4">
-        <NewPipelineCard onCreate={() => navigate('/pipelines/new')} />
+      <Row xs={1} lg={2} xxl={3} className="mt-4 g-4">
+        <Col>
+          <NewPipelineCard onCreate={() => navigate('/pipelines/new')} />
+        </Col>
         <WaitForData
           data={pipelinesFetcher.value}
           status={pipelinesFetcher.status}
@@ -90,9 +96,8 @@ export default (): React.ReactElement => {
         >
           {(pipelines) => (
             <>
-              {pipelines.map((pipeline, index) => (
-                <React.Fragment key={`fragment-${index}`}>
-                  {index % 2 ? <div className="w-100 d-none d-md-block" /> : null}
+              {pipelines.map((pipeline) => (
+                <Col key={pipeline.name}>
                   <PipelineCard
                     pipeline={pipeline}
                     onInstantiate={() => {
@@ -100,15 +105,12 @@ export default (): React.ReactElement => {
                     }}
                     showLink={`/pipelines/${pipeline.name}/edit`}
                   />
-                  {index === pipelines.length - 1 && pipelines.length % 2 === 0 ? (
-                    <div className="w-50 d-none d-md-block" />
-                  ) : null}
-                </React.Fragment>
+                </Col>
               ))}
             </>
           )}
         </WaitForData>
-      </CardDeck>
+      </Row>
     </Container>
   );
 };

--- a/src/RealmSettingsPage.tsx
+++ b/src/RealmSettingsPage.tsx
@@ -53,7 +53,7 @@ const RealmSettingsForm = ({
         <Form.Label>Public key</Form.Label>
         <Form.Control
           as="textarea"
-          className="text-monospace"
+          className="font-monospace"
           rows={16}
           value={values.publicKey}
           onChange={(e) => setValues({ ...values, publicKey: e.target.value })}
@@ -65,7 +65,7 @@ const RealmSettingsForm = ({
         onClick={() => onSubmit(values)}
       >
         {isUpdatingSettings && (
-          <Spinner className="mr-2" size="sm" animation="border" role="status" />
+          <Spinner className="me-2" size="sm" animation="border" role="status" />
         )}
         Change
       </Button>

--- a/src/RegisterDevicePage.tsx
+++ b/src/RegisterDevicePage.tsx
@@ -21,7 +21,7 @@
 import React, { useCallback, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { v4 as uuidv4, v5 as uuidv5 } from 'uuid';
-import { Button, Col, Form, Spinner, Table } from 'react-bootstrap';
+import { Button, Col, Form, Row, Spinner, Table } from 'react-bootstrap';
 import type { AstarteDevice, AstarteInterfaceDescriptor } from 'astarte-client';
 
 import Icon from './components/Icon';
@@ -321,7 +321,7 @@ export default (): React.ReactElement => {
     <SingleCardPage title="Register Device" backLink="/devices">
       <AlertsBanner alerts={registrationAlerts} />
       <Form onSubmit={registerDevice}>
-        <Form.Row className="mb-2">
+        <Row className="mb-2">
           <Form.Group as={Col} controlId="deviceIdInput">
             <Form.Label>Device ID</Form.Label>
             <Form.Control
@@ -351,7 +351,7 @@ export default (): React.ReactElement => {
               Generate from name...
             </Button>
           </Form.Group>
-        </Form.Row>
+        </Row>
         <Form.Group
           controlId="sendIntrospectionInput"
           className={shouldSendIntrospection ? 'mb-0' : ''}
@@ -372,7 +372,7 @@ export default (): React.ReactElement => {
             onRemoveInterface={removeIntrospectionInterface}
           />
         )}
-        <Form.Row className="flex-row-reverse pe-2">
+        <Row className="flex-row-reverse pe-2">
           <Button
             variant="primary"
             type="submit"
@@ -383,7 +383,7 @@ export default (): React.ReactElement => {
             )}
             Register device
           </Button>
-        </Form.Row>
+        </Row>
       </Form>
       {showNamespaceModal && (
         <NamespaceModal

--- a/src/RegisterDevicePage.tsx
+++ b/src/RegisterDevicePage.tsx
@@ -326,7 +326,7 @@ export default (): React.ReactElement => {
             <Form.Label>Device ID</Form.Label>
             <Form.Control
               type="text"
-              className="text-monospace"
+              className="font-monospace"
               placeholder="Your device ID"
               value={deviceId}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDeviceId(e.target.value)}
@@ -372,14 +372,14 @@ export default (): React.ReactElement => {
             onRemoveInterface={removeIntrospectionInterface}
           />
         )}
-        <Form.Row className="flex-row-reverse pr-2">
+        <Form.Row className="flex-row-reverse pe-2">
           <Button
             variant="primary"
             type="submit"
             disabled={!isValidDeviceId || isRegisteringDevice}
           >
             {isRegisteringDevice && (
-              <Spinner as="span" size="sm" animation="border" role="status" className="mr-2" />
+              <Spinner as="span" size="sm" animation="border" role="status" className="me-2" />
             )}
             Register device
           </Button>

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -55,7 +55,7 @@ const SidebarApiStatus = () => {
   }
 
   return (
-    <NavItem className="nav-status pl-4">
+    <NavItem className="nav-status ps-4">
       <div>
         <b>Realm</b>
       </div>
@@ -82,7 +82,7 @@ const SidebarApiStatus = () => {
         <b>API Status</b>
       </div>
       <p className="my-1">
-        <Icon icon={isApiHealthy ? 'statusConnected' : 'statusDisconnected'} className="mr-2" />
+        <Icon icon={isApiHealthy ? 'statusConnected' : 'statusDisconnected'} className="me-2" />
         {isApiHealthy ? 'Up and running' : 'Degraded'}
       </p>
     </NavItem>
@@ -123,7 +123,7 @@ const SidebarItem = ({ icon, label, link }: SidebarItemProps) => {
 
   return (
     <NavLink as={Link} to={link} active={isSelected}>
-      <Icon icon={icon} className="mr-2" />
+      <Icon icon={icon} className="me-2" />
       {label}
     </NavLink>
   );

--- a/src/TriggerDeliveryPoliciesPage.tsx
+++ b/src/TriggerDeliveryPoliciesPage.tsx
@@ -35,7 +35,7 @@ interface TriggerPolicyRowProps {
 const TriggerPolicyRow = ({ name, onClick }: TriggerPolicyRowProps): React.ReactElement => (
   <ListGroup.Item>
     <Button variant="link" className="p-0" onClick={onClick}>
-      <Icon icon="policy" className="mr-2" />
+      <Icon icon="policy" className="me-2" />
       {name}
     </Button>
   </ListGroup.Item>
@@ -84,7 +84,7 @@ export default (): React.ReactElement => {
                   navigate('/trigger-delivery-policies/new');
                 }}
               >
-                <Icon icon="add" className="mr-2" />
+                <Icon icon="add" className="me-2" />
                 Install a new trigger delivery policy...
               </Button>
             </ListGroup.Item>

--- a/src/TriggerDeliveryPolicyPage.tsx
+++ b/src/TriggerDeliveryPolicyPage.tsx
@@ -167,7 +167,7 @@ export default (): React.ReactElement => {
                 isSourceVisible={isSourceVisible}
               />
               <Row className="justify-content-end m-0 mt-3">
-                <Button variant="secondary" className="mr-2" onClick={handleToggleSourceVisibility}>
+                <Button variant="secondary" className="me-2" onClick={handleToggleSourceVisibility}>
                   {isSourceVisible ? 'Hide' : 'Show'} source
                 </Button>
                 <Button
@@ -181,7 +181,7 @@ export default (): React.ReactElement => {
                       size="sm"
                       animation="border"
                       role="status"
-                      className="mr-2"
+                      className="me-2"
                     />
                   )}
                   Delete Trigger Delivery Policy

--- a/src/TriggerPage.tsx
+++ b/src/TriggerPage.tsx
@@ -148,7 +148,7 @@ export default (): React.ReactElement => {
                 fetchInterface={astarte.client.getInterface}
               />
               <Row className="justify-content-end m-0 mt-3">
-                <Button variant="secondary" className="mr-2" onClick={handleToggleSourceVisibility}>
+                <Button variant="secondary" className="me-2" onClick={handleToggleSourceVisibility}>
                   {isSourceVisible ? 'Hide' : 'Show'} source
                 </Button>
                 <Button
@@ -162,7 +162,7 @@ export default (): React.ReactElement => {
                       size="sm"
                       animation="border"
                       role="status"
-                      className="mr-2"
+                      className="me-2"
                     />
                   )}
                   Delete trigger

--- a/src/TriggersPage.tsx
+++ b/src/TriggersPage.tsx
@@ -35,7 +35,7 @@ interface TriggerRowProps {
 const TriggerRow = ({ name, onClick }: TriggerRowProps): React.ReactElement => (
   <ListGroup.Item>
     <Button variant="link" className="p-0" onClick={onClick}>
-      <Icon icon="triggers" className="mr-2" />
+      <Icon icon="triggers" className="me-2" />
       {name}
     </Button>
   </ListGroup.Item>
@@ -84,7 +84,7 @@ export default (): React.ReactElement => {
                   navigate('/triggers/new');
                 }}
               >
-                <Icon icon="add" className="mr-2" />
+                <Icon icon="add" className="me-2" />
                 Install a new trigger...
               </Button>
             </ListGroup.Item>

--- a/src/components/InterfaceEditor.tsx
+++ b/src/components/InterfaceEditor.tsx
@@ -71,13 +71,9 @@ const databaseRetentionToLabel = {
 };
 
 const MappingRow = ({ className, mapping, onEdit, onDelete }: MappingRowProps) => (
-  <Accordion data-testid={mapping.endpoint}>
-    <Card className={className}>
-      <Accordion.Button
-        eventKey={mapping.endpoint}
-        as={Card.Header}
-        className="d-flex align-items-center flex-wrap"
-      >
+  <Accordion data-testid={mapping.endpoint} className={className}>
+    <Accordion.Item eventKey={mapping.endpoint}>
+      <Accordion.Header className="d-flex align-items-center flex-wrap">
         <span className="flex-grow-1">
           <Badge bg="secondary">{mapping.type}</Badge>
           <Button className="text-start text-truncate" variant="link">
@@ -90,70 +86,68 @@ const MappingRow = ({ className, mapping, onEdit, onDelete }: MappingRowProps) =
           </Button>
         )}
         {onDelete && (
-          <Button variant="outline-primary" onClick={onDelete}>
+          <Button className="me-2" variant="outline-primary" onClick={onDelete}>
             Delete
           </Button>
         )}
-      </Accordion.Button>
-      <Accordion.Collapse eventKey={mapping.endpoint}>
-        <Card.Body>
-          {mapping.description && (
-            <>
-              <h5>Description</h5>
-              <p>{mapping.description}</p>
-            </>
-          )}
-          {mapping.documentation && (
-            <>
-              <h5>Documentation</h5>
-              <p>{mapping.documentation}</p>
-            </>
-          )}
-          {mapping.allowUnset && (
-            <>
-              <h5>Allow Unset</h5>
-              <p>True</p>
-            </>
-          )}
-          {mapping.explicitTimestamp && (
-            <>
-              <h5>Explicit Timestamp</h5>
-              <p>True</p>
-            </>
-          )}
-          {mapping.reliability && (
-            <>
-              <h5>Reliability</h5>
-              <p>{reliabilityToLabel[mapping.reliability]}</p>
-            </>
-          )}
-          {mapping.retention && (
-            <>
-              <h5>Retention</h5>
-              <p>{retentionToLabel[mapping.retention]}</p>
-            </>
-          )}
-          {mapping.expiry && (
-            <>
-              <h5>Expiry</h5>
-              <p>{mapping.expiry} seconds</p>
-            </>
-          )}
-          {mapping.databaseRetentionPolicy && (
-            <>
-              <h5>Database Retention</h5>
-              <p>{databaseRetentionToLabel[mapping.databaseRetentionPolicy]}</p>
-            </>
-          )}
-          {mapping.databaseRetentionTtl != null && (
-            <>
-              <h5>Database Retention TTL</h5>
-              <p>{mapping.databaseRetentionTtl} seconds</p>
-            </>
-          )}
-        </Card.Body>
-      </Accordion.Collapse>
-    </Card>
+      </Accordion.Header>
+      <Accordion.Body>
+        {mapping.description && (
+          <>
+            <h5>Description</h5>
+            <p>{mapping.description}</p>
+          </>
+        )}
+        {mapping.documentation && (
+          <>
+            <h5>Documentation</h5>
+            <p>{mapping.documentation}</p>
+          </>
+        )}
+        {mapping.allowUnset && (
+          <>
+            <h5>Allow Unset</h5>
+            <p>True</p>
+          </>
+        )}
+        {mapping.explicitTimestamp && (
+          <>
+            <h5>Explicit Timestamp</h5>
+            <p>True</p>
+          </>
+        )}
+        {mapping.reliability && (
+          <>
+            <h5>Reliability</h5>
+            <p>{reliabilityToLabel[mapping.reliability]}</p>
+          </>
+        )}
+        {mapping.retention && (
+          <>
+            <h5>Retention</h5>
+            <p>{retentionToLabel[mapping.retention]}</p>
+          </>
+        )}
+        {mapping.expiry && (
+          <>
+            <h5>Expiry</h5>
+            <p>{mapping.expiry} seconds</p>
+          </>
+        )}
+        {mapping.databaseRetentionPolicy && (
+          <>
+            <h5>Database Retention</h5>
+            <p>{databaseRetentionToLabel[mapping.databaseRetentionPolicy]}</p>
+          </>
+        )}
+        {mapping.databaseRetentionTtl != null && (
+          <>
+            <h5>Database Retention TTL</h5>
+            <p>{mapping.databaseRetentionTtl} seconds</p>
+          </>
+        )}
+      </Accordion.Body>
+    </Accordion.Item>
   </Accordion>
 );
 
@@ -993,7 +987,7 @@ export default ({
                 <Form.Group controlId="interfaceMappings">
                   <button
                     type="button"
-                    className="btn accordion-button w-100 mb-2"
+                    className="btn border p-3 w-100 mb-2"
                     onClick={handleAddMapping}
                   >
                     <Icon icon="add" className="me-2" /> Add mapping...

--- a/src/components/InterfaceEditor.tsx
+++ b/src/components/InterfaceEditor.tsx
@@ -80,12 +80,12 @@ const MappingRow = ({ className, mapping, onEdit, onDelete }: MappingRowProps) =
       >
         <span className="flex-grow-1">
           <Badge variant="secondary">{mapping.type}</Badge>
-          <Button className="text-left text-truncate" variant="link">
+          <Button className="text-start text-truncate" variant="link">
             {mapping.endpoint}
           </Button>
         </span>
         {onEdit && (
-          <Button className="mr-2" variant="outline-primary" onClick={onEdit}>
+          <Button className="me-2" variant="outline-primary" onClick={onEdit}>
             Edit...
           </Button>
         )}
@@ -1000,7 +1000,7 @@ export default ({
                     className="btn accordion-button w-100 mb-2"
                     onClick={handleAddMapping}
                   >
-                    <Icon icon="add" className="mr-2" /> Add mapping...
+                    <Icon icon="add" className="me-2" /> Add mapping...
                   </button>
                   {interfaceDraft.mappings.map((mapping, index) => {
                     const isExistingMapping = (initialData?.mappings || []).some(
@@ -1037,7 +1037,7 @@ export default ({
           <Form.Group controlId="interfaceSource" className="h-100 d-flex flex-column">
             <Form.Control
               as="textarea"
-              className="flex-grow-1 text-monospace"
+              className="flex-grow-1 font-monospace"
               value={interfaceSource}
               onChange={handleInterfaceSourceChange}
               autoComplete="off"

--- a/src/components/InterfaceEditor.tsx
+++ b/src/components/InterfaceEditor.tsx
@@ -73,13 +73,13 @@ const databaseRetentionToLabel = {
 const MappingRow = ({ className, mapping, onEdit, onDelete }: MappingRowProps) => (
   <Accordion data-testid={mapping.endpoint}>
     <Card className={className}>
-      <Accordion.Toggle
+      <Accordion.Button
         eventKey={mapping.endpoint}
         as={Card.Header}
         className="d-flex align-items-center flex-wrap"
       >
         <span className="flex-grow-1">
-          <Badge variant="secondary">{mapping.type}</Badge>
+          <Badge bg="secondary">{mapping.type}</Badge>
           <Button className="text-start text-truncate" variant="link">
             {mapping.endpoint}
           </Button>
@@ -94,7 +94,7 @@ const MappingRow = ({ className, mapping, onEdit, onDelete }: MappingRowProps) =
             Delete
           </Button>
         )}
-      </Accordion.Toggle>
+      </Accordion.Button>
       <Accordion.Collapse eventKey={mapping.endpoint}>
         <Card.Body>
           {mapping.description && (
@@ -513,12 +513,15 @@ export default ({
     [],
   );
 
-  const handleInterfaceReliabilityChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const { value } = e.currentTarget;
-    let reliability = value as AstarteMapping['reliability'];
-    reliability = reliability === 'unreliable' ? undefined : reliability;
-    setDatastreamOptions((options) => ({ ...options, reliability }));
-  }, []);
+  const handleInterfaceReliabilityChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const { value } = e.currentTarget;
+      let reliability = value as AstarteMapping['reliability'];
+      reliability = reliability === 'unreliable' ? undefined : reliability;
+      setDatastreamOptions((options) => ({ ...options, reliability }));
+    },
+    [],
+  );
 
   const handleInterfaceExplicitTimestampChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -529,7 +532,7 @@ export default ({
     [],
   );
 
-  const handleInterfaceRetentionChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleInterfaceRetentionChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
     const { value } = e.currentTarget;
     const retention = value as AstarteMapping['retention'];
     setDatastreamOptions((options) => ({
@@ -545,7 +548,7 @@ export default ({
   }, []);
 
   const handleInterfaceDatabaseRetentionPolicyChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
       const { value } = e.currentTarget;
       const databaseRetentionPolicy = value as AstarteMapping['databaseRetentionPolicy'];
       setDatastreamOptions((options) => ({
@@ -709,7 +712,7 @@ export default ({
       <Col md={isSourceVisible ? 6 : 12}>
         <Container fluid className="bg-white rounded p-3">
           <Form>
-            <Form.Row className="mb-2">
+            <Row className="mb-2">
               <Col md={6}>
                 <Form.Group controlId="interfaceName">
                   <Form.Label>Name</Form.Label>
@@ -764,8 +767,8 @@ export default ({
                   </Form.Control.Feedback>
                 </Form.Group>
               </Col>
-            </Form.Row>
-            <Form.Row className="mb-2">
+            </Row>
+            <Row className="mb-2">
               <Col md={4}>
                 <Form.Group>
                   <Form.Label>Type</Form.Label>
@@ -843,14 +846,13 @@ export default ({
                   />
                 </Form.Group>
               </Col>
-            </Form.Row>
+            </Row>
             {interfaceDraft.type === 'datastream' && interfaceDraft.aggregation === 'object' && (
-              <Form.Row className="mb-2">
+              <Row className="mb-2">
                 <Col md={6}>
                   <Form.Group controlId="objectMappingReliability">
                     <Form.Label>Reliability</Form.Label>
-                    <Form.Control
-                      as="select"
+                    <Form.Select
                       name="mappingReliability"
                       value={datastreamOptions.reliability || 'unreliable'}
                       onChange={handleInterfaceReliabilityChange}
@@ -859,7 +861,7 @@ export default ({
                       <option value="unreliable">{reliabilityToLabel.unreliable}</option>
                       <option value="guaranteed">{reliabilityToLabel.guaranteed}</option>
                       <option value="unique">{reliabilityToLabel.unique}</option>
-                    </Form.Control>
+                    </Form.Select>
                   </Form.Group>
                 </Col>
                 <Col md={6}>
@@ -875,15 +877,14 @@ export default ({
                     />
                   </Form.Group>
                 </Col>
-              </Form.Row>
+              </Row>
             )}
             {interfaceDraft.type === 'datastream' && interfaceDraft.aggregation === 'object' && (
-              <Form.Row className="mb-2">
+              <Row className="mb-2">
                 <Col md={showInterfaceExpiry ? 6 : 12}>
                   <Form.Group controlId="objectMappingRetention">
                     <Form.Label>Retention</Form.Label>
-                    <Form.Control
-                      as="select"
+                    <Form.Select
                       name="mappingRetention"
                       value={datastreamOptions.retention || 'discard'}
                       onChange={handleInterfaceRetentionChange}
@@ -892,7 +893,7 @@ export default ({
                       <option value="discard">{retentionToLabel.discard}</option>
                       <option value="volatile">{retentionToLabel.volatile}</option>
                       <option value="stored">{retentionToLabel.stored}</option>
-                    </Form.Control>
+                    </Form.Select>
                   </Form.Group>
                 </Col>
                 {showInterfaceExpiry && (
@@ -908,22 +909,19 @@ export default ({
                           isInvalid={(datastreamOptions.expiry || 0) < 0}
                           disabled={denyMajorChanges}
                         />
-                        <InputGroup.Append>
-                          <InputGroup.Text>seconds</InputGroup.Text>
-                        </InputGroup.Append>
+                        <InputGroup.Text>seconds</InputGroup.Text>
                       </InputGroup>
                     </Form.Group>
                   </Col>
                 )}
-              </Form.Row>
+              </Row>
             )}
             {interfaceDraft.type === 'datastream' && interfaceDraft.aggregation === 'object' && (
-              <Form.Row className="mb-2">
+              <Row className="mb-2">
                 <Col md={showInterfaceDatabaseRetentionTtl ? 6 : 12}>
                   <Form.Group controlId="objectMappingDatabaseRetention">
                     <Form.Label>Database Retention</Form.Label>
-                    <Form.Control
-                      as="select"
+                    <Form.Select
                       name="mappingDatabaseRetention"
                       value={datastreamOptions.databaseRetentionPolicy || 'no_ttl'}
                       onChange={handleInterfaceDatabaseRetentionPolicyChange}
@@ -931,7 +929,7 @@ export default ({
                     >
                       <option value="no_ttl">{databaseRetentionToLabel.no_ttl}</option>
                       <option value="use_ttl">{databaseRetentionToLabel.use_ttl}</option>
-                    </Form.Control>
+                    </Form.Select>
                   </Form.Group>
                 </Col>
                 {showInterfaceDatabaseRetentionTtl && (
@@ -947,16 +945,14 @@ export default ({
                           isInvalid={(datastreamOptions.databaseRetentionTtl || 60) < 60}
                           disabled={denyMajorChanges}
                         />
-                        <InputGroup.Append>
-                          <InputGroup.Text>seconds</InputGroup.Text>
-                        </InputGroup.Append>
+                        <InputGroup.Text>seconds</InputGroup.Text>
                       </InputGroup>
                     </Form.Group>
                   </Col>
                 )}
-              </Form.Row>
+              </Row>
             )}
-            <Form.Row className="mb-2">
+            <Row className="mb-2">
               <Col sm={12}>
                 <Form.Group controlId="interfaceDescription">
                   <Form.Label>Description</Form.Label>
@@ -973,8 +969,8 @@ export default ({
                   </Form.Control.Feedback>
                 </Form.Group>
               </Col>
-            </Form.Row>
-            <Form.Row className="mb-2">
+            </Row>
+            <Row className="mb-2">
               <Col sm={12}>
                 <Form.Group controlId="interfaceDocumentation">
                   <Form.Label>Documentation</Form.Label>
@@ -991,8 +987,8 @@ export default ({
                   </Form.Control.Feedback>
                 </Form.Group>
               </Col>
-            </Form.Row>
-            <Form.Row className="mb-2">
+            </Row>
+            <Row className="mb-2">
               <Col sm={12}>
                 <Form.Group controlId="interfaceMappings">
                   <button
@@ -1028,7 +1024,7 @@ export default ({
                   <FormControlWarning message={interfaceValidationWarnings.mappings} />
                 </Form.Group>
               </Col>
-            </Form.Row>
+            </Row>
           </Form>
         </Container>
       </Col>

--- a/src/components/MappingEditor.tsx
+++ b/src/components/MappingEditor.tsx
@@ -17,7 +17,7 @@
 */
 
 import React from 'react';
-import { Col, Form, InputGroup } from 'react-bootstrap';
+import { Col, Form, InputGroup, Row } from 'react-bootstrap';
 import { AstarteMapping } from 'astarte-client';
 import type { AstarteInterface } from 'astarte-client';
 import _ from 'lodash';
@@ -72,7 +72,7 @@ export default ({
 
   return (
     <Form>
-      <Form.Row className="mb-2">
+      <Row className="mb-2">
         <Col sm={12}>
           <Form.Group controlId="mappingEndpoint">
             <Form.Label>Endpoint</Form.Label>
@@ -89,13 +89,12 @@ export default ({
             </Form.Control.Feedback>
           </Form.Group>
         </Col>
-      </Form.Row>
-      <Form.Row className="mb-2">
+      </Row>
+      <Row className="mb-2">
         <Col sm={isPropertiesInterface ? 8 : 12}>
           <Form.Group controlId="mappingType">
             <Form.Label>Type</Form.Label>
-            <Form.Control
-              as="select"
+            <Form.Select
               value={mapping.type}
               onChange={({ target: { value } }) =>
                 onChange({ ...mapping, type: value as AstarteMapping['type'] })
@@ -105,7 +104,7 @@ export default ({
               {astarteDataTypes.map((t) => (
                 <option key={t}>{t}</option>
               ))}
-            </Form.Control>
+            </Form.Select>
             <Form.Control.Feedback type="invalid">
               {mappingValidationErrors.type}
             </Form.Control.Feedback>
@@ -131,14 +130,13 @@ export default ({
             </Form.Group>
           </Col>
         )}
-      </Form.Row>
+      </Row>
       {isDatastreamIndividualInterface && (
-        <Form.Row className="mb-2">
+        <Row className="mb-2">
           <Col md={6}>
             <Form.Group controlId="mappingReliability">
               <Form.Label>Reliability</Form.Label>
-              <Form.Control
-                as="select"
+              <Form.Select
                 name="reliability"
                 value={mapping.reliability || 'unreliable'}
                 onChange={({ currentTarget: { value } }) => {
@@ -151,7 +149,7 @@ export default ({
                 <option value="unreliable">Unreliable</option>
                 <option value="guaranteed">Guaranteed</option>
                 <option value="unique">Unique</option>
-              </Form.Control>
+              </Form.Select>
               <Form.Control.Feedback type="invalid">
                 {mappingValidationErrors.reliability}
               </Form.Control.Feedback>
@@ -175,15 +173,14 @@ export default ({
               </Form.Control.Feedback>
             </Form.Group>
           </Col>
-        </Form.Row>
+        </Row>
       )}
       {isDatastreamIndividualInterface && (
-        <Form.Row className="mb-2">
+        <Row className="mb-2">
           <Col md={showMappingExpiry ? 6 : 12}>
             <Form.Group controlId="mappingRetention">
               <Form.Label>Retention</Form.Label>
-              <Form.Control
-                as="select"
+              <Form.Select
                 name="retention"
                 value={mapping.retention || 'discard'}
                 onChange={({ currentTarget: { value } }) => {
@@ -199,7 +196,7 @@ export default ({
                 <option value="discard">Discard</option>
                 <option value="volatile">Volatile</option>
                 <option value="stored">Stored</option>
-              </Form.Control>
+              </Form.Select>
               <Form.Control.Feedback type="invalid">
                 {mappingValidationErrors.retention}
               </Form.Control.Feedback>
@@ -220,9 +217,7 @@ export default ({
                     }}
                     isInvalid={mappingValidationErrors.expiry != null}
                   />
-                  <InputGroup.Append>
-                    <InputGroup.Text>seconds</InputGroup.Text>
-                  </InputGroup.Append>
+                  <InputGroup.Text>seconds</InputGroup.Text>
                   <Form.Control.Feedback type="invalid">
                     {mappingValidationErrors.expiry}
                   </Form.Control.Feedback>
@@ -230,15 +225,14 @@ export default ({
               </Form.Group>
             </Col>
           )}
-        </Form.Row>
+        </Row>
       )}
       {isDatastreamIndividualInterface && (
-        <Form.Row className="mb-2">
+        <Row className="mb-2">
           <Col md={showInterfaceDatabaseRetentionTtl ? 6 : 12}>
             <Form.Group controlId="mappingDatabaseRetention">
               <Form.Label>Database retention</Form.Label>
-              <Form.Control
-                as="select"
+              <Form.Select
                 name="mappingDatabaseRetention"
                 value={mapping.databaseRetentionPolicy || 'no_ttl'}
                 onChange={({ currentTarget: { value } }) => {
@@ -258,7 +252,7 @@ export default ({
               >
                 <option value="no_ttl">No TTL</option>
                 <option value="use_ttl">Use TTL</option>
-              </Form.Control>
+              </Form.Select>
               <Form.Control.Feedback type="invalid">
                 {mappingValidationErrors.databaseRetentionPolicy}
               </Form.Control.Feedback>
@@ -279,9 +273,7 @@ export default ({
                     }}
                     isInvalid={mappingValidationErrors.databaseRetentionTtl != null}
                   />
-                  <InputGroup.Append>
-                    <InputGroup.Text>seconds</InputGroup.Text>
-                  </InputGroup.Append>
+                  <InputGroup.Text>seconds</InputGroup.Text>
                   <Form.Control.Feedback type="invalid">
                     {mappingValidationErrors.databaseRetentionTtl}
                   </Form.Control.Feedback>
@@ -289,9 +281,9 @@ export default ({
               </Form.Group>
             </Col>
           )}
-        </Form.Row>
+        </Row>
       )}
-      <Form.Row className="mb-2">
+      <Row className="mb-2">
         <Col sm={12}>
           <Form.Group controlId="mappingDescription">
             <Form.Label>Description</Form.Label>
@@ -309,8 +301,8 @@ export default ({
             </Form.Control.Feedback>
           </Form.Group>
         </Col>
-      </Form.Row>
-      <Form.Row className="mb-2">
+      </Row>
+      <Row className="mb-2">
         <Col sm={12}>
           <Form.Group controlId="mappingDocumentation">
             <Form.Label>Documentation</Form.Label>
@@ -328,7 +320,7 @@ export default ({
             </Form.Control.Feedback>
           </Form.Group>
         </Col>
-      </Form.Row>
+      </Row>
     </Form>
   );
 };

--- a/src/components/TriggerDeliveryPolicyEditor.tsx
+++ b/src/components/TriggerDeliveryPolicyEditor.tsx
@@ -253,7 +253,7 @@ export default ({
           <Form.Group controlId="policySource" className="h-100 d-flex flex-column">
             <Form.Control
               as="textarea"
-              className="flex-grow-1 text-monospace"
+              className="flex-grow-1 font-monospace"
               value={policySource}
               onChange={handlePolicySourceChange}
               autoComplete="off"

--- a/src/components/TriggerDeliveryPolicyEditor.tsx
+++ b/src/components/TriggerDeliveryPolicyEditor.tsx
@@ -172,7 +172,7 @@ export default ({
       <Col md={isSourceVisible ? 6 : 12}>
         <Container fluid className="bg-white rounded p-3">
           <Form>
-            <Form.Row className="mb-2">
+            <Row className="mb-2">
               <Col sm={12}>
                 <Form.Group controlId="policyName">
                   <Form.Label>Name</Form.Label>
@@ -238,13 +238,11 @@ export default ({
                       value={_.get(policyDraft, 'event_ttl') || 0}
                       onChange={handleEventTtlChange}
                     />
-                    <InputGroup.Append>
-                      <InputGroup.Text>seconds</InputGroup.Text>
-                    </InputGroup.Append>
+                    <InputGroup.Text>seconds</InputGroup.Text>
                   </InputGroup>
                 </Form.Group>
               </Col>
-            </Form.Row>
+            </Row>
           </Form>
         </Container>
       </Col>

--- a/src/components/TriggerDeliveryPolicyHandler.tsx
+++ b/src/components/TriggerDeliveryPolicyHandler.tsx
@@ -95,7 +95,7 @@ const HandlerModal = ({
     typeof handlerOn === 'object' ? handler.on.toString() : '',
   );
 
-  const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
+  const handleOnChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const { value } = event.target;
     setSelectedErrorType(value);
     setHandlerOn(value as 'any_error' | 'client_error' | 'server_error' | number[]);
@@ -141,11 +141,10 @@ const HandlerModal = ({
           <Form>
             <Form.Group className="mb-3" controlId="errorHandlerOn">
               <Form.Label>On</Form.Label>
-              <Form.Control
-                as="select"
+              <Form.Select
                 required
                 name="on"
-                readOnly={readOnly}
+                disabled={readOnly}
                 value={typeof handlerOn === 'object' ? 'custom_errors' : handlerOn.toString()}
                 onChange={handleOnChange}
               >
@@ -153,7 +152,7 @@ const HandlerModal = ({
                 <option value="server_error">server_error</option>
                 <option value="client_error">client_error</option>
                 <option value="custom_errors">Enter custom array of error numbers (400-599)</option>
-              </Form.Control>
+              </Form.Select>
             </Form.Group>
             {selectedErrorType === 'custom_errors' && (
               <ErrorCodesControl
@@ -165,17 +164,16 @@ const HandlerModal = ({
             )}
             <Form.Group className="mb-3" controlId="errorHandlerStrategy">
               <Form.Label>Strategy</Form.Label>
-              <Form.Control
-                as="select"
+              <Form.Select
                 value={handlerStrategy}
-                readOnly={readOnly}
+                disabled={readOnly}
                 required
                 name="strategy"
                 onChange={handleStrategyChange}
               >
                 <option value="discard">Discard</option>
                 <option value="retry">Retry</option>
-              </Form.Control>
+              </Form.Select>
             </Form.Group>
           </Form>
         </Modal.Body>

--- a/src/components/TriggerDeliveryPolicyHandler.tsx
+++ b/src/components/TriggerDeliveryPolicyHandler.tsx
@@ -266,7 +266,7 @@ export default ({ isReadOnly, initialData, onChange }: Props): React.ReactElemen
       <Form.Group controlId="policyHandler">
         {!isReadOnly && (
           <Button variant="link" className="p-0" onClick={() => setIsAddingHandler(true)}>
-            <Icon icon="add" className="mr-2" />
+            <Icon icon="add" className="me-2" />
             Add Error Handler
           </Button>
         )}
@@ -294,7 +294,7 @@ export default ({ isReadOnly, initialData, onChange }: Props): React.ReactElemen
                       <Icon
                         icon="edit"
                         onClick={() => setHandlerToEditIndex(index)}
-                        className="color-grey mr-2"
+                        className="color-grey me-2"
                       />
                       <Icon
                         icon="erase"

--- a/src/components/TriggerEditor/SimpleTriggerForm.tsx
+++ b/src/components/TriggerEditor/SimpleTriggerForm.tsx
@@ -17,7 +17,7 @@
 */
 
 import React, { useCallback, useMemo } from 'react';
-import { Col, Form } from 'react-bootstrap';
+import { Col, Form, Row } from 'react-bootstrap';
 import {
   AstarteInterface,
   AstarteMapping,
@@ -132,7 +132,7 @@ const SimpleTriggerForm = ({
   }, [simpleTriggerInterface, triggerMatchPath]);
 
   const handleTriggerTypeChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
       const { value } = e.currentTarget;
       const type = value as AstarteSimpleTrigger['type'];
       onChange(type === 'data_trigger' ? defaultSimpleDataTrigger : defaultSimpleDeviceTrigger);
@@ -141,7 +141,7 @@ const SimpleTriggerForm = ({
   );
 
   const handleTriggerConditionChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
       const { value } = e.currentTarget;
       const on = value as AstarteSimpleTrigger['on'];
       onChange({ ...simpleTrigger, on } as AstarteSimpleTrigger);
@@ -150,7 +150,7 @@ const SimpleTriggerForm = ({
   );
 
   const handleTriggerTargetChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
       const { value } = e.currentTarget;
       const target = value as 'all_devices' | 'device' | 'group';
       if (target === 'device') {
@@ -181,7 +181,7 @@ const SimpleTriggerForm = ({
   );
 
   const handleTriggerInterfaceNameChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
       const { value } = e.target;
       const interfaceName = value;
       const newSimpleTrigger = {
@@ -207,7 +207,7 @@ const SimpleTriggerForm = ({
   );
 
   const handleTriggerInterfaceMajorChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
       const { value } = e.target;
       const interfaceMajor = parseInt(value, 10);
       onChange({
@@ -238,7 +238,7 @@ const SimpleTriggerForm = ({
   );
 
   const handleTriggerInterfaceOperatorChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
       const { value } = e.target;
       const valueMatchOperator = value as AstarteSimpleDataTrigger['valueMatchOperator'];
       if (valueMatchOperator === '*') {
@@ -361,12 +361,11 @@ const SimpleTriggerForm = ({
 
   return (
     <Form>
-      <Form.Row className="mb-2">
+      <Row className="mb-2">
         <Col sm={12}>
           <Form.Group controlId="triggerSimpleTriggerType">
             <Form.Label>Trigger type</Form.Label>
-            <Form.Control
-              as="select"
+            <Form.Select
               name="triggerSimpleTriggerType"
               disabled={isReadOnly}
               value={_.get(simpleTrigger, 'type')}
@@ -375,19 +374,18 @@ const SimpleTriggerForm = ({
             >
               <option value="device_trigger">Device Trigger</option>
               <option value="data_trigger">Data Trigger</option>
-            </Form.Control>
+            </Form.Select>
             <Form.Control.Feedback type="invalid">
               {_.get(validationErrors, 'type')}
             </Form.Control.Feedback>
           </Form.Group>
         </Col>
-      </Form.Row>
-      <Form.Row className="mb-2">
+      </Row>
+      <Row className="mb-2">
         <Col sm={hasTargetDevice || hasTargetGroup ? 4 : 12}>
           <Form.Group controlId="triggerTargetSelect">
             <Form.Label>Target</Form.Label>
-            <Form.Control
-              as="select"
+            <Form.Select
               name="triggerTargetSelect"
               disabled={isReadOnly}
               value={triggerTargetType}
@@ -396,7 +394,7 @@ const SimpleTriggerForm = ({
               <option value="all_devices">All devices</option>
               <option value="device">Device</option>
               <option value="group">Group</option>
-            </Form.Control>
+            </Form.Select>
           </Form.Group>
         </Col>
         {hasTargetDevice && (
@@ -437,13 +435,12 @@ const SimpleTriggerForm = ({
             </Form.Group>
           </Col>
         )}
-      </Form.Row>
-      <Form.Row className="mb-2">
+      </Row>
+      <Row className="mb-2">
         <Col sm={12}>
           <Form.Group controlId="triggerCondition">
             <Form.Label>Trigger condition</Form.Label>
-            <Form.Control
-              as="select"
+            <Form.Select
               name="triggerCondition"
               disabled={isReadOnly || isLoadingInterface}
               value={_.get(simpleTrigger, 'on')}
@@ -451,21 +448,20 @@ const SimpleTriggerForm = ({
               isInvalid={_.get(validationErrors, 'on') != null}
             >
               {renderTriggerConditionOptions()}
-            </Form.Control>
+            </Form.Select>
             <Form.Control.Feedback type="invalid">
               {_.get(validationErrors, 'on')}
             </Form.Control.Feedback>
           </Form.Group>
         </Col>
-      </Form.Row>
+      </Row>
       {isDataTrigger && (
         <>
-          <Form.Row className="mb-2">
+          <Row className="mb-2">
             <Col sm={hasSelectedInterface ? 8 : 12}>
               <Form.Group controlId="triggerInterfaceName">
                 <Form.Label>Interface name</Form.Label>
-                <Form.Control
-                  as="select"
+                <Form.Select
                   name="triggerInterfaceName"
                   disabled={isReadOnly || isLoadingInterfacesName}
                   value={triggerInterfaceName || '*'}
@@ -473,7 +469,7 @@ const SimpleTriggerForm = ({
                   isInvalid={_.get(validationErrors, 'interfaceName') != null}
                 >
                   {renderInterfaceNameOptions()}
-                </Form.Control>
+                </Form.Select>
                 <Form.Control.Feedback type="invalid">
                   {_.get(validationErrors, 'interfaceName')}
                 </Form.Control.Feedback>
@@ -483,8 +479,7 @@ const SimpleTriggerForm = ({
               <Col sm={4}>
                 <Form.Group controlId="triggerInterfaceMajor">
                   <Form.Label>Interface major</Form.Label>
-                  <Form.Control
-                    as="select"
+                  <Form.Select
                     name="triggerInterfaceMajor"
                     disabled={isReadOnly || isLoadingInterfaceMajors || isLoadingInterface}
                     value={_.get(simpleTrigger, 'interfaceMajor') || 0}
@@ -492,17 +487,17 @@ const SimpleTriggerForm = ({
                     isInvalid={_.get(validationErrors, 'interfaceMajor') != null}
                   >
                     {renderInterfaceMajorOptions()}
-                  </Form.Control>
+                  </Form.Select>
                   <Form.Control.Feedback type="invalid">
                     {_.get(validationErrors, 'interfaceMajor')}
                   </Form.Control.Feedback>
                 </Form.Group>
               </Col>
             )}
-          </Form.Row>
+          </Row>
           {hasSelectedInterface && (
             <>
-              <Form.Row className="mb-2">
+              <Row className="mb-2">
                 <Col sm={12}>
                   <Form.Group controlId="triggerPath">
                     <Form.Label>Path</Form.Label>
@@ -520,13 +515,12 @@ const SimpleTriggerForm = ({
                     </Form.Control.Feedback>
                   </Form.Group>
                 </Col>
-              </Form.Row>
-              <Form.Row className="mb-2">
+              </Row>
+              <Row className="mb-2">
                 <Col sm={4}>
                   <Form.Group controlId="triggerOperator">
                     <Form.Label>Operator</Form.Label>
-                    <Form.Control
-                      as="select"
+                    <Form.Select
                       name="triggerOperator"
                       disabled={isReadOnly || isLoadingInterfaceMajors || isLoadingInterface}
                       value={triggerValueMatchOperator || '*'}
@@ -534,7 +528,7 @@ const SimpleTriggerForm = ({
                       isInvalid={_.get(validationErrors, 'valueMatchOperator') != null}
                     >
                       {renderTriggerOperatorOptions()}
-                    </Form.Control>
+                    </Form.Select>
                     <Form.Control.Feedback type="invalid">
                       {_.get(validationErrors, 'valueMatchOperator')}
                     </Form.Control.Feedback>
@@ -559,7 +553,7 @@ const SimpleTriggerForm = ({
                     </Form.Group>
                   </Col>
                 )}
-              </Form.Row>
+              </Row>
             </>
           )}
         </>

--- a/src/components/TriggerEditor/TriggerActionForm.tsx
+++ b/src/components/TriggerEditor/TriggerActionForm.tsx
@@ -300,7 +300,7 @@ const TriggerActionForm = ({
               <Form.Group controlId="actionHttpHeaders">
                 {!isReadOnly && (
                   <Button variant="link" className="p-0" onClick={() => onAddHttpHeader()}>
-                    <Icon icon="add" className="mr-2" />
+                    <Icon icon="add" className="me-2" />
                     Add custom HTTP headers
                   </Button>
                 )}
@@ -323,7 +323,7 @@ const TriggerActionForm = ({
                               <Icon
                                 icon="edit"
                                 onClick={() => onEditHttpHeader(headerName)}
-                                className="color-grey mr-2"
+                                className="color-grey me-2"
                               />
                               <Icon icon="erase" onClick={() => onDeleteHttpHeader(headerName)} />
                             </td>
@@ -454,7 +454,7 @@ const TriggerActionForm = ({
               <Form.Group controlId="actionAmqpHeaders">
                 {!isReadOnly && (
                   <Button variant="link" className="p-0" onClick={() => onAddAmqpHeader()}>
-                    <Icon icon="add" className="mr-2" />
+                    <Icon icon="add" className="me-2" />
                     Add static AMQP headers
                   </Button>
                 )}
@@ -477,7 +477,7 @@ const TriggerActionForm = ({
                               <Icon
                                 icon="edit"
                                 onClick={() => onEditAmqpHeader(headerName)}
-                                className="color-grey mr-2"
+                                className="color-grey me-2"
                               />
                               <Icon icon="erase" onClick={() => onDeleteAmqpHeader(headerName)} />
                             </td>

--- a/src/components/TriggerEditor/TriggerActionForm.tsx
+++ b/src/components/TriggerEditor/TriggerActionForm.tsx
@@ -17,7 +17,7 @@
 */
 
 import React, { useCallback } from 'react';
-import { Button, Col, Form, InputGroup, Table } from 'react-bootstrap';
+import { Button, Col, Form, InputGroup, Row, Table } from 'react-bootstrap';
 import { AstarteTrigger, AstarteTriggerHTTPAction, AstarteTriggerAMQPAction } from 'astarte-client';
 import _ from 'lodash';
 
@@ -68,7 +68,7 @@ const TriggerActionForm = ({
   const triggerAmqpHeaders = _.get(action, 'amqpStaticHeaders') || {};
 
   const handleTriggerActionTypeChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
       const { value } = e.target;
       const actionType = value as 'amqp' | 'http';
       onChange(actionType === 'http' ? defaultTriggerHttpAction : defaultTriggerAmqpAction);
@@ -77,7 +77,7 @@ const TriggerActionForm = ({
   );
 
   const handleTriggerActionHttpMethodChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
       const { value } = e.target;
       const httpMethod = value as AstarteTriggerHTTPAction['httpMethod'];
       onChange({ ...action, httpMethod });
@@ -104,7 +104,7 @@ const TriggerActionForm = ({
   );
 
   const handleTriggerActionHttpPayloadTypeChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
       const { value } = e.target;
       const payloadType = value as 'default' | 'mustache';
       if (payloadType === 'mustache') {
@@ -178,12 +178,11 @@ const TriggerActionForm = ({
 
   return (
     <Form>
-      <Form.Row className="mb-2">
+      <Row className="mb-2">
         <Col sm={12}>
           <Form.Group controlId="triggerActionType">
             <Form.Label>Action type</Form.Label>
-            <Form.Control
-              as="select"
+            <Form.Select
               name="triggerActionType"
               disabled={isReadOnly}
               value={isAmqpAction ? 'amqp' : 'http'}
@@ -191,18 +190,17 @@ const TriggerActionForm = ({
             >
               <option value="http">HTTP request</option>
               <option value="amqp">AMQP Message</option>
-            </Form.Control>
+            </Form.Select>
           </Form.Group>
         </Col>
-      </Form.Row>
+      </Row>
       {isHttpAction && (
         <>
-          <Form.Row className="mb-2">
+          <Row className="mb-2">
             <Col sm={4}>
               <Form.Group controlId="triggerMethod">
                 <Form.Label>Method</Form.Label>
-                <Form.Control
-                  as="select"
+                <Form.Select
                   name="triggerMethod"
                   disabled={isReadOnly}
                   value={_.get(action, 'httpMethod') || 'post'}
@@ -214,7 +212,7 @@ const TriggerActionForm = ({
                       {method.toUpperCase()}
                     </option>
                   ))}
-                </Form.Control>
+                </Form.Select>
                 <Form.Control.Feedback type="invalid">
                   {_.get(validationErrors, 'httpMethod')}
                 </Form.Control.Feedback>
@@ -237,8 +235,8 @@ const TriggerActionForm = ({
                 </Form.Control.Feedback>
               </Form.Group>
             </Col>
-          </Form.Row>
-          <Form.Row className="mb-2">
+          </Row>
+          <Row className="mb-2">
             <Col sm={12}>
               <Form.Group controlId="actionIgnoreSSLErrors">
                 <Form.Check
@@ -255,13 +253,12 @@ const TriggerActionForm = ({
                 </Form.Control.Feedback>
               </Form.Group>
             </Col>
-          </Form.Row>
-          <Form.Row className="mb-2">
+          </Row>
+          <Row className="mb-2">
             <Col sm={12}>
               <Form.Group controlId="triggerTemplateType">
                 <Form.Label>Payload type</Form.Label>
-                <Form.Control
-                  as="select"
+                <Form.Select
                   name="triggerTemplateType"
                   disabled={isReadOnly}
                   value={triggerPayloadType}
@@ -269,12 +266,12 @@ const TriggerActionForm = ({
                 >
                   <option value="default">Use default event format (JSON)</option>
                   <option value="mustache">Mustache</option>
-                </Form.Control>
+                </Form.Select>
               </Form.Group>
             </Col>
-          </Form.Row>
+          </Row>
           {triggerPayloadType === 'mustache' && (
-            <Form.Row className="mb-2">
+            <Row className="mb-2">
               <Col sm={12}>
                 <Form.Group controlId="actionPayload">
                   <Form.Label>Payload</Form.Label>
@@ -293,9 +290,9 @@ const TriggerActionForm = ({
                   </Form.Control.Feedback>
                 </Form.Group>
               </Col>
-            </Form.Row>
+            </Row>
           )}
-          <Form.Row className="mb-2">
+          <Row className="mb-2">
             <Col sm={12}>
               <Form.Group controlId="actionHttpHeaders">
                 {!isReadOnly && (
@@ -342,12 +339,12 @@ const TriggerActionForm = ({
                 </Form.Control.Feedback>
               </Form.Group>
             </Col>
-          </Form.Row>
+          </Row>
         </>
       )}
       {isAmqpAction && (
         <>
-          <Form.Row className="mb-2">
+          <Row className="mb-2">
             <Col sm={12}>
               <Form.Group controlId="amqpExchange">
                 <Form.Label>Exchange</Form.Label>
@@ -366,8 +363,8 @@ const TriggerActionForm = ({
                 </Form.Control.Feedback>
               </Form.Group>
             </Col>
-          </Form.Row>
-          <Form.Row className="mb-2">
+          </Row>
+          <Row className="mb-2">
             <Col sm={12}>
               <Form.Group controlId="amqpRoutingKey">
                 <Form.Label>Routing key</Form.Label>
@@ -385,8 +382,8 @@ const TriggerActionForm = ({
                 </Form.Control.Feedback>
               </Form.Group>
             </Col>
-          </Form.Row>
-          <Form.Row className="mb-2">
+          </Row>
+          <Row className="mb-2">
             <Col sm={12}>
               <Form.Group controlId="amqpPersistency">
                 <Form.Label>Persistency</Form.Label>
@@ -404,8 +401,8 @@ const TriggerActionForm = ({
                 </Form.Control.Feedback>
               </Form.Group>
             </Col>
-          </Form.Row>
-          <Form.Row className="mb-2">
+          </Row>
+          <Row className="mb-2">
             <Col sm={12}>
               <Form.Group controlId="amqpPriority">
                 <Form.Label>Priority</Form.Label>
@@ -424,8 +421,8 @@ const TriggerActionForm = ({
                 </Form.Control.Feedback>
               </Form.Group>
             </Col>
-          </Form.Row>
-          <Form.Row className="mb-2">
+          </Row>
+          <Row className="mb-2">
             <Col sm={12}>
               <Form.Group controlId="amqpExpiration">
                 <Form.Label>Expiration</Form.Label>
@@ -439,17 +436,15 @@ const TriggerActionForm = ({
                     onChange={handleTriggerActionAmqpMessageExpirationMillisecondsChange}
                     isInvalid={_.get(validationErrors, 'amqpMessageExpirationMilliseconds') != null}
                   />
-                  <InputGroup.Append>
-                    <InputGroup.Text>milliseconds</InputGroup.Text>
-                  </InputGroup.Append>
+                  <InputGroup.Text>milliseconds</InputGroup.Text>
                   <Form.Control.Feedback type="invalid">
                     {_.get(validationErrors, 'amqpMessageExpirationMilliseconds')}
                   </Form.Control.Feedback>
                 </InputGroup>
               </Form.Group>
             </Col>
-          </Form.Row>
-          <Form.Row className="mb-2">
+          </Row>
+          <Row className="mb-2">
             <Col sm={12}>
               <Form.Group controlId="actionAmqpHeaders">
                 {!isReadOnly && (
@@ -496,7 +491,7 @@ const TriggerActionForm = ({
                 </Form.Control.Feedback>
               </Form.Group>
             </Col>
-          </Form.Row>
+          </Row>
         </>
       )}
     </Form>

--- a/src/components/TriggerEditor/index.tsx
+++ b/src/components/TriggerEditor/index.tsx
@@ -532,7 +532,7 @@ export default ({
           <Form.Group controlId="triggerSource" className="h-100 d-flex flex-column">
             <Form.Control
               as="textarea"
-              className="flex-grow-1 text-monospace"
+              className="flex-grow-1 font-monospace"
               autoComplete="off"
               spellCheck={false}
               required

--- a/src/components/TriggerEditor/index.tsx
+++ b/src/components/TriggerEditor/index.tsx
@@ -288,7 +288,7 @@ export default ({
     setTriggerDraft((draft) => ({ ...draft, name: value }));
   }, []);
 
-  const handleTriggerPolicyNameChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleTriggerPolicyNameChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
     const { value } = e.target;
     if (value) {
       setTriggerDraft((draft) => ({ ...draft, policy: value }));
@@ -448,7 +448,7 @@ export default ({
       <Col md={isSourceVisible ? 6 : 12}>
         <Container fluid className="bg-white rounded p-3">
           <Form>
-            <Form.Row className="mb-2">
+            <Row className="mb-2">
               <Col sm={12}>
                 <Form.Group controlId="triggerName">
                   <Form.Label>Name</Form.Label>
@@ -466,7 +466,7 @@ export default ({
                   </Form.Control.Feedback>
                 </Form.Group>
               </Col>
-            </Form.Row>
+            </Row>
           </Form>
           <SimpleTriggerForm
             fetchInterface={handleFetchInterface}
@@ -496,12 +496,11 @@ export default ({
             validationErrors={actionValidationErrors}
           />
           <Form>
-            <Form.Row className="mb-2">
+            <Row className="mb-2">
               <Col sm={12}>
                 <Form.Group controlId="triggerPolicyName">
                   <Form.Label>Trigger delivery policy</Form.Label>
-                  <Form.Control
-                    as="select"
+                  <Form.Select
                     name="triggerPolicyName"
                     disabled={isReadOnly || isLoadingPoliciesName}
                     value={_.get(triggerDraft, 'policy')}
@@ -517,13 +516,13 @@ export default ({
                         {policy}
                       </option>
                     ))}
-                  </Form.Control>
+                  </Form.Select>
                   <Form.Control.Feedback type="invalid">
                     {_.get(triggerValidationErrors, 'policy')}
                   </Form.Control.Feedback>
                 </Form.Group>
               </Col>
-            </Form.Row>
+            </Row>
           </Form>
         </Container>
       </Col>

--- a/src/components/modals/Confirm.tsx
+++ b/src/components/modals/Confirm.tsx
@@ -87,7 +87,7 @@ const ConfirmModal = ({
             style={{ minWidth: '5em' }}
           >
             {isConfirming && (
-              <Spinner className="mr-2" size="sm" animation="border" role="status" />
+              <Spinner className="me-2" size="sm" animation="border" role="status" />
             )}
             {confirmLabel}
           </Button>

--- a/src/components/modals/Form.tsx
+++ b/src/components/modals/Form.tsx
@@ -165,7 +165,7 @@ const FormModal = ({
           >
             <hr style={{ display: 'block', marginLeft: '-1em', marginRight: '-1em' }} />
             <div className="d-flex justify-content-end">
-              <Button variant="secondary mr-2" onClick={onCancel} style={{ minWidth: '5em' }}>
+              <Button variant="secondary me-2" onClick={onCancel} style={{ minWidth: '5em' }}>
                 {cancelLabel}
               </Button>
               <Button
@@ -176,7 +176,7 @@ const FormModal = ({
                 style={{ minWidth: '5em' }}
               >
                 {isConfirming && (
-                  <Spinner className="mr-2" size="sm" animation="border" role="status" />
+                  <Spinner className="me-2" size="sm" animation="border" role="status" />
                 )}
                 {confirmLabel}
               </Button>

--- a/src/components/modals/Form.tsx
+++ b/src/components/modals/Form.tsx
@@ -19,7 +19,9 @@
 import React, { useState } from 'react';
 import { Button, Form, Modal, Spinner } from 'react-bootstrap';
 import type { ModalProps } from 'react-bootstrap';
-import JsonSchemaForm from '@rjsf/bootstrap-4';
+// TODO: use @rjsf/react-bootstrap when @rjsf publishes v6 with support for
+// Bootstrap 5: https://github.com/rjsf-team/react-jsonschema-form/issues/4162
+import JsonSchemaForm from '@astarte-platform/react-bootstrap';
 import validator from '@rjsf/validator-ajv8';
 import type { IChangeEvent } from '@rjsf/core';
 import type { WidgetProps } from '@rjsf/utils';

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -250,15 +250,6 @@ h6,
   }
 }
 
-.accordion-button {
-  padding: 1em 2em;
-  border: 1px solid rgba(0, 0, 0, 0.125);
-  border-radius: 0.25rem;
-  background-color: rgba(0, 0, 0, 0.03);
-  color: $primary;
-  text-align: left;
-}
-
 .device-data-piechart {
   max-height: 20em;
   height: 100%;

--- a/src/ui/BackButton.tsx
+++ b/src/ui/BackButton.tsx
@@ -27,7 +27,7 @@ interface Props {
 
 export default function BackButton({ href }: Props): React.ReactElement {
   return (
-    <Link to={href} className="mr-2" aria-label="Back">
+    <Link to={href} className="me-2" aria-label="Back">
       <Icon icon="arrowLeft" />
     </Link>
   );

--- a/src/ui/CheckableDeviceTable.tsx
+++ b/src/ui/CheckableDeviceTable.tsx
@@ -78,7 +78,7 @@ const DeviceTableRow = ({
           onChange={onToggleChange}
         />
       </td>
-      <td className="text-monospace">
+      <td className="font-monospace">
         <Highlight text={deviceId} word={filter} />
       </td>
       <td>

--- a/src/ui/SingleCardPage.tsx
+++ b/src/ui/SingleCardPage.tsx
@@ -43,9 +43,9 @@ export default function SingleCardPage({
           {title}
         </h2>
         {docsLink && (
-          <div className="float-right">
+          <div className="float-end">
             <a target="_blank" rel="noreferrer" href={docsLink}>
-              <Icon icon="documentation" className="mr-2" />
+              <Icon icon="documentation" className="me-2" />
               Documentation
             </a>
           </div>


### PR DESCRIPTION
Migrate the code from using Bootstrap v4 to v5.

The migration paths from Bootstrap and React Bootstrap are followed to adopt the updated defaults and components.

Notable changes:
- The custom color palette is updated to work better with the default Boostrap settings and produce readable texts on colored backgrounds.
- Links are now styled with an underline.

Closes #413