### PR TITLE
Display device registration limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add Delete device button in Device Info Card ([#397](https://github.com/astarte-platform/astarte-dashboard/issues/397)).
 - Add Deletion in progress column for every device ([#398](https://github.com/astarte-platform/astarte-dashboard/issues/398)).
+- Report the device registration limit, how many devices can be registered, and why new devices cannot be registered ([#407](https://github.com/astarte-platform/astarte-dashboard/issues/407), [#408](https://github.com/astarte-platform/astarte-dashboard/issues/408)). 
 
 ## [1.1.2] - Unreleased
 ### Fixed

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,29 +29,11 @@ import PageRouter from './Router';
 import AstarteProvider, { useAstarte } from './AstarteManager';
 import type { DashboardConfig } from './types';
 import Snackbar from './ui/Snackbar';
-import useFetch from './hooks/useFetch';
-import useInterval from './hooks/useInterval';
 import createReduxStore from './store';
 
 const DashboardSidebar = () => {
   const config = useConfig();
   const astarte = useAstarte();
-
-  const healthFetcher = useFetch(() => {
-    const apiChecks = [
-      astarte.client.getAppengineHealth(),
-      astarte.client.getRealmManagementHealth(),
-      astarte.client.getPairingHealth(),
-    ];
-    if (config.features.flow) {
-      apiChecks.push(astarte.client.getFlowHealth());
-    }
-    return Promise.all(apiChecks);
-  });
-
-  useInterval(healthFetcher.refresh, 30000);
-
-  const isApiHealthy = healthFetcher.status !== 'err';
 
   if (!astarte.isAuthenticated) {
     return null;
@@ -80,7 +62,7 @@ const DashboardSidebar = () => {
         )}
         <Sidebar.Item label="Realm settings" link="/settings" icon="settings" />
         <Sidebar.Separator />
-        <Sidebar.ApiStatus healthy={isApiHealthy} realm={astarte.realm} />
+        <Sidebar.ApiStatus />
         <Sidebar.Separator />
         <Sidebar.Item label="Logout" link="/logout" icon="logout" />
         <Sidebar.AppInfo appVersion={import.meta.env.VITE_APP_VERSION || ''} />

--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -108,12 +108,14 @@ const ApiStatusCard = ({
 interface DevicesCardProps {
   connectedDevices: number;
   totalDevices: number;
+  deviceRegistrationLimit: number | null;
   connectedDevicesProvider: ChartProvider<'Object', ConnectedDevices>;
 }
 
 const DevicesCard = ({
   connectedDevices,
   totalDevices,
+  deviceRegistrationLimit,
   connectedDevicesProvider,
 }: DevicesCardProps): React.ReactElement => (
   <Card id="devices-card" className="h-100">
@@ -123,9 +125,15 @@ const DevicesCard = ({
         <Row noGutters>
           <Col xs={12} lg={6}>
             <Card.Title>Connected devices</Card.Title>
-            <Card.Text>{connectedDevices}</Card.Text>
+            <Card.Text>
+              {connectedDevices} / {totalDevices}
+            </Card.Text>
             <Card.Title>Registered devices</Card.Title>
-            <Card.Text>{totalDevices}</Card.Text>
+            <Card.Text>
+              {deviceRegistrationLimit != null
+                ? `${totalDevices} / ${deviceRegistrationLimit}`
+                : totalDevices}
+            </Card.Text>
           </Col>
           <Col xs={12} lg={6}>
             {totalDevices > 0 && <ConnectedDevicesChart provider={connectedDevicesProvider} />}
@@ -319,6 +327,7 @@ const HomePage = (): React.ReactElement => {
   const realmManagementHealth = useFetch(astarte.client.getRealmManagementHealth);
   const pairingHealth = useFetch(astarte.client.getPairingHealth);
   const flowHealth = useFetch(config.features.flow ? astarte.client.getFlowHealth : async () => {});
+  const deviceRegistrationLimitFetcher = useFetch(astarte.client.getDeviceRegistrationLimit);
   const navigate = useNavigate();
 
   const connectedDevicesProvider = useMemo(
@@ -379,6 +388,7 @@ const HomePage = (): React.ReactElement => {
               <DevicesCard
                 connectedDevices={connectedDevices}
                 totalDevices={totalDevices}
+                deviceRegistrationLimit={deviceRegistrationLimitFetcher.value}
                 connectedDevicesProvider={connectedDevicesProvider}
               />
             </Col>

--- a/src/RealmSettingsPage.tsx
+++ b/src/RealmSettingsPage.tsx
@@ -82,6 +82,7 @@ export default (): React.ReactElement => {
   const navigate = useNavigate();
 
   const authConfigFetcher = useFetch(astarte.client.getConfigAuth);
+  const deviceRegistrationLimitFetcher = useFetch(astarte.client.getDeviceRegistrationLimit);
 
   const showModal = useCallback(() => setIsModalVisible(true), [setIsModalVisible]);
 
@@ -122,6 +123,10 @@ export default (): React.ReactElement => {
   return (
     <SingleCardPage title="Realm Settings">
       <AlertsBanner alerts={formAlerts} />
+      <Form.Group controlId="device-registration-limit">
+        <Form.Label>Device registration limit</Form.Label>
+        <Form.Control value={deviceRegistrationLimitFetcher.value ?? 'No limit'} readOnly />
+      </Form.Group>
       <WaitForData
         data={authConfigFetcher.value}
         status={authConfigFetcher.status}

--- a/src/RegisterDevicePage.tsx
+++ b/src/RegisterDevicePage.tsx
@@ -295,8 +295,13 @@ export default (): React.ReactElement => {
         setShowCredentialSecretModal(true);
       })
       .catch((err) => {
+        const deviceRegistrationLimitReached =
+          err?.response?.data?.errors?.error_name?.[0] === 'device_registration_limit_reached';
+        const errorMessage = deviceRegistrationLimitReached
+          ? `The device registration limit was reached and there are too many registered devices already.`
+          : err.message;
         setRegisteringDevice(false);
-        registrationAlertsController.showError(`Couldn't register device: ${err.message}`);
+        registrationAlertsController.showError(`Could not register the device. ${errorMessage}`);
       });
   };
 

--- a/src/astarte-client/client.ts
+++ b/src/astarte-client/client.ts
@@ -176,6 +176,7 @@ class AstarteClient {
     this.listeners = {};
 
     this.getConfigAuth = this.getConfigAuth.bind(this);
+    this.getDeviceRegistrationLimit = this.getDeviceRegistrationLimit.bind(this);
     this.getBlocks = this.getBlocks.bind(this);
     this.getDeviceData = this.getDeviceData.bind(this);
     this.getDevicesStats = this.getDevicesStats.bind(this);
@@ -198,6 +199,7 @@ class AstarteClient {
     this.apiConfig = {
       realmManagementHealth: astarteAPIurl`${config.realmManagementApiUrl}health`,
       auth:                  astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/config/auth`,
+      deviceRegistrationLimit: astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/config/device_registration_limit`,
       interfaces:            astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/interfaces`,
       interfaceMajors:       astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/interfaces/${'interfaceName'}`,
       interface:             astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/interfaces/${'interfaceName'}/${'interfaceMajor'}`,
@@ -266,6 +268,11 @@ astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/interfaces/${'interfa
     await this.$put(this.apiConfig.auth(this.config), {
       jwt_public_key_pem: params.publicKey,
     });
+  }
+
+  async getDeviceRegistrationLimit(): Promise<number | null> {
+    const response = await this.$get(this.apiConfig.deviceRegistrationLimit(this.config));
+    return response.data;
   }
 
   async getPolicyNames(): Promise<string[]> {


### PR DESCRIPTION
The PR reports the device registration limit, how many devices can be registered, and why new devices cannot be registered.

- The number of devices and the device registration limit are displayed on the sidebar and on the device stats on the homepage.
- The device registration limit is reported as a read-only field on the Realm Settings page.
- When the device registration limit is reached and the user tries to register a new device, an appropriate feedback message is shown explaining why the registration fails.

Navbar without registration limit:

![Screenshot 2024-03-04 at 10-47-30 Astarte - Dashboard](https://github.com/astarte-platform/astarte-dashboard/assets/60540759/47b6eb8e-1e53-470b-912c-cf9b76636005)

Navbar with registration limit:

![Screenshot 2024-03-04 at 10-48-39 Astarte - Dashboard](https://github.com/astarte-platform/astarte-dashboard/assets/60540759/b9933b68-cb3d-4720-8864-16b76c511c67)

Homepage without registration limit:

![Screenshot 2024-03-04 at 10-49-07 Astarte - Dashboard](https://github.com/astarte-platform/astarte-dashboard/assets/60540759/c67c7775-cc00-43d6-aae4-7dd18129935e)

Homepage with registration limit:

![Screenshot 2024-03-04 at 10-49-25 Astarte - Dashboard](https://github.com/astarte-platform/astarte-dashboard/assets/60540759/ab925c8c-b748-4402-8cd0-29189bedafd5)

Realm Settings page without registration limit:

![Screenshot 2024-03-04 at 10-49-32 Astarte - Dashboard](https://github.com/astarte-platform/astarte-dashboard/assets/60540759/7bc14d01-1617-4db0-af69-792f5c45206a)

Realm Settings page without registration limit:

![Screenshot 2024-03-04 at 10-50-20 Astarte - Dashboard](https://github.com/astarte-platform/astarte-dashboard/assets/60540759/bd8062b2-0616-4a84-adc5-6e013326c6b2)

Feedback shown when trying to register a new device but the device registration limit was already reached:

![Screenshot 2024-03-04 at 11-33-30 Astarte - Dashboard](https://github.com/astarte-platform/astarte-dashboard/assets/60540759/f3bb98de-65b9-4633-a3a9-ba53ccc486c6)

Closes #407, #408.