### PR TITLE
Send data to server-owned interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.3.0-dev] - Unreleased
 ### Added
 - Compute permissions from the JWT and disable unavailable UI sections, ([#416](https://github.com/astarte-platform/astarte-dashboard/issues/416)).
+- For server-owned interfaces, display a form to send data to the device, ([#417](https://github.com/astarte-platform/astarte-dashboard/issues/417)).
 
 ## [1.2.0-rc.0] - 2024-05-28
 ### Added

--- a/src/astarte-client/client.ts
+++ b/src/astarte-client/client.ts
@@ -219,6 +219,7 @@ astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/interfaces/${'interfa
       groupDevices:          astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/groups/${'groupName'}/devices`,
       deviceInGroup:         astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/groups/${'groupName'}/devices/${'deviceId'}`,
       phoenixSocket:         astarteAPIurl`${config.appEngineApiUrl}v1/socket`,
+      sendInterfaceData:     astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/devices/${'deviceId'}/interfaces/${'interfaceName'}${'path'}`,      
       pairingHealth:         astarteAPIurl`${config.pairingApiUrl}health`,
       registerDevice:        astarteAPIurl`${config.pairingApiUrl}v1/${'realm'}/agent/devices`,
       deviceAgent:           astarteAPIurl`${config.pairingApiUrl}v1/${'realm'}/agent/devices/${'deviceId'}`,
@@ -895,6 +896,19 @@ astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/interfaces/${'interfa
 
   get realm(): string | null {
     return this.config.realm || null;
+  }
+
+  async sendDataToInterface(params: {
+    deviceId: string;
+    interfaceName: string;
+    path: string;
+    data: any;
+  }): Promise<void> {
+    const { deviceId, interfaceName, path, data } = params;
+    await this.$post(
+      this.apiConfig.sendInterfaceData({ ...this.config, deviceId, interfaceName, path }),
+      data,
+    );
   }
 }
 

--- a/src/astarte-client/models/InterfaceValue/index.ts
+++ b/src/astarte-client/models/InterfaceValue/index.ts
@@ -1,0 +1,136 @@
+/*
+This file is part of Astarte.
+
+Copyright 2024 SECO Mind Srl
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import * as yup from 'yup';
+
+const base64Regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+const iso8601Regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+const getValidationSchema = (type: string) => {
+  switch (type) {
+    case 'integer':
+      return yup
+        .number()
+        .integer('The value must be an integer.')
+        .max(2147483647, 'The value is too large.')
+        .required('This field is required and must be an integer.')
+        .typeError('The value must be an integer.');
+    case 'longinteger':
+      return yup
+        .number()
+        .test('is-safe-integer', 'The value is too large.', (value) => Number.isSafeInteger(value))
+        .required('This field is required and must be a long integer.')
+        .typeError('The value must be a long integer.');
+    case 'double':
+      return yup
+        .number()
+        .required('This field is required and must be a decimal number.')
+        .typeError('The value must be a decimal number.');
+    case 'boolean':
+      return yup
+        .boolean()
+        .required('This field is required and must be true or false.')
+        .typeError('The value must be either true or false.');
+    case 'string':
+      return yup
+        .string()
+        .required('This field is required and must be a string.')
+        .typeError('The value must be a valid string.');
+    case 'binaryblob':
+      return yup
+        .string()
+        .matches(base64Regex, 'The value must be a valid binary blob encoded.')
+        .required('This field is required and must be a binary blob.')
+        .typeError('The value must be a valid binary blob.');
+    case 'datetime':
+      return yup
+        .string()
+        .matches(iso8601Regex, 'The date must be in the format "YYYY-MM-DDTHH:mm:ss.sssZ".')
+        .required('This field is required and must be a valid datetime.')
+        .typeError('The value must be a valid datetime.');
+    case 'doublearray':
+      return yup
+        .array()
+        .of(yup.number().typeError('Each item in the array must be a valid decimal number.'))
+        .required('This field is required and must be an array of decimal numbers.')
+        .typeError('Each item in the array must be a valid decimal number.');
+    case 'integerarray':
+      return yup
+        .array()
+        .of(
+          yup
+            .number()
+            .integer('Each item in the array must be a valid integer.')
+            .max(2147483647, 'The value is too large.')
+            .typeError('Each item in the array must be a valid integer.'),
+        )
+        .required('This field is required and must be an array of integers.')
+        .typeError('Each item in the array must be a valid integer.');
+    case 'longintegerarray':
+      return yup
+        .array()
+        .of(
+          yup
+            .number()
+            .test('is-safe-integer', 'The value is too large.', (value) =>
+              Number.isSafeInteger(value),
+            )
+            .typeError('Each item in the array must be a long integer.'),
+        )
+        .required('This field is required and must be an array of long integers.')
+        .typeError('Each item in the array must be a long integer.');
+    case 'booleanarray':
+      return yup
+        .array()
+        .of(yup.boolean().typeError('Each item in the array must be either true or false.'))
+        .required('This field is required and must be an array of booleans.')
+        .typeError('Each item in the array must be either true or false.');
+    case 'stringarray':
+      return yup
+        .array()
+        .of(yup.string().typeError('Each item in the array must be a valid string.'))
+        .required('This field is required and must be an array of strings.')
+        .typeError('Each item in the array must be a valid string.');
+    case 'binaryblobarray':
+      return yup
+        .array()
+        .of(
+          yup
+            .string()
+            .matches(base64Regex, 'Each item must be a valid binary blob encoded.')
+            .typeError('Each item in the array must be a valid binary blob.'),
+        )
+        .required('This field is required and must be an array of binary blobs.')
+        .typeError('Each item in the array must be a valid binary blob.');
+    case 'datetimearray':
+      return yup
+        .array()
+        .of(
+          yup
+            .string()
+            .matches(iso8601Regex, 'Each item must be in the format "YYYY-MM-DDTHH:mm:ss.sssZ".')
+            .typeError('Each item in the array must be a valid datetime string.'),
+        )
+        .required('This field is required and must be an array of datetime strings.')
+        .typeError('Each item in the array must be a valid datetime string.');
+    default:
+      return yup.string().required('This field is required.');
+  }
+};
+
+export { getValidationSchema };

--- a/src/astarte-client/models/Mapping/index.ts
+++ b/src/astarte-client/models/Mapping/index.ts
@@ -50,6 +50,7 @@ interface AstarteMappingObject {
 
 const mappingEndpointRegex = /^(\/(%{([a-zA-Z][a-zA-Z0-9_]*)}|[a-zA-Z][a-zA-Z0-9_]*)){1,64}$/;
 const mappingEndpointParamRegex = /^%{([a-zA-Z][a-zA-Z0-9_]*)}$/;
+const mappingEndpointPathParamsRegex = /%\{(.+?)\}/g;
 
 const astarteDataTypes: AstarteDataType[] = [
   'string',
@@ -151,6 +152,18 @@ class AstarteMapping {
 
   static toJSON(mapping: AstarteMapping): AstarteMappingJSON {
     return toAstarteMappingDTO(mapping);
+  }
+
+  static getEndpointParameters(endpoint: string): string[] {
+    const pathParamsArray: string[] = [];
+    const endpointParams = endpoint.match(mappingEndpointPathParamsRegex);
+    if (endpointParams) {
+      endpointParams.forEach((param) => {
+        const paramName = param.slice(2, -1);
+        pathParamsArray.push(paramName);
+      });
+    }
+    return pathParamsArray;
   }
 }
 

--- a/src/astarte-client/models/index.ts
+++ b/src/astarte-client/models/index.ts
@@ -26,3 +26,4 @@ export * from './Mapping';
 export * from './Interface';
 export * from './Trigger';
 export * from './Policy';
+export * from './InterfaceValue';

--- a/src/astarte-client/transforms/dataTree.test.ts
+++ b/src/astarte-client/transforms/dataTree.test.ts
@@ -45,6 +45,7 @@ describe('DataTree for properties interface', () => {
     expect(dataTree).toEqual({
       dataKind: 'properties',
       endpoint: '',
+      interface: iface,
       parent: null,
       children: [],
     });
@@ -76,6 +77,7 @@ describe('DataTree for datastream individual interface', () => {
     expect(dataTree).toEqual({
       dataKind: 'datastream_individual',
       endpoint: '',
+      interface: iface,
       parent: null,
       children: [],
     });
@@ -108,6 +110,7 @@ describe('DataTree for datastream object interface', () => {
     expect(dataTree).toEqual({
       dataKind: 'datastream_object',
       endpoint: '',
+      interface: iface,
       parent: null,
       children: [],
     });

--- a/src/astarte-client/transforms/dataTree.ts
+++ b/src/astarte-client/transforms/dataTree.ts
@@ -103,6 +103,7 @@ interface AstarteDataTreeNode<
   dataKind: AstarteDataTreeKind;
   name: string;
   endpoint: string;
+  interface: AstarteInterface;
   getParentNode: () => AstarteDataTreeNode<Data> | null;
   getNode: (endpoint: string) => AstarteDataTreeNode<Data> | null;
   getLeaves: () => AstarteDataTreeNode<Data>[];
@@ -140,6 +141,8 @@ class AstarteDataTreeLeafNode<
 
   readonly endpoint: string;
 
+  readonly interface: AstarteInterface;
+
   private readonly parent: AstarteDataTreeBranchNode<Data> | null;
 
   private readonly data: Equals<Data, AstarteDatastreamObjectData> extends true
@@ -164,6 +167,7 @@ class AstarteDataTreeLeafNode<
     this.parent = parentNode;
     this.dataKind = getDataTreeKind(iface);
     this.data = data;
+    this.interface = iface;
     if (iface.type === 'properties') {
       // @ts-expect-error cannot correctly infer from generics
       this.linearizedData = data as AstartePropertyData;
@@ -264,6 +268,8 @@ class AstarteDataTreeBranchNode<
 
   readonly endpoint: string;
 
+  readonly interface: AstarteInterface;
+
   private readonly parent: AstarteDataTreeBranchNode<Data> | null;
 
   private readonly children: Array<AstarteDataTreeBranchNode<Data> | AstarteDataTreeLeafNode<Data>>;
@@ -277,6 +283,7 @@ class AstarteDataTreeBranchNode<
     this.endpoint = endpoint;
     this.parent = parentNode;
     this.dataKind = getDataTreeKind(iface);
+    this.interface = iface;
     if (iface.type === 'properties') {
       // @ts-expect-error cannot correctly infer from generics
       this.children = Object.entries(data).map(([prop, propValue]) =>


### PR DESCRIPTION
Display form for server-owned interfaces to send data to device.

Screenshots:
![Screenshot from 2024-06-14 15-13-33](https://github.com/astarte-platform/astarte-dashboard/assets/74568584/e5972e7f-1a16-4025-9b51-2a6a8390f28f)
![Screenshot from 2024-06-14 15-23-44](https://github.com/astarte-platform/astarte-dashboard/assets/74568584/4e76e53c-fa17-4b4f-9dfc-5f0ba7af37ac)

- If interface type is `datastream` or `properties` and aggregation is `individual` we first have possibility to choose to which endpoint we want to send data.
![Screenshot from 2024-06-14 15-13-50](https://github.com/astarte-platform/astarte-dashboard/assets/74568584/d128a5d7-0f58-4a1e-bee2-92dbf16edb90)
![Screenshot from 2024-06-14 15-14-08](https://github.com/astarte-platform/astarte-dashboard/assets/74568584/21bf36ba-bbfb-48d2-afef-0d98d7d01aff)
- Then we insert value 
![Screenshot from 2024-06-14 15-14-25](https://github.com/astarte-platform/astarte-dashboard/assets/74568584/efb4bebf-0d09-46f8-9fd7-c269559d7788)
- If endpoint have some path parameters, we need to fill them and then send data
![Screenshot from 2024-06-14 15-14-37](https://github.com/astarte-platform/astarte-dashboard/assets/74568584/f3679fcf-75c4-4b85-98e8-4d1ecdd37fa0)

- If interface aggregation is `object` we need to fill all input fields that are declared in interface mappings and then send data
![Screenshot from 2024-06-14 15-15-07](https://github.com/astarte-platform/astarte-dashboard/assets/74568584/8b37355a-d7a0-4497-87bd-20d324b7568d)
![Screenshot from 2024-06-14 15-19-02](https://github.com/astarte-platform/astarte-dashboard/assets/74568584/c1951119-ba8f-4a8a-b8e2-4e89bd16c3c9)

closes #417 
