### PR TITLE
Adapt Device Stats to exclude interfaces with 0 exchanged messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Compute permissions from the JWT and disable unavailable UI sections, ([#416](https://github.com/astarte-platform/astarte-dashboard/issues/416)).
 - For server-owned interfaces, display a form to send data to the device, ([#417](https://github.com/astarte-platform/astarte-dashboard/issues/417)).
+### Changed
+- Adapt Device Stats and PieChart to exclude interfaces with 0 exchanged messages, ([[#428](https://github.com/astarte-platform/astarte-dashboard/issues/428)]).
 
 ## [1.2.0] - 2024-07-01
 ### Changed

--- a/src/DeviceStatusPage/ExchangedBytesCard.tsx
+++ b/src/DeviceStatusPage/ExchangedBytesCard.tsx
@@ -73,18 +73,21 @@ const ExchangedBytesCard = ({ astarte, device }: ExchangedBytesCardProps): React
   const computedStats: BytesAndMessagesStats[] = [];
   let interfaceBytes = 0;
   let interfaceMessages = 0;
-  fullList.forEach((interfaceStats: AstarteDeviceInterfaceStats) => {
-    interfaceBytes += interfaceStats.exchangedBytes;
-    interfaceMessages += interfaceStats.exchangedMessages;
-    computedStats.push({
-      name: `${interfaceStats.name} v${interfaceStats.major}.${interfaceStats.minor}`,
-      bytes: interfaceStats.exchangedBytes,
-      bytesPercent: interfaceBytes !== 0 ? (interfaceStats.exchangedBytes * 100) / totalBytes : 0,
-      messages: interfaceStats.exchangedMessages,
-      messagesPercent:
-        interfaceMessages !== 0 ? (interfaceStats.exchangedMessages * 100) / totalMessages : 0,
+  fullList
+    .filter((interfaceStats: AstarteDeviceInterfaceStats) => interfaceStats.exchangedMessages > 0)
+    .forEach((interfaceStats: AstarteDeviceInterfaceStats) => {
+      interfaceBytes += interfaceStats.exchangedBytes;
+      interfaceMessages += interfaceStats.exchangedMessages;
+
+      computedStats.push({
+        name: `${interfaceStats.name} v${interfaceStats.major}.${interfaceStats.minor}`,
+        bytes: interfaceStats.exchangedBytes,
+        bytesPercent: interfaceBytes !== 0 ? (interfaceStats.exchangedBytes * 100) / totalBytes : 0,
+        messages: interfaceStats.exchangedMessages,
+        messagesPercent:
+          interfaceMessages !== 0 ? (interfaceStats.exchangedMessages * 100) / totalMessages : 0,
+      });
     });
-  });
 
   computedStats.push({
     name: 'Other',

--- a/src/astarte-charts/react/PieChart/index.tsx
+++ b/src/astarte-charts/react/PieChart/index.tsx
@@ -55,8 +55,9 @@ export const PieChart = <Kind extends Aggregated = Aggregated>({
       return noChartData;
     }
     const { data } = providerData;
-    const labels = Object.keys(data);
-    const series = labels.map((label) => Number(data[label].value));
+    const filteredEntries = Object.entries(data).filter(([, value]) => Number(value.value) !== 0);
+    const labels = filteredEntries.map(([label]) => label);
+    const series = filteredEntries.map(([, value]) => Number(value.value));
     const colors = labels.map((label, index) =>
       Color.hsl((index * 360) / labels.length, 70, 70)
         .rgb()


### PR DESCRIPTION
Device Stats table shows only interfaces > 0 exchanged messages
PieChart shows only interfaces > 0 exchanged messages

closes. #428 