### PR TITLE
Allow to filter time of Interface Datastream data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - For server-owned interfaces, display a form to send data to the device, ([#417](https://github.com/astarte-platform/astarte-dashboard/issues/417)).
 - Add a "keep me logged in" during login, ([#451](https://github.com/astarte-platform/astarte-dashboard/issues/451)).
 - Allow unsetting property endpoints, ([#450](https://github.com/astarte-platform/astarte-dashboard/issues/450)).
+- Allow to filter time of Interface DataStream data, ([#441](https://github.com/astarte-platform/astarte-dashboard/issues/441)).
 ### Fixed
 - Avoid querying Astarte for trigger delivery policies when Astarte does not support them ([#459](https://github.com/astarte-platform/astarte-dashboard/issues/459)).
 

--- a/cypress/e2e/interface_value_page.cy.js
+++ b/cypress/e2e/interface_value_page.cy.js
@@ -12,8 +12,8 @@ describe('Interface values page tests', () => {
     });
 
     it('correctly loads the page', () => {
-      cy.visit('/devices/deviceId/interfaces/interfaceName');
-      cy.location('pathname').should('eq', '/devices/deviceId/interfaces/interfaceName');
+      cy.visit('/devices/deviceId/interfaces/interfaceName/interfaceMajor');
+      cy.location('pathname').should('eq', '/devices/deviceId/interfaces/interfaceName/interfaceMajor');
       cy.get('.main-content').within(() => {
         cy.get('h2').contains('Interface Data');
         cy.get('.card-header').contains('deviceId /interfaceName');
@@ -31,8 +31,9 @@ describe('Interface values page tests', () => {
 
       const deviceId = '0ma4SioESHKk28VhYGcW1w';
       const interfaceName = 'test.astarte.IndividualObjectInterface';
+      const interfaceMajor = 0;
 
-      cy.visit(`/devices/${deviceId}/interfaces/${interfaceName}`);
+      cy.visit(`/devices/${deviceId}/interfaces/${interfaceName}/${interfaceMajor}`);
       cy.get('[aria-label="Back"]').click();
       cy.location('pathname').should('eq', `/devices/${deviceId}/edit`);
     });
@@ -47,17 +48,18 @@ describe('Interface values page tests', () => {
             .then((device) => {
               const interfaceName = iface.data.interface_name;
               const deviceId = device.data.id;
+              const interfaceMajor = iface.data.interfaceMajor;
               cy.intercept('GET', `/appengine/v1/*/devices/${deviceId}`, device);
               cy.intercept(
                 'GET',
-                `/appengine/v1/*/devices/${deviceId}/interfaces/${interfaceName}`,
+                `/appengine/v1/*/devices/${deviceId}/interfaces/${interfaceName}/${interfaceMajor}`,
                 { fixture: 'test_aggregated_object_interface_values' },
               );
-              cy.intercept('GET', `/realmmanagement/v1/*/interfaces/${interfaceName}/*`, {
+              cy.intercept('GET', `/realmmanagement/v1/*/interfaces/${interfaceName}/${interfaceMajor}/*`, {
                 statusCode: 418,
                 body: '',
               });
-              cy.visit(`/devices/${deviceId}/interfaces/${interfaceName}`);
+              cy.visit(`/devices/${deviceId}/interfaces/${interfaceName}/${interfaceMajor}`);
               cy.get('.main-content .card-body').contains("Couldn't load interface data");
             });
         });
@@ -73,17 +75,18 @@ describe('Interface values page tests', () => {
             .then((device) => {
               const interfaceName = iface.data.interface_name;
               const deviceId = device.data.id;
-              cy.intercept('GET', `/realmmanagement/v1/*/interfaces/${interfaceName}/*`, iface);
+              const interfaceMajor = iface.data.interfaceMajor;
+              cy.intercept('GET', `/realmmanagement/v1/*/interfaces/${interfaceName}/${interfaceMajor}/*`, iface);
               cy.intercept(
                 'GET',
-                `/appengine/v1/*/devices/${deviceId}/interfaces/${interfaceName}`,
+                `/appengine/v1/*/devices/${deviceId}/interfaces/${interfaceName}/${interfaceMajor}`,
                 { fixture: 'test_aggregated_object_interface_values' },
               );
               cy.intercept('GET', `/appengine/v1/*/devices/${deviceId}`, {
                 statusCode: 418,
                 body: '',
               });
-              cy.visit(`/devices/${deviceId}/interfaces/${interfaceName}`);
+              cy.visit(`/devices/${deviceId}/interfaces/${interfaceName}/${interfaceMajor}`);
               cy.get('.main-content .card-body').contains("Couldn't load interface data");
             });
         });
@@ -99,17 +102,18 @@ describe('Interface values page tests', () => {
             .then((device) => {
               const interfaceName = iface.data.interface_name;
               const deviceId = device.data.id;
-              cy.intercept('GET', `/realmmanagement/v1/*/interfaces/${interfaceName}/*`, iface);
+              const interfaceMajor = iface.data.interfaceMajor;
+              cy.intercept('GET', `/realmmanagement/v1/*/interfaces/${interfaceName}/${interfaceMajor}/*`, iface);
               cy.intercept('GET', `/appengine/v1/*/devices/${deviceId}`, device);
               cy.intercept(
                 'GET',
-                `/appengine/v1/*/devices/${deviceId}/interfaces/${interfaceName}`,
+                `/appengine/v1/*/devices/${deviceId}/interfaces/${interfaceName}/${interfaceMajor}`,
                 {
                   statusCode: 418,
                   body: '',
                 },
               );
-              cy.visit(`/devices/${deviceId}/interfaces/${interfaceName}`);
+              cy.visit(`/devices/${deviceId}/interfaces/${interfaceName}/${interfaceMajor}`);
               cy.get('.main-content .card-body').contains("Couldn't load interface data");
             });
         });
@@ -132,8 +136,9 @@ describe('Interface values page tests', () => {
       it('shows correct aggregated datastream data', function () {
         const deviceId = this.device.data.id;
         const interfaceName = this.interface.data.interface_name;
-        cy.visit(`/devices/${deviceId}/interfaces/${interfaceName}`);
-        cy.location('pathname').should('eq', `/devices/${deviceId}/interfaces/${interfaceName}`);
+        const interfaceMajor = this.interface.data.interfaceMajor;
+        cy.visit(`/devices/${deviceId}/interfaces/${interfaceName}/${interfaceMajor}`);
+        cy.location('pathname').should('eq', `/devices/${deviceId}/interfaces/${interfaceName}/${interfaceMajor}`);
         cy.get('.main-content').within(() => {
           cy.get('.card-header').contains(`${deviceId} /${interfaceName}`);
           Object.keys(this.interface_data.data.sensors).forEach((sensorId) => {
@@ -172,8 +177,9 @@ describe('Interface values page tests', () => {
       it('shows correct individual datastream data', function () {
         const deviceId = this.device.data.id;
         const interfaceName = this.interface.data.interface_name;
-        cy.visit(`/devices/${deviceId}/interfaces/${interfaceName}`);
-        cy.location('pathname').should('eq', `/devices/${deviceId}/interfaces/${interfaceName}`);
+        const interfaceMajor = this.interface.data.interfaceMajor;
+        cy.visit(`/devices/${deviceId}/interfaces/${interfaceName}/${interfaceMajor}`);
+        cy.location('pathname').should('eq', `/devices/${deviceId}/interfaces/${interfaceName}/${interfaceMajor}`);
         cy.get('.main-content').within(() => {
           cy.get('.card-header').contains(`${deviceId} /${interfaceName}`);
           cy.get('.card-body table').within(() => {
@@ -204,8 +210,9 @@ describe('Interface values page tests', () => {
       it('shows correct properties data', function () {
         const deviceId = this.device.data.id;
         const interfaceName = this.interface.data.interface_name;
-        cy.visit(`/devices/${deviceId}/interfaces/${interfaceName}`);
-        cy.location('pathname').should('eq', `/devices/${deviceId}/interfaces/${interfaceName}`);
+        const interfaceMajor = this.interface.data.interfaceMajor;
+        cy.visit(`/devices/${deviceId}/interfaces/${interfaceName}/${interfaceMajor}`);
+        cy.location('pathname').should('eq', `/devices/${deviceId}/interfaces/${interfaceName}/${interfaceMajor}`);
         cy.get('.main-content').within(() => {
           cy.get('.card-header').contains(`${deviceId} /${interfaceName}`);
           Object.keys(this.interface_data.data).forEach((key) => {

--- a/src/DeviceDataStreamValues.tsx
+++ b/src/DeviceDataStreamValues.tsx
@@ -1,0 +1,308 @@
+/*
+   This file is part of Astarte.
+
+   Copyright 2024 SECO Mind Srl
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Card, Container, Table } from 'react-bootstrap';
+import {
+  AstarteDataTuple,
+  AstarteDataValue,
+  AstarteDatastreamIndividualData,
+  AstarteDatastreamObjectData,
+  AstarteInterface,
+  AstarteInterfaceValues,
+} from 'astarte-client';
+import _ from 'lodash';
+
+import BackButton from './ui/BackButton';
+import { useAstarte } from './AstarteManager';
+import { AlertsBanner, useAlerts } from 'AlertManager';
+import 'react-datepicker/dist/react-datepicker.css';
+import FiltersForm from 'components/FiltersForm';
+import useFetch from 'hooks/useFetch';
+
+function formatAstarteData(data?: AstarteDataTuple): string {
+  if (data == null) {
+    return '';
+  }
+  if (_.isArray(data)) {
+    return JSON.stringify(data);
+  }
+  if (_.isBoolean(data)) {
+    return data ? 'true' : 'false';
+  }
+  if (_.isNumber(data)) {
+    return data.toString();
+  }
+  if (_.isNull(data)) {
+    return '';
+  }
+  return String(data);
+}
+
+function mapValueToAstarteDataTuple(value: AstarteDataValue): AstarteDataTuple {
+  if (_.isNumber(value)) {
+    return { type: 'double', value };
+  } else if (_.isBoolean(value)) {
+    return { type: 'boolean', value };
+  } else if (_.isString(value)) {
+    return { type: 'string', value };
+  } else if (_.isArray(value)) {
+    if (value.length > 0) {
+      if (_.isNumber(value[0])) {
+        return { type: 'doublearray', value: value as number[] };
+      } else if (_.isBoolean(value[0])) {
+        return { type: 'booleanarray', value: value as boolean[] };
+      } else if (_.isString(value[0])) {
+        return { type: 'stringarray', value: value as string[] };
+      }
+    }
+    return { type: 'binaryblobarray', value: [] };
+  }
+  return { type: 'binaryblob', value: null };
+}
+
+const transformAggregatedDatastreamInterfaceValues = (
+  selectedPath: string,
+  fetchedData: AstarteInterfaceValues,
+): AstarteDatastreamObjectData[] => {
+  const transformedAggregatedDatastreamValues: AstarteDatastreamObjectData[] = [];
+
+  const handleAggregatedDatastreamValues = (aggregatedDatastreamData: any) => {
+    if (Array.isArray(aggregatedDatastreamData)) {
+      aggregatedDatastreamData.forEach(handleAggregatedDatastreamValues);
+    } else if (aggregatedDatastreamData && typeof aggregatedDatastreamData === 'object') {
+      if ('timestamp' in aggregatedDatastreamData) {
+        const { timestamp, ...valueData } = aggregatedDatastreamData;
+        transformedAggregatedDatastreamValues.push({
+          endpoint: selectedPath,
+          timestamp,
+          value: valueData,
+        });
+      } else {
+        Object.values(aggregatedDatastreamData).forEach(handleAggregatedDatastreamValues);
+      }
+    }
+  };
+
+  handleAggregatedDatastreamValues(fetchedData);
+  return transformedAggregatedDatastreamValues;
+};
+
+const transformIndividualDatastreamInterfaceValues = (
+  selectedPath: string,
+  fetchedData: AstarteInterfaceValues,
+): AstarteDatastreamIndividualData[] => {
+  const transformedIndividualDatastreamValues: AstarteDatastreamIndividualData[] = [];
+
+  const handleIndividualDatastreamValues = (individualDatastreamData: any) => {
+    if (Array.isArray(individualDatastreamData)) {
+      individualDatastreamData.forEach((data) => {
+        if (data && typeof data === 'object' && 'timestamp' in data && 'value' in data) {
+          const { timestamp, value } = data;
+          transformedIndividualDatastreamValues.push({
+            endpoint: selectedPath,
+            timestamp,
+            ...mapValueToAstarteDataTuple(value),
+          });
+        }
+      });
+    } else if (individualDatastreamData && typeof individualDatastreamData === 'object') {
+      Object.values(individualDatastreamData).forEach(handleIndividualDatastreamValues);
+    }
+  };
+
+  handleIndividualDatastreamValues(fetchedData);
+  return transformedIndividualDatastreamValues;
+};
+
+interface IndividualDatastreamTableProps {
+  data: AstarteDatastreamIndividualData[];
+}
+
+const IndividualDatastreamTable = ({
+  data,
+}: IndividualDatastreamTableProps): React.ReactElement => {
+  return (
+    <Table responsive>
+      <thead>
+        <tr>
+          <th>Path</th>
+          <th>Value</th>
+          <th>Timestamp</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((tree, index) => (
+          <tr key={index}>
+            <td>{tree.endpoint}</td>
+            <td>{tree.value}</td>
+            <td>{new Date(tree.timestamp).toLocaleString()}</td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+};
+
+interface ObjectDatastreamTableProps {
+  data: AstarteDatastreamObjectData[];
+}
+
+const ObjectDatastreamTable = ({ data }: ObjectDatastreamTableProps): React.ReactElement => {
+  const objectProperties = Object.keys(data[0].value);
+  return (
+    <>
+      <Table responsive>
+        <thead>
+          <tr>
+            {objectProperties.map((property) => (
+              <th key={property}>{property}</th>
+            ))}
+            <th>Timestamp</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((tree) => (
+            <tr key={tree.timestamp}>
+              {objectProperties.map((property) => (
+                <td key={property}>{formatAstarteData(tree.value[property])}</td>
+              ))}
+              <td>{new Date(tree.timestamp).toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </>
+  );
+};
+
+interface InterfaceDataProps {
+  interfaceData: AstarteDatastreamIndividualData[] | AstarteDatastreamObjectData[];
+  aggregation: AstarteInterface['aggregation'];
+}
+
+const InterfaceData = ({ interfaceData, aggregation }: InterfaceDataProps): React.ReactElement => {
+  if (interfaceData.length === 0) {
+    return <p>No data in the selected timeframe.</p>;
+  } else if (aggregation === 'individual') {
+    return <IndividualDatastreamTable data={interfaceData as AstarteDatastreamIndividualData[]} />;
+  }
+  return <ObjectDatastreamTable data={interfaceData as AstarteDatastreamObjectData[]} />;
+};
+
+export default (): React.ReactElement => {
+  const { interfaceName = '', deviceId = '', interfaceMajor } = useParams();
+  const astarte = useAstarte();
+  const [requestingData, setRequestingData] = useState(false);
+  const [fetchedData, setFetchedData] = useState<AstarteInterfaceValues | null>(null);
+  const [formAlerts, formAlertsController] = useAlerts();
+  const [interfaceData, setInterfaceData] = useState<AstarteInterface | null>(null);
+  const [selectedPath, setSelectedPath] = useState<string>('');
+
+  const deviceDataFetcher = useFetch(() =>
+    astarte.client.getDeviceDataTree({
+      deviceId,
+      interfaceName,
+    }),
+  );
+
+  const interfacePaths = useMemo(() => {
+    if (deviceDataFetcher.value == null) {
+      return [];
+    } else if (deviceDataFetcher.value.dataKind === 'datastream_individual') {
+      return deviceDataFetcher.value.toLinearizedData().map((data) => data.endpoint);
+    } else {
+      return deviceDataFetcher.value.getLeaves().map((data) => data.endpoint);
+    }
+  }, [deviceDataFetcher.value]);
+
+  const fetchData = async (path: string, since?: string, to?: string) => {
+    setRequestingData(true);
+    setFetchedData(null);
+    astarte.client
+      .getDeviceData({
+        deviceId,
+        interfaceName,
+        path,
+        since,
+        to,
+      })
+      .then((data) => {
+        setSelectedPath(path);
+        setFetchedData(data);
+      })
+      .catch((err) => {
+        formAlertsController.showError(
+          `Could not fetch data to interface: ${err.response.data.errors.detail}`,
+        );
+        setFetchedData([]);
+      })
+      .finally(() => {
+        setRequestingData(false);
+      });
+  };
+
+  const transformedData =
+    interfaceData && fetchedData
+      ? interfaceData.aggregation === 'individual'
+        ? transformIndividualDatastreamInterfaceValues(selectedPath, fetchedData)
+        : transformAggregatedDatastreamInterfaceValues(selectedPath, fetchedData)
+      : [];
+
+  useEffect(() => {
+    if (interfaceMajor) {
+      const major = parseInt(interfaceMajor, 10);
+      astarte.client
+        .getInterface({ interfaceName, interfaceMajor: major })
+        .then((interfaceData) => {
+          setInterfaceData(interfaceData);
+        });
+    }
+  }, []);
+
+  return (
+    <Container fluid className="p-3">
+      <div className="d-flex justify-content-between">
+        <h2>
+          <BackButton href={`/devices/${deviceId}/interfaces/${interfaceName}/${interfaceMajor}`} />
+          Interface Datastream Data
+        </h2>
+      </div>
+      <AlertsBanner alerts={formAlerts} />
+      <Card className="mt-4">
+        <Card.Header>
+          <span className="font-monospace">{deviceId}</span> /{interfaceName}
+        </Card.Header>
+        <Card.Body>
+          <FiltersForm
+            interfacePaths={interfacePaths}
+            onFiltersChange={fetchData}
+            isLoading={requestingData}
+          />
+          {fetchedData && (
+            <InterfaceData
+              interfaceData={transformedData}
+              aggregation={interfaceData?.aggregation}
+            />
+          )}
+        </Card.Body>
+      </Card>
+    </Container>
+  );
+};

--- a/src/DeviceInterfaceValues.tsx
+++ b/src/DeviceInterfaceValues.tsx
@@ -17,7 +17,7 @@
 */
 
 import React, { ChangeEvent, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { Button, Card, Col, Container, Form, Modal, Row, Spinner, Table } from 'react-bootstrap';
 import {
   AstarteDataTuple,
@@ -83,6 +83,7 @@ const IndividualDatastreamTable = ({
   treeNode,
 }: IndividualDatastreamTableProps): React.ReactElement => {
   const dataValues = treeNode.toLinearizedData();
+
   if (dataValues.length === 0) {
     return <p>No data sent by the device.</p>;
   }
@@ -117,6 +118,7 @@ const ObjectDatastreamTable = ({
   dataTreeNode,
 }: ObjectDatastreamTableProps): React.ReactElement => {
   const treeData = dataTreeNode.toData();
+
   if (treeData.length === 0) {
     return <p>No data sent by the device.</p>;
   }
@@ -694,19 +696,19 @@ export default (): React.ReactElement => {
 
   return (
     <Container fluid className="p-3">
-      <div className="d-flex justify-content-between">
+      <div className="d-flex justify-content-between align-items-center">
         <h2>
           <BackButton href={`/devices/${deviceId}/edit`} />
           Interface Data
         </h2>
-        {astarte.token?.can(
-          'appEngine',
-          'POST',
-          `devices/${deviceId}/interfaces/${interfaceName}`,
-        ) &&
-          iface?.ownership === 'server' && (
-            <>
-              <div className="button-container">
+        <div className="d-flex align-items-center">
+          {astarte.token?.can(
+            'appEngine',
+            'POST',
+            `devices/${deviceId}/interfaces/${interfaceName}`,
+          ) &&
+            iface?.ownership === 'server' && (
+              <>
                 <Button onClick={handleShowModal} className="m-2">
                   Publish Data
                 </Button>
@@ -715,9 +717,17 @@ export default (): React.ReactElement => {
                     Unset Data
                   </Button>
                 )}
-              </div>
-            </>
+              </>
+            )}
+          {iface?.type === 'datastream' && (
+            <Link
+              to={`/devices/${deviceId}/interfaces/${interfaceName}/${iface.major}/datastream`}
+              className="ml-2"
+            >
+              Filter Data
+            </Link>
           )}
+        </div>
       </div>
       <AlertsBanner alerts={formAlerts} />
       <Card className="mt-4">

--- a/src/DeviceStatusPage/IntrospectionCard.tsx
+++ b/src/DeviceStatusPage/IntrospectionCard.tsx
@@ -53,7 +53,9 @@ const IntrospectionTable = ({
                 'GET',
                 `/devices/${deviceId}/interfaces/${iface.name}`,
               ) ? (
-                <Link to={`/devices/${deviceId}/interfaces/${iface.name}`}>{iface.name}</Link>
+                <Link to={`/devices/${deviceId}/interfaces/${iface.name}/${iface.major}`}>
+                  {iface.name}
+                </Link>
               ) : (
                 iface.name
               )}

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -49,6 +49,7 @@ import { useAstarte } from './AstarteManager';
 import TriggerPoliciesPage from './TriggerDeliveryPoliciesPage';
 import NewPolicyPage from './NewTriggerDeliveryPolicyPage';
 import TriggerDeliveryPolicyPage from './TriggerDeliveryPolicyPage';
+import DeviceDataStreamValues from 'DeviceDataStreamValues';
 
 function AttemptLogin(): React.ReactElement {
   const { search, hash } = useLocation();
@@ -119,7 +120,14 @@ const privateRoutes: RouteObject[] = [
   { path: 'devices', element: <DevicesPage /> },
   { path: 'devices/register', element: <RegisterDevicePage /> },
   { path: 'devices/:deviceId/edit', element: <DeviceStatusPage /> },
-  { path: 'devices/:deviceId/interfaces/:interfaceName', element: <DeviceInterfaceValues /> },
+  {
+    path: 'devices/:deviceId/interfaces/:interfaceName/:interfaceMajor',
+    element: <DeviceInterfaceValues />,
+  },
+  {
+    path: 'devices/:deviceId/interfaces/:interfaceName/:interfaceMajor/datastream',
+    element: <DeviceDataStreamValues />,
+  },
   { path: 'groups', element: <GroupsPage /> },
   { path: 'groups/new', element: <NewGroupPage /> },
   { path: 'groups/:groupName/edit', element: <GroupDevicesPage /> },

--- a/src/components/FiltersForm.tsx
+++ b/src/components/FiltersForm.tsx
@@ -1,0 +1,97 @@
+/*
+   This file is part of Astarte.
+
+   Copyright 2024 SECO Mind Srl
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import React, { useState } from 'react';
+import { Button, Form, Col, Row, Spinner } from 'react-bootstrap';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+
+interface FiltersFormProps {
+  interfacePaths: string[];
+  onFiltersChange: (path: string, since?: string, to?: string) => void;
+  isLoading?: boolean;
+}
+
+const FiltersForm = ({
+  interfacePaths,
+  onFiltersChange,
+  isLoading,
+}: FiltersFormProps): React.ReactElement => {
+  const [fromTime, setFromTime] = useState<Date | null>(null);
+  const [toTime, setToTime] = useState<Date | null>(null);
+  const [path, setPath] = useState<string>('');
+
+  const handleFetchData = () => {
+    const since = fromTime ? fromTime.toISOString() : undefined;
+    const to = toTime ? toTime.toISOString() : undefined;
+    onFiltersChange(path, since, to);
+  };
+
+  return (
+    <>
+      <Row className="mb-4">
+        <Col xs={12} md={2} className="d-flex justify-content-between">
+          <Form.Group controlId="formPath" className="d-flex align-items-center">
+            <Form.Label className="me-2 mb-0">Path</Form.Label>
+            <Form.Control as="select" value={path} onChange={(e) => setPath(e.target.value)}>
+              <option value="">Select path</option>
+              {interfacePaths.map((pathOption) => (
+                <option key={pathOption} value={pathOption}>
+                  {pathOption}
+                </option>
+              ))}
+            </Form.Control>
+          </Form.Group>
+        </Col>
+        <Col
+          xs={12}
+          md={6}
+          className="d-flex align-items-center justify-content-center justify-content-between"
+        >
+          <Form.Group controlId="formFromTime" className="d-flex align-items-center">
+            <Form.Label className="me-2 mb-0">From</Form.Label>
+            <DatePicker
+              selected={fromTime}
+              onChange={(date: Date) => setFromTime(date)}
+              showTimeSelect
+              dateFormat="Pp"
+              className="form-control"
+              placeholderText="Select from time"
+            />
+          </Form.Group>
+          <Form.Group controlId="formToTime" className="d-flex align-items-center">
+            <Form.Label className="me-2 mb-0">To</Form.Label>
+            <DatePicker
+              selected={toTime}
+              onChange={(date: Date) => setToTime(date)}
+              showTimeSelect
+              dateFormat="Pp"
+              className="form-control"
+              placeholderText="Select to time"
+            />
+          </Form.Group>
+          <Button variant="primary" onClick={handleFetchData} disabled={isLoading}>
+            {isLoading ? <Spinner size="sm" animation="border" /> : 'Filter Data'}
+          </Button>
+        </Col>
+      </Row>
+    </>
+  );
+};
+
+export default FiltersForm;


### PR DESCRIPTION
Add ```from``` - ```to``` time input fields to filter Interface DataStream data
Screenshot:
![Screenshot from 2024-07-19 12-34-58](https://github.com/user-attachments/assets/6c3daeec-faa9-4a87-8a18-92f1fc23b7fb)


When filtering both (```from``` time and ```to``` time) :

https://github.com/astarte-platform/astarte-dashboard/assets/34908857/7e0af2e1-f856-46d5-a809-c0dd839c6a6c

When filtering just from time :

https://github.com/astarte-platform/astarte-dashboard/assets/34908857/1b85bfe7-3e7e-461a-ab2e-814f2d835238


closes. #441 