### PR TITLE
Add "Keep me logged in" functionality to login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Compute permissions from the JWT and disable unavailable UI sections, ([#416](https://github.com/astarte-platform/astarte-dashboard/issues/416)).
 - For server-owned interfaces, display a form to send data to the device, ([#417](https://github.com/astarte-platform/astarte-dashboard/issues/417)).
+- Add a "keep me logged in" during login, ([#451](https://github.com/astarte-platform/astarte-dashboard/issues/451)).
+
 ### Changed
 - Adapt Device Stats and PieChart to exclude interfaces with 0 exchanged messages, ([#428](https://github.com/astarte-platform/astarte-dashboard/issues/428)).
 - Persist login using cookies instead of localStorage, ([#419](https://github.com/astarte-platform/astarte-dashboard/issues/419)).

--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -21,6 +21,7 @@ import { useNavigate } from 'react-router-dom';
 import { Button, Col, Container, Form, Row, Stack } from 'react-bootstrap';
 import { AstarteRealm, AstarteToken } from 'astarte-client';
 import type { AuthOptions, LoginType } from 'ConfigManager';
+import { useAstarte } from 'AstarteManager';
 
 function isValidUrl(urlString: string): boolean {
   try {
@@ -68,6 +69,8 @@ const TokenForm = ({
   const navigate = useNavigate();
   const [realm, setRealm] = useState(defaultRealm);
   const [jwt, setJwt] = useState('');
+  const [keepMeLoggedIn, setKeepMeLoggedIn] = useState(false);
+  const { login } = useAstarte();
 
   const isValidRealm = AstarteRealm.isValidName(realm);
 
@@ -78,9 +81,10 @@ const TokenForm = ({
   const handleTokenLogin = (event: React.FormEvent<HTMLElement>) => {
     event.preventDefault();
     event.stopPropagation();
-    const searchParams = new URLSearchParams({ realm });
-    const hashParams = new URLSearchParams({ access_token: jwt });
-    navigate(`/auth?${searchParams}#${hashParams}`, { replace: true });
+    const successfulLogin = login({ realm, token: jwt, authUrl: null }, keepMeLoggedIn);
+    if (successfulLogin) {
+      navigate('/', { replace: true });
+    }
   };
 
   const AstartectlLink = () => (
@@ -125,6 +129,14 @@ const TokenForm = ({
             required
           />
           {tokenValidationFeedback(tokenValidation)}
+        </Form.Group>
+        <Form.Group controlId="keepMeLoggedIn">
+          <Form.Check
+            type="checkbox"
+            label="Keep me logged in"
+            checked={keepMeLoggedIn}
+            onChange={(e) => setKeepMeLoggedIn(e.target.checked)}
+          />
         </Form.Group>
         <Button type="submit" variant="primary" disabled={!canSubmitForm} className="w-100">
           Login

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -59,11 +59,12 @@ function AttemptLogin(): React.ReactElement {
   const realm = searchParams.get('realm');
   const token = hashParams.get('access_token');
   const authUrl = searchParams.get('authUrl');
+  const persistent = false;
 
   let succesfulLogin = false;
 
   if (realm && token) {
-    succesfulLogin = astarte.login({ realm, token, authUrl });
+    succesfulLogin = astarte.login({ realm, token, authUrl }, persistent);
   }
 
   if (!succesfulLogin) {


### PR DESCRIPTION
![Screenshot from 2024-07-25 15-18-50](https://github.com/user-attachments/assets/7d5f10b7-7780-4aac-aa66-fd749b0088c8)
When signing in with a token, users are now able to choose whether to use a session cookie (which is discarded when the browser is closed) or a persistent cookie that is kept until it expires or is manually cleared
closes #451