### PR TITLE
Allow unsetting property endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Compute permissions from the JWT and disable unavailable UI sections, ([#416](https://github.com/astarte-platform/astarte-dashboard/issues/416)).
 - For server-owned interfaces, display a form to send data to the device, ([#417](https://github.com/astarte-platform/astarte-dashboard/issues/417)).
 - Add a "keep me logged in" during login, ([#451](https://github.com/astarte-platform/astarte-dashboard/issues/451)).
+- Allow unsetting property endpoints, ([#450](https://github.com/astarte-platform/astarte-dashboard/issues/450)).
 
 ### Changed
 - Adapt Device Stats and PieChart to exclude interfaces with 0 exchanged messages, ([#428](https://github.com/astarte-platform/astarte-dashboard/issues/428)).

--- a/src/astarte-client/client.ts
+++ b/src/astarte-client/client.ts
@@ -910,6 +910,17 @@ astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/interfaces/${'interfa
       data,
     );
   }
+  async unsetProperty(params: {
+    deviceId: string;
+    interfaceName: string;
+    path: string;
+  }): Promise<void> {
+    const { deviceId, interfaceName, path } = params;
+
+    await this.$delete(
+      this.apiConfig.sendInterfaceData({ ...this.config, deviceId, interfaceName, path }),
+    );
+  }
 }
 
 export default AstarteClient;


### PR DESCRIPTION
![Screenshot from 2024-08-08 10-36-55](https://github.com/user-attachments/assets/1cfccbf2-bb68-4285-90cc-35824dc5e612)
![Screenshot from 2024-08-08 10-36-40](https://github.com/user-attachments/assets/cf234145-def2-42fe-ac9f-0e9b54377be0)
![Screenshot from 2024-08-08 10-36-30](https://github.com/user-attachments/assets/e2783340-49c5-45bf-bbb7-cb93d74661fd)
![Screenshot from 2024-08-08 10-36-01](https://github.com/user-attachments/assets/6d938eca-3561-4e7a-b512-81b4bd93305e)
![Screenshot from 2024-08-08 10-35-36](https://github.com/user-attachments/assets/efdc4001-fd76-4173-9ba2-523048b607f5)


Added a button to allow users to unset properties
endpoints.
Implemented a new modal specifically for unsetting properties

closes #450