### PR TITLE
Disable trigger delivery policies when unsupported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ([#393](https://github.com/astarte-platform/astarte-dashboard/issues/393))
 - Correctly parse and display device data for datastream object interfaces with parametric endpoints.
 ([#376](https://github.com/astarte-platform/astarte-dashboard/issues/376))
+- Avoid querying Astarte for trigger delivery policies when Astarte does not support them ([#459](https://github.com/astarte-platform/astarte-dashboard/issues/459)).
 
 ## [1.1.1] - 2023-11-15
 ### Added

--- a/cypress/integration/sidebar_test.js
+++ b/cypress/integration/sidebar_test.js
@@ -15,6 +15,7 @@ describe('Sidebar tests', () => {
     });
 
     it('correctly renders sidebar elements', function () {
+      cy.intercept('GET', '/realmmanagement/v1/testrealm/version', { data: '1.1.1' });
       cy.intercept('GET', '/appengine/health', '');
       cy.intercept('GET', '/realmmanagement/health', '');
       cy.intercept('GET', '/pairing/health', '');

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/react-dom": "^17.0.2",
         "@types/react-redux": "^7.1.24",
         "@types/react-syntax-highlighter": "^13.5.0",
+        "@types/semver": "^7.5.8",
         "@types/uuid": "^8.3.4",
         "@types/yup": "^0.29.11",
         "ajv": "^6.12.6",
@@ -57,6 +58,7 @@
         "react-syntax-highlighter": "^15.5.0",
         "resize-observer-polyfill": "^1.5.1",
         "sass": "^1.56.1",
+        "semver": "^6.3.1",
         "uuid": "^8.3.2",
         "yup": "^0.29.3"
       },
@@ -4129,6 +4131,11 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ=="
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "6.0.2",
@@ -22286,9 +22293,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -29900,6 +29907,11 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
+    },
+    "@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ=="
     },
     "@types/sinonjs__fake-timers": {
       "version": "6.0.2",
@@ -43795,9 +43807,9 @@
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
     },
     "send": {
       "version": "0.17.1",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@types/react-dom": "^17.0.2",
     "@types/react-redux": "^7.1.24",
     "@types/react-syntax-highlighter": "^13.5.0",
+    "@types/semver": "^7.5.8",
     "@types/uuid": "^8.3.4",
     "@types/yup": "^0.29.11",
     "ajv": "^6.12.6",
@@ -103,6 +104,7 @@
     "react-syntax-highlighter": "^15.5.0",
     "resize-observer-polyfill": "^1.5.1",
     "sass": "^1.56.1",
+    "semver": "^6.3.1",
     "uuid": "^8.3.2",
     "yup": "^0.29.3"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import createReduxStore from './store';
 const DashboardSidebar = () => {
   const config = useConfig();
   const astarte = useAstarte();
+  const { triggerDeliveryPoliciesSupported } = useAstarte();
 
   const healthFetcher = useFetch(() => {
     const apiChecks = [
@@ -65,7 +66,9 @@ const DashboardSidebar = () => {
         <Sidebar.Separator />
         <Sidebar.Item label="Interfaces" link="/interfaces" icon="interfaces" />
         <Sidebar.Item label="Triggers" link="/triggers" icon="triggers" />
-        <Sidebar.Item label="Delivery Policies" link="/trigger-delivery-policies" icon="policy" />
+        {triggerDeliveryPoliciesSupported && (
+          <Sidebar.Item label="Delivery Policies" link="/trigger-delivery-policies" icon="policy" />
+        )}
         <Sidebar.Separator />
         <Sidebar.Item label="Devices" link="/devices" icon="devices" />
         <Sidebar.Item label="Groups" link="/groups" icon="groups" />

--- a/src/AstarteManager.tsx
+++ b/src/AstarteManager.tsx
@@ -16,9 +16,10 @@
    limitations under the License.
 */
 
-import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import AstarteClient, { AstarteToken } from 'astarte-client';
 import _ from 'lodash';
+import semver from 'semver';
 
 import type { DashboardConfig } from './types';
 
@@ -100,6 +101,7 @@ type AstarteContextValue = {
   isAuthenticated: boolean;
   login: (params: { realm: string; token: string; authUrl: string | null }) => boolean;
   logout: () => void;
+  triggerDeliveryPoliciesSupported: boolean;
 };
 
 const AstarteContext = createContext<AstarteContextValue | null>(null);
@@ -109,12 +111,15 @@ interface AstarteProviderProps {
   config: DashboardConfig;
 }
 
+const astarteVersionWithTriggerDeliveryPoliciesSupport = '1.1.1';
+
 const AstarteProvider = ({
   children,
   config,
   ...props
 }: AstarteProviderProps): React.ReactElement => {
   const [session, setSession] = useState(loadSession());
+  const [realmManagementVersion, setRealmManagementVersion] = useState<string | null>(null);
 
   const client = useMemo(() => {
     const apiConfig = parseAstarteApiUrls(config);
@@ -151,6 +156,20 @@ const AstarteProvider = ({
 
   const logout = useCallback(() => updateSession(null), [updateSession]);
 
+  useEffect(() => {
+    client
+      .getRealmManagementVersion()
+      .then((version) => setRealmManagementVersion(version))
+      .catch(() => setRealmManagementVersion(null));
+  }, [client]);
+
+  const triggerDeliveryPoliciesSupported = useMemo(
+    () =>
+      realmManagementVersion != null &&
+      semver.gte(realmManagementVersion, astarteVersionWithTriggerDeliveryPoliciesSupport),
+    [realmManagementVersion],
+  );
+
   const contextValue = useMemo(
     () => ({
       client,
@@ -158,8 +177,9 @@ const AstarteProvider = ({
       isAuthenticated: session != null,
       login,
       logout,
+      triggerDeliveryPoliciesSupported,
     }),
-    [client, login, logout, session],
+    [client, login, logout, session, triggerDeliveryPoliciesSupported],
   );
 
   return (

--- a/src/NewTriggerPage.tsx
+++ b/src/NewTriggerPage.tsx
@@ -33,7 +33,12 @@ export default (): React.ReactElement => {
   const [isSourceVisible, setIsSourceVisible] = useState(true);
   const [installationAlerts, installationAlertsController] = useAlerts();
   const astarte = useAstarte();
+  const { triggerDeliveryPoliciesSupported } = astarte;
   const navigate = useNavigate();
+
+  const fetchPoliciesName = triggerDeliveryPoliciesSupported
+    ? astarte.client.getPolicyNames
+    : undefined;
 
   const handleToggleSourceVisibility = useCallback(() => {
     setIsSourceVisible((isVisible) => !isVisible);
@@ -80,7 +85,7 @@ export default (): React.ReactElement => {
           onChange={handleTriggerChange}
           onError={handleTriggerEditorError}
           isSourceVisible={isSourceVisible}
-          fetchPoliciesName={astarte.client.getPolicyNames}
+          fetchPoliciesName={fetchPoliciesName}
           fetchInterfacesName={astarte.client.getInterfaceNames}
           fetchInterfaceMajors={astarte.client.getInterfaceMajors}
           fetchInterface={astarte.client.getInterface}

--- a/src/TriggerPage.tsx
+++ b/src/TriggerPage.tsx
@@ -79,8 +79,13 @@ export default (): React.ReactElement => {
   const astarte = useAstarte();
   const navigate = useNavigate();
   const { triggerName = '' } = useParams();
+  const { triggerDeliveryPoliciesSupported } = astarte;
 
   const triggerFetcher = useFetch(() => astarte.client.getTrigger(triggerName));
+
+  const fetchPoliciesName = triggerDeliveryPoliciesSupported
+    ? astarte.client.getPolicyNames
+    : undefined;
 
   const handleToggleSourceVisibility = useCallback(() => {
     setIsSourceVisible((isVisible) => !isVisible);
@@ -142,7 +147,7 @@ export default (): React.ReactElement => {
                 isReadOnly
                 onError={handleTriggerEditorError}
                 isSourceVisible={isSourceVisible}
-                fetchPoliciesName={astarte.client.getPolicyNames}
+                fetchPoliciesName={fetchPoliciesName}
                 fetchInterfacesName={astarte.client.getInterfaceNames}
                 fetchInterfaceMajors={astarte.client.getInterfaceMajors}
                 fetchInterface={astarte.client.getInterface}

--- a/src/astarte-client/client.ts
+++ b/src/astarte-client/client.ts
@@ -193,10 +193,12 @@ class AstarteClient {
     this.getPipeline = this.getPipeline.bind(this);
     this.getPipelines = this.getPipelines.bind(this);
     this.getPolicyNames = this.getPolicyNames.bind(this);
+    this.getRealmManagementVersion = this.getRealmManagementVersion.bind(this);
 
     // prettier-ignore
     this.apiConfig = {
       realmManagementHealth: astarteAPIurl`${config.realmManagementApiUrl}health`,
+      realmManagementVersion:astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/version`,
       auth:                  astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/config/auth`,
       interfaces:            astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/interfaces`,
       interfaceMajors:       astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/interfaces/${'interfaceName'}`,
@@ -711,6 +713,11 @@ class AstarteClient {
 
   async getFlowHealth(): Promise<void> {
     await this.$get(this.apiConfig.flowHealth(this.config));
+  }
+
+  async getRealmManagementVersion(): Promise<string> {
+    const response = await this.$get(this.apiConfig.realmManagementVersion(this.config));
+    return response.data;
   }
 
   private async $get(url: string) {

--- a/src/components/TriggerEditor/index.tsx
+++ b/src/components/TriggerEditor/index.tsx
@@ -78,7 +78,7 @@ interface Props {
     interfaceName: string;
     interfaceMajor: number;
   }) => Promise<AstarteInterface>;
-  fetchPoliciesName: () => Promise<string[]>;
+  fetchPoliciesName?: () => Promise<string[]>;
   initialData?: AstarteTrigger;
   isReadOnly?: boolean;
   isSourceVisible?: boolean;
@@ -127,8 +127,11 @@ export default ({
   );
 
   const handleFetchPoliciesName = useCallback(async () => {
-    setIsLoadingPoliciesName(true);
     let policies: string[] = [];
+    if (!fetchPoliciesName) {
+      return policies;
+    }
+    setIsLoadingPoliciesName(true);
     try {
       policies = await fetchPoliciesName();
     } catch (err: any) {


### PR DESCRIPTION
- Added a function to check if the current Astarte version is compatible with trigger delivery policies.
- Updated the Dashboard components to conditionally render UI elements related to trigger delivery policies based on the version check.

closes #459 