### PR TITLE
Trigger Editor: Allow autosuggest on path input field when select interface name

### DIFF
--- a/src/components/TriggerEditor/SimpleTriggerForm.tsx
+++ b/src/components/TriggerEditor/SimpleTriggerForm.tsx
@@ -97,6 +97,8 @@ const SimpleTriggerForm = ({
   simpleTriggerInterface,
   validationErrors = {},
 }: SimpleTriggerFormProps): React.ReactElement => {
+  const endpointList =
+    simpleTriggerInterface?.mappings.map((mapping: AstarteMapping) => mapping.endpoint) || [];
   const isDeviceTrigger = _.get(simpleTrigger, 'type') === 'device_trigger';
   const isDataTrigger = _.get(simpleTrigger, 'type') === 'data_trigger';
   const hasTargetDevice = _.get(simpleTrigger, 'deviceId') != null;
@@ -510,10 +512,18 @@ const SimpleTriggerForm = ({
                         value={_.get(simpleTrigger, 'matchPath') || ''}
                         isInvalid={_.get(validationErrors, 'matchPath') != null}
                         onChange={handleTriggerInterfacePathChange}
+                        list="endpoints-list"
                       />
                       <Form.Control.Feedback type="invalid">
                         {_.get(validationErrors, 'matchPath')}
                       </Form.Control.Feedback>
+                      <datalist id="endpoints-list">
+                        {endpointList.map((endpoint, index) => (
+                          <option key={index} value={endpoint}>
+                            {endpoint}
+                          </option>
+                        ))}
+                      </datalist>
                     </Form.Group>
                   </Col>
                 </Row>


### PR DESCRIPTION
Added autosuggest on path input field when selected interface name

Implemented auto-suggest functionality for the path input field in the Trigger Editor. This feature provides suggestions for 
available mappings when an interface name is selected

closes #432

Screens:
![Screenshot from 2024-09-11 13-19-40](https://github.com/user-attachments/assets/edd9b433-1846-4ef1-9237-a9fe9abb73fc)
![Screenshot from 2024-09-11 13-07-56](https://github.com/user-attachments/assets/4db9b617-d030-45ef-88fd-3071059ed54f)
![Screenshot from 2024-09-11 13-07-51](https://github.com/user-attachments/assets/217b47a4-2857-4fa9-8711-dd18309c5c40)
![Screenshot from 2024-09-11 13-07-42](https://github.com/user-attachments/assets/71cacf9e-95b6-4811-a664-55b857fe5dee)
