### PR TITLE
Improve floating point input handling for `known_value` in Trigger Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Correctly parse and display device data for datastream object interfaces with parametric endpoints.
 ([#376](https://github.com/astarte-platform/astarte-dashboard/issues/376))
 - Avoid querying Astarte for trigger delivery policies when Astarte does not support them ([#459](https://github.com/astarte-platform/astarte-dashboard/issues/459)).
+- Simplified floating point values for specifying `known_value` in "incoming data" triggers.
+([#465](https://github.com/astarte-platform/astarte-dashboard/issues/465))
 
 ## [1.1.1] - 2023-11-15
 ### Added

--- a/src/components/TriggerEditor/SimpleTriggerForm.tsx
+++ b/src/components/TriggerEditor/SimpleTriggerForm.tsx
@@ -359,6 +359,9 @@ const SimpleTriggerForm = ({
     return options;
   }, [triggerInterfacePathType]);
 
+  const hasNumericKnownValue =
+    triggerInterfacePathType != null && ['double', 'integer'].includes(triggerInterfacePathType);
+
   return (
     <Form>
       <Form.Row className="mb-2">
@@ -545,7 +548,7 @@ const SimpleTriggerForm = ({
                     <Form.Group controlId="triggerKnownValue">
                       <Form.Label>Value</Form.Label>
                       <Form.Control
-                        type="text"
+                        type={hasNumericKnownValue ? 'number' : 'text'}
                         autoComplete="off"
                         required
                         readOnly={isReadOnly || isLoadingInterfaceMajors || isLoadingInterface}


### PR DESCRIPTION
Simplified floating point values for specifying `known_value` in "incoming data" triggers.

closes #465 