### PR TITLE
Implement the option to list installed interfaces in the dropdown

### DIFF
--- a/src/astarte-client/client.ts
+++ b/src/astarte-client/client.ts
@@ -288,6 +288,13 @@ astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/interfaces/${'interfa
     return response.data;
   }
 
+  async getInterfaces(): Promise<string[]> {
+    const endpointUri = new URL(this.apiConfig.interfaces(this.config));
+    endpointUri.searchParams.set('detailed', 'true');
+    const response = await this.$get(endpointUri.toString());
+    return response.data;
+  }
+
   async getInterfaceMajors(interfaceName: string): Promise<number[]> {
     const response = await this.$get(
       this.apiConfig.interfaceMajors({ ...this.config, interfaceName }),


### PR DESCRIPTION
Implement the option to list installed interfaces in the dropdown

- Introduce the fetchInterfacesInfo method to asynchronously retrieve interface details from the Astarte API, including major and minor version information.
- Update the handleNameChange function to set the interfaceDescriptor based on the selected interface from the dropdown, ensuring accurate data representation.
- Modify the UI to utilize <Form.Select>, providing a more intuitive and user-friendly interface for selecting interfaces.

#### Screenshots:
![Screenshot from 2024-10-22 13-33-27](https://github.com/user-attachments/assets/3263bde4-e834-4273-b7b0-bf076e4af239)
![Screenshot from 2024-10-22 13-32-45](https://github.com/user-attachments/assets/676c6e20-0eb2-4b4f-82db-8dba6d9d95e4)
![Screenshot from 2024-10-22 13-32-37](https://github.com/user-attachments/assets/ff01a1f4-3b75-4bbd-bff7-562247c45759)


closes #467 