### PR TITLE
fix(DeviceLiveEventsCard): show falsey values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Avoid querying Astarte for trigger delivery policies when Astarte does not support them ([#459](https://github.com/astarte-platform/astarte-dashboard/issues/459)).
 - Simplified floating point values for specifying `known_value` in "incoming data" triggers.
 ([#465](https://github.com/astarte-platform/astarte-dashboard/issues/465))
+- Show falsey values in the DeviceLiveEventCard by `JSON.stringify` all values and not only objects.
 
 ## [1.1.1] - 2023-11-15
 ### Added

--- a/src/DeviceStatusPage/DeviceLiveEventsCard.tsx
+++ b/src/DeviceStatusPage/DeviceLiveEventsCard.tsx
@@ -242,9 +242,7 @@ const astarteDeviceEventBody = (event: AstarteDeviceEvent) => {
         </Badge>
         <span className="mr-2">{event.interfaceName}</span>
         <span className="mr-2">{event.path}</span>
-        <span className="mr-2 text-monospace">
-          {_.isObject(event.value) ? JSON.stringify(event.value) : event.value}
-        </span>
+        <span className="mr-2 text-monospace">{JSON.stringify(event.value)}</span>
       </>
     );
   }


### PR DESCRIPTION
Use JSON.stringify for all types of values and not only objects.

This will change the behaviour of all the values shown in the component, now all of them are JSON values (e.g. string with `"`, bolean `false`), before React wouldn't have shown `false`, empty arrays or strings.