### PR TITLE
Add Warnings for Missing Interfaces in Device Introspection

### DIFF
--- a/src/DeviceStatusPage/IntrospectionCard.tsx
+++ b/src/DeviceStatusPage/IntrospectionCard.tsx
@@ -16,10 +16,9 @@
    limitations under the License.
 */
 
-import React from 'react';
-import { Card, Table } from 'react-bootstrap';
+import React, { useState, useEffect } from 'react';
+import { Card, Table, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
-
 import type { AstarteDevice, AstarteDeviceInterfaceStats } from 'astarte-client';
 import FullHeightCard from '../components/FullHeightCard';
 import { useAstarte } from 'AstarteManager';
@@ -27,11 +26,13 @@ import { useAstarte } from 'AstarteManager';
 interface IntrospectionTableProps {
   deviceId: string;
   introspection: AstarteDeviceInterfaceStats[];
+  interfacesData: AstarteDeviceInterfaceStats[];
 }
 
 const IntrospectionTable = ({
   deviceId,
   introspection,
+  interfacesData,
 }: IntrospectionTableProps): React.ReactElement => {
   const astarte = useAstarte();
 
@@ -45,25 +46,54 @@ const IntrospectionTable = ({
         </tr>
       </thead>
       <tbody>
-        {introspection.map((iface) => (
-          <tr key={iface.name}>
-            <td>
-              {astarte.token?.can(
-                'appEngine',
-                'GET',
-                `/devices/${deviceId}/interfaces/${iface.name}`,
-              ) ? (
-                <Link to={`/devices/${deviceId}/interfaces/${iface.name}/${iface.major}`}>
-                  {iface.name}
-                </Link>
-              ) : (
-                iface.name
-              )}
-            </td>
-            <td>{iface.major}</td>
-            <td>{iface.minor}</td>
-          </tr>
-        ))}
+        {introspection.map((iface) => {
+          const isInterfaceInstalled = interfacesData.some(
+            (interfaceData) => interfaceData.name === iface.name,
+          );
+          return (
+            <tr key={iface.name}>
+              <td>
+                {astarte.token?.can(
+                  'appEngine',
+                  'GET',
+                  `/devices/${deviceId}/interfaces/${iface.name}`,
+                ) ? (
+                  !isInterfaceInstalled ? (
+                    <>
+                      <OverlayTrigger
+                        placement="top"
+                        overlay={
+                          <Tooltip id={`tooltip-${iface.name}`}>
+                            Interface not installed in the realm
+                          </Tooltip>
+                        }
+                      >
+                        <span
+                          className="d-inline-flex align-items-center justify-content-center rounded-circle border border-danger bg-white text-danger fw-bold me-2"
+                          style={{
+                            width: '20px',
+                            height: '20px',
+                          }}
+                        >
+                          !
+                        </span>
+                      </OverlayTrigger>
+                      {iface.name}
+                    </>
+                  ) : (
+                    <Link to={`/devices/${deviceId}/interfaces/${iface.name}/${iface.major}`}>
+                      {iface.name}
+                    </Link>
+                  )
+                ) : (
+                  iface.name
+                )}
+              </td>
+              <td>{iface.major}</td>
+              <td>{iface.minor}</td>
+            </tr>
+          );
+        })}
       </tbody>
     </Table>
   );
@@ -74,14 +104,30 @@ interface IntrospectionCardProps {
 }
 
 const IntrospectionCard = ({ device }: IntrospectionCardProps): React.ReactElement => {
+  const [interfacesData, setInterfacesData] = useState<AstarteDeviceInterfaceStats[]>([]);
   const introspection = Array.from(device.introspection.values());
+  const astarte = useAstarte();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await astarte.client.getInterfaces();
+      const formattedData = data.map((iface: string) => ({ name: iface }));
+      setInterfacesData(formattedData as AstarteDeviceInterfaceStats[]);
+    };
+
+    fetchData();
+  }, [astarte]);
 
   return (
     <FullHeightCard xs={12} md={6} className="mb-4">
       <Card.Header as="h5">Interfaces</Card.Header>
       <Card.Body className="d-flex flex-column">
         {introspection.length > 0 ? (
-          <IntrospectionTable deviceId={device.id} introspection={introspection} />
+          <IntrospectionTable
+            deviceId={device.id}
+            introspection={introspection}
+            interfacesData={interfacesData}
+          />
         ) : (
           <p>No introspection info</p>
         )}


### PR DESCRIPTION
Added a warning indicator for interfaces not installed in the realm. Links are removed for such interfaces.

Screens:
![Screenshot from 2024-12-31 13-24-33](https://github.com/user-attachments/assets/ccf17e99-c2a2-42bb-8103-5a274f12a891)
![Screenshot from 2024-12-31 13-24-24](https://github.com/user-attachments/assets/a4674c97-b055-4453-9214-2c8dbdf4cae3)
