### PR TITLE
Display useful feedback for invalid JWT token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add a "keep me logged in" during login, ([#451](https://github.com/astarte-platform/astarte-dashboard/issues/451)).
 - Allow unsetting property endpoints, ([#450](https://github.com/astarte-platform/astarte-dashboard/issues/450)).
 - Allow to filter time of Interface DataStream data, ([#441](https://github.com/astarte-platform/astarte-dashboard/issues/441)).
+- Add useful feedback about the invalid JWT token, ([#485](https://github.com/astarte-platform/astarte-dashboard/issues/485)).
 ### Changed
 - Adapt Device Stats and PieChart to exclude interfaces with 0 exchanged messages, ([#428](https://github.com/astarte-platform/astarte-dashboard/issues/428)).
 - Persist login using cookies instead of localStorage, ([#419](https://github.com/astarte-platform/astarte-dashboard/issues/419)).

--- a/cypress/e2e/sidebar.cy.js
+++ b/cypress/e2e/sidebar.cy.js
@@ -15,7 +15,9 @@ describe('Sidebar tests', () => {
     });
 
     it('correctly renders sidebar elements', function () {
-      cy.intercept('GET', '/realmmanagement/v1/testrealm/version', { data: '1.1.1' });
+      cy.intercept('GET', '**/version', (req) => {
+        req.reply({ data: '1.1.1' });
+      })
       cy.intercept('GET', '/appengine/health', '');
       cy.intercept('GET', '/realmmanagement/health', '');
       cy.intercept('GET', '/pairing/health', '');

--- a/src/AstarteManager.tsx
+++ b/src/AstarteManager.tsx
@@ -176,10 +176,31 @@ const AstarteProvider = ({
 
   useEffect(() => {
     client
-      .getRealmManagementVersion()
+      .getUnauthenticatedRealmManagementVersion()
       .then((version) => setRealmManagementVersion(version))
       .catch(() => setRealmManagementVersion(null));
-  }, [client]);
+
+    client.getRealmManagementVersion().catch((error) => {
+      if (error.response && error.response.status === 401) {
+        // This prevents the "Cannot update a component while rendering a different component" warning
+        setTimeout(() => logout(), 0);
+      }
+    });
+
+    client.getAppEngineVersion().catch((error) => {
+      if (error.response && error.response.status === 401) {
+        // This prevents the "Cannot update a component while rendering a different component" warning.
+        setTimeout(() => logout(), 0);
+      }
+    });
+
+    client.getPairingVersion().catch((error) => {
+      if (error.response && error.response.status === 401) {
+        // This prevents the "Cannot update a component while rendering a different component" warning.
+        setTimeout(() => logout(), 0);
+      }
+    });
+  }, [client, logout]);
 
   const triggerDeliveryPoliciesSupported = useMemo(
     () =>

--- a/src/DevicesPage.tsx
+++ b/src/DevicesPage.tsx
@@ -22,6 +22,7 @@ import {
   Col,
   Container,
   Form,
+  ListGroup,
   Pagination,
   Row,
   Spinner,
@@ -417,6 +418,24 @@ const FilterForm = ({ filters, onUpdateFilters }: FilterFormProps): React.ReactE
   );
 };
 
+interface ErrorRowProps {
+  onRetry: () => void;
+  errorMessage?: string;
+}
+
+const ErrorRow = ({ onRetry, errorMessage }: ErrorRowProps): React.ReactElement => (
+  <ListGroup.Item>
+    <Empty
+      title={
+        errorMessage?.includes('401')
+          ? "The JWT token is invalid or does not match the realm's public key."
+          : "Couldn't load the device list"
+      }
+      onRetry={onRetry}
+    />
+  </ListGroup.Item>
+);
+
 export default (): React.ReactElement => {
   const [activePage, setActivePage] = useState(0);
   const [showSidebar, setShowSidebar] = useState(true);
@@ -496,7 +515,10 @@ export default (): React.ReactElement => {
           </Container>
         }
         errorFallback={
-          <Empty title="Couldn't load the device list" onRetry={() => devicesFetcher.refresh({})} />
+          <ErrorRow
+            onRetry={() => devicesFetcher.refresh({})}
+            errorMessage={devicesFetcher.error?.message}
+          />
         }
       >
         {({ devices, nextToken }) =>

--- a/src/GroupsPage.tsx
+++ b/src/GroupsPage.tsx
@@ -18,7 +18,7 @@
 
 import React, { useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Button, Container, Spinner, Table } from 'react-bootstrap';
+import { Button, Container, ListGroup, Spinner, Table } from 'react-bootstrap';
 
 import SingleCardPage from './ui/SingleCardPage';
 import { AlertsBanner, useAlerts } from './AlertManager';
@@ -75,6 +75,24 @@ const GroupsTable = ({ groupMap }: GroupsTableProps) => {
   );
 };
 
+interface ErrorRowProps {
+  onRetry: () => void;
+  errorMessage?: string;
+}
+
+const ErrorRow = ({ onRetry, errorMessage }: ErrorRowProps): React.ReactElement => (
+  <ListGroup.Item>
+    <Empty
+      title={
+        errorMessage?.includes('401')
+          ? "The JWT token is invalid or does not match the realm's public key."
+          : "Couldn't load groups"
+      }
+      onRetry={onRetry}
+    />
+  </ListGroup.Item>
+);
+
 export default (): React.ReactElement => {
   const astarte = useAstarte();
   const [pageAlerts, pageAlertsController] = useAlerts();
@@ -122,7 +140,9 @@ export default (): React.ReactElement => {
             <Spinner animation="border" role="status" />
           </Container>
         }
-        errorFallback={<Empty title="Couldn't load groups" onRetry={groupsFetcher.refresh} />}
+        errorFallback={
+          <ErrorRow onRetry={groupsFetcher.refresh} errorMessage={groupsFetcher.error?.message} />
+        }
       >
         {(groupMap) => <GroupsTable groupMap={groupMap} />}
       </WaitForData>

--- a/src/InterfacesPage.tsx
+++ b/src/InterfacesPage.tsx
@@ -83,11 +83,19 @@ const LoadingRow = (): React.ReactElement => (
 
 interface ErrorRowProps {
   onRetry: () => void;
+  errorMessage?: string;
 }
 
-const ErrorRow = ({ onRetry }: ErrorRowProps): React.ReactElement => (
+const ErrorRow = ({ onRetry, errorMessage }: ErrorRowProps): React.ReactElement => (
   <ListGroup.Item>
-    <Empty title="Couldn't load available interfaces" onRetry={onRetry} />
+    <Empty
+      title={
+        errorMessage?.includes('401')
+          ? "The JWT token is invalid or does not match the realm's public key."
+          : "Couldn't load available interfaces"
+      }
+      onRetry={onRetry}
+    />
   </ListGroup.Item>
 );
 
@@ -143,7 +151,12 @@ export default (): React.ReactElement => {
               data={interfacesInfoFetcher.value}
               status={interfacesInfoFetcher.status}
               fallback={<LoadingRow />}
-              errorFallback={<ErrorRow onRetry={interfacesInfoFetcher.refresh} />}
+              errorFallback={
+                <ErrorRow
+                  onRetry={interfacesInfoFetcher.refresh}
+                  errorMessage={interfacesInfoFetcher.error?.message}
+                />
+              }
             >
               {(interfaces) => (
                 <>

--- a/src/RealmSettingsPage.tsx
+++ b/src/RealmSettingsPage.tsx
@@ -18,7 +18,7 @@
 
 import React, { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Button, Container, Form, Spinner, Stack } from 'react-bootstrap';
+import { Button, Container, Form, ListGroup, Spinner, Stack } from 'react-bootstrap';
 
 import Empty from './components/Empty';
 import ConfirmModal from './components/modals/Confirm';
@@ -78,6 +78,24 @@ const RealmSettingsForm = ({
     </Form>
   );
 };
+
+interface ErrorRowProps {
+  onRetry: () => void;
+  errorMessage?: string;
+}
+
+const ErrorRow = ({ onRetry, errorMessage }: ErrorRowProps): React.ReactElement => (
+  <ListGroup.Item>
+    <Empty
+      title={
+        errorMessage?.includes('401')
+          ? "The JWT token is invalid or does not match the realm's public key."
+          : "Couldn't load realm settings"
+      }
+      onRetry={onRetry}
+    />
+  </ListGroup.Item>
+);
 
 export default (): React.ReactElement => {
   const [draftRealmSettings, setDraftRealmSettings] = useState<RealmSettings | null>(null);
@@ -146,7 +164,10 @@ export default (): React.ReactElement => {
           </Container>
         }
         errorFallback={
-          <Empty title="Couldn't load realm settings" onRetry={authConfigFetcher.refresh} />
+          <ErrorRow
+            onRetry={authConfigFetcher.refresh}
+            errorMessage={authConfigFetcher.error?.message}
+          />
         }
       >
         {({ publicKey }) => (

--- a/src/TriggerDeliveryPoliciesPage.tsx
+++ b/src/TriggerDeliveryPoliciesPage.tsx
@@ -61,11 +61,19 @@ const LoadingRow = (): React.ReactElement => (
 
 interface ErrorRowProps {
   onRetry: () => void;
+  errorMessage?: string;
 }
 
-const ErrorRow = ({ onRetry }: ErrorRowProps): React.ReactElement => (
+const ErrorRow = ({ onRetry, errorMessage }: ErrorRowProps): React.ReactElement => (
   <ListGroup.Item>
-    <Empty title="Couldn't load available delivery policies" onRetry={onRetry} />
+    <Empty
+      title={
+        errorMessage?.includes('401')
+          ? "The JWT token is invalid or does not match the realm's public key."
+          : "Couldn't load available delivery policies"
+      }
+      onRetry={onRetry}
+    />
   </ListGroup.Item>
 );
 
@@ -103,7 +111,12 @@ export default (): React.ReactElement => {
               data={policiesFetcher.value}
               status={policiesFetcher.status}
               fallback={<LoadingRow />}
-              errorFallback={<ErrorRow onRetry={policiesFetcher.refresh} />}
+              errorFallback={
+                <ErrorRow
+                  onRetry={policiesFetcher.refresh}
+                  errorMessage={policiesFetcher.error?.message}
+                />
+              }
             >
               {(policies) => (
                 <>

--- a/src/TriggersPage.tsx
+++ b/src/TriggersPage.tsx
@@ -61,11 +61,19 @@ const LoadingRow = (): React.ReactElement => (
 
 interface ErrorRowProps {
   onRetry: () => void;
+  errorMessage?: string;
 }
 
-const ErrorRow = ({ onRetry }: ErrorRowProps): React.ReactElement => (
+const ErrorRow = ({ onRetry, errorMessage }: ErrorRowProps): React.ReactElement => (
   <ListGroup.Item>
-    <Empty title="Couldn't load available triggers" onRetry={onRetry} />
+    <Empty
+      title={
+        errorMessage?.includes('401')
+          ? "The JWT token is invalid or does not match the realm's public key."
+          : "Couldn't load available triggers"
+      }
+      onRetry={onRetry}
+    />
   </ListGroup.Item>
 );
 
@@ -103,7 +111,12 @@ export default (): React.ReactElement => {
               data={triggersFetcher.value}
               status={triggersFetcher.status}
               fallback={<LoadingRow />}
-              errorFallback={<ErrorRow onRetry={triggersFetcher.refresh} />}
+              errorFallback={
+                <ErrorRow
+                  onRetry={triggersFetcher.refresh}
+                  errorMessage={triggersFetcher.error?.message}
+                />
+              }
             >
               {(triggers) => (
                 <>

--- a/src/astarte-client/client.ts
+++ b/src/astarte-client/client.ts
@@ -194,13 +194,18 @@ class AstarteClient {
     this.getPipeline = this.getPipeline.bind(this);
     this.getPipelines = this.getPipelines.bind(this);
     this.getPolicyNames = this.getPolicyNames.bind(this);
+    this.getUnauthenticatedRealmManagementVersion =
+      this.getUnauthenticatedRealmManagementVersion.bind(this);
     this.getRealmManagementVersion = this.getRealmManagementVersion.bind(this);
+    this.getUnauthenticatedAppEngineVersion = this.getUnauthenticatedAppEngineVersion.bind(this);
     this.getAppEngineVersion = this.getAppEngineVersion.bind(this);
+    this.getUnauthenticatedPairingVersion = this.getUnauthenticatedPairingVersion.bind(this);
     this.getPairingVersion = this.getPairingVersion.bind(this);
 
     // prettier-ignore
     this.apiConfig = {
       realmManagementHealth: astarteAPIurl`${config.realmManagementApiUrl}health`,
+      unAuthenticatedRealmManagementVersion: astarteAPIurl`${config.realmManagementApiUrl}version`,
       realmManagementVersion:astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/version`,
       auth:                  astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/config/auth`,
       deviceRegistrationLimit: astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/config/device_registration_limit`,
@@ -215,6 +220,7 @@ astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/interfaces/${'interfa
       policy:                astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/policies/${'policyName'}`,
       device:                astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/devices/${'deviceId'}`,
       appengineHealth:       astarteAPIurl`${config.appEngineApiUrl}health`,
+      unAuthenticatedAppEngineVersion: astarteAPIurl`${config.appEngineApiUrl}version`,
       appengineVersion:      astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/version`,
       devicesStats:          astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/stats/devices`,
       devices:               astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/devices`,
@@ -226,6 +232,7 @@ astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/interfaces/${'interfa
       phoenixSocket:         astarteAPIurl`${config.appEngineApiUrl}v1/socket`,
       sendInterfaceData:     astarteAPIurl`${config.appEngineApiUrl}v1/${'realm'}/devices/${'deviceId'}/interfaces/${'interfaceName'}${'path'}`,      
       pairingHealth:         astarteAPIurl`${config.pairingApiUrl}health`,
+      unAuthenticatedPairingVersion: astarteAPIurl`${config.pairingApiUrl}version`,
       pairingVersion:        astarteAPIurl`${config.pairingApiUrl}v1/${'realm'}/version`,
       registerDevice:        astarteAPIurl`${config.pairingApiUrl}v1/${'realm'}/agent/devices`,
       deviceAgent:           astarteAPIurl`${config.pairingApiUrl}v1/${'realm'}/agent/devices/${'deviceId'}`,
@@ -740,13 +747,30 @@ astarteAPIurl`${config.realmManagementApiUrl}v1/${'realm'}/interfaces/${'interfa
     await this.$get(this.apiConfig.flowHealth(this.config));
   }
 
+  async getUnauthenticatedRealmManagementVersion(): Promise<string> {
+    const response = await this.$get(
+      this.apiConfig.unAuthenticatedRealmManagementVersion(this.config),
+    );
+    return response.data;
+  }
+
   async getRealmManagementVersion(): Promise<string> {
     const response = await this.$get(this.apiConfig.realmManagementVersion(this.config));
     return response.data;
   }
 
+  async getUnauthenticatedAppEngineVersion(): Promise<string> {
+    const response = await this.$get(this.apiConfig.unAuthenticatedAppEngineVersion(this.config));
+    return response.data;
+  }
+
   async getAppEngineVersion(): Promise<string> {
     const response = await this.$get(this.apiConfig.appengineVersion(this.config));
+    return response.data;
+  }
+
+  async getUnauthenticatedPairingVersion(): Promise<string> {
+    const response = await this.$get(this.apiConfig.unAuthenticatedPairingVersion(this.config));
     return response.data;
   }
 

--- a/src/components/Empty.tsx
+++ b/src/components/Empty.tsx
@@ -18,6 +18,7 @@
 
 import React from 'react';
 import { Button, Container } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
 
 interface Props {
   title: string;
@@ -33,6 +34,16 @@ const Empty = ({ title, onRetry }: Props): React.ReactElement => {
     'try again'
   );
 
+  const isJWTError = title.includes('JWT');
+
+  const message = isJWTError ? (
+    <>
+      Please check your JWT token and <Link to="/logout">log out</Link>.
+    </>
+  ) : (
+    <>Please check your connectivity and {tryAgain}.</>
+  );
+
   return (
     <Container fluid className="text-center">
       <img
@@ -41,7 +52,7 @@ const Empty = ({ title, onRetry }: Props): React.ReactElement => {
         style={{ maxWidth: 200 }}
       />
       <h5 className="mt-2">{title}</h5>
-      <p>Please check your connectivity and {tryAgain}.</p>
+      <p>{message}</p>
     </Container>
   );
 };

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -40,6 +40,8 @@ const iconToClassName = {
   statusOK: 'fas fa-check-circle color-green',
   statusConnected: 'fas fa-circle color-green',
   statusDisconnected: 'fas fa-circle color-red',
+  statusExWarning: 'fas fa-exclamation-circle color-yellow',
+  statusWarning: 'fas fa-circle color-yellow',
   statusKO: 'fas fa-times-circle color-red',
   statusNeverConnected: 'fas fa-circle color-grey',
   statusInDeletion: 'fas fa-circle color-grey',

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -95,6 +95,10 @@ h6,
   color: $red;
 }
 
+.color-yellow {
+  color: $yellow;
+}
+
 .login-form {
   max-width: 50rem;
 }


### PR DESCRIPTION
**When logged in with invalid JWT token (```astartectl utils gen-jwt all-realm-apis -k test_private.pem```) :**
![Screenshot from 2025-02-05 16-04-00](https://github.com/user-attachments/assets/7c648e87-44c2-4496-8713-f7aa3a019292)
![Screenshot from 2025-02-06 11-03-18](https://github.com/user-attachments/assets/0a7ac665-ba51-4d1a-b8d5-a8a3b2c17ec8)
![Screenshot from 2025-02-06 11-03-14](https://github.com/user-attachments/assets/ca70fe2a-abfc-4cc1-8adf-0a4069723c50)



**When logged in with valid JWT token (```astartectl utils gen-jwt appengine -k test_private.pem```) :**
![Screenshot from 2025-02-05 16-34-10](https://github.com/user-attachments/assets/80ac38be-4710-496e-9d09-373342e19911)

**When logged in with valid JWT token (```astartectl utils gen-jwt realmmanagement -k test_private.pem```) :**
![Screenshot from 2025-02-05 16-33-34](https://github.com/user-attachments/assets/b893f7bf-6e15-4bc2-88de-04b706e1c78b)


closes #485 