### PR TITLE
Optimize API version fetching with permission checks

### DIFF
--- a/cypress/e2e/home_page.cy.js
+++ b/cypress/e2e/home_page.cy.js
@@ -39,7 +39,11 @@ describe('Home page tests', () => {
           services.forEach((service, index) => {
             cy.get(`table tbody tr:nth-child(${index + 1})`).within(() => {
               cy.contains(service);
-              cy.contains('This service is operating normally');
+              if (service === 'Flow') {
+                cy.contains('This service is operating normally');
+              } else {
+                cy.contains('Cannot query the service with the current token');
+              }
             });
           });
         });

--- a/src/DevicesPage.tsx
+++ b/src/DevicesPage.tsx
@@ -427,7 +427,7 @@ const ErrorRow = ({ onRetry, errorMessage }: ErrorRowProps): React.ReactElement 
   <ListGroup.Item>
     <Empty
       title={
-        errorMessage?.includes('401')
+        errorMessage?.includes('401') || errorMessage?.includes('403')
           ? "The JWT token is invalid or does not match the realm's public key."
           : "Couldn't load the device list"
       }

--- a/src/GroupsPage.tsx
+++ b/src/GroupsPage.tsx
@@ -84,7 +84,7 @@ const ErrorRow = ({ onRetry, errorMessage }: ErrorRowProps): React.ReactElement 
   <ListGroup.Item>
     <Empty
       title={
-        errorMessage?.includes('401')
+        errorMessage?.includes('401') || errorMessage?.includes('403')
           ? "The JWT token is invalid or does not match the realm's public key."
           : "Couldn't load groups"
       }

--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -61,7 +61,7 @@ const ServiceStatusRow = ({
     messageCell = (
       <td className="color-yellow">
         <Icon icon="statusExWarning" className="me-1" />
-        This service is operating normally but token is invalid
+        Cannot query the service with the current token
       </td>
     );
   } else {
@@ -400,6 +400,9 @@ const TriggersCard = ({
 const HomePage = (): React.ReactElement => {
   const astarte = useAstarte();
   const config = useConfig();
+  const canFetchRealmManagementVersion = astarte.token?.can('realmManagement', 'GET', '/version');
+  const canFetchAppEngineVersion = astarte.token?.can('appEngine', 'GET', '/version');
+  const canFetchPairingVersion = astarte.token?.can('pairing', 'GET', '/version');
   const canFetchInterfaces = astarte.token?.can('realmManagement', 'GET', '/interfaces');
   const canFetchTriggers = astarte.token?.can('realmManagement', 'GET', '/triggers');
   const canFetchDeviceStats = astarte.token?.can('appEngine', 'GET', '/stats/devices');
@@ -420,12 +423,18 @@ const HomePage = (): React.ReactElement => {
   const appEngineHealth = useFetch(astarte.client.getAppengineHealth);
   const realmManagementHealth = useFetch(astarte.client.getRealmManagementHealth);
   const pairingHealth = useFetch(astarte.client.getPairingHealth);
+  const realmManagementAuth = useFetch(
+    canFetchRealmManagementVersion ? astarte.client.getRealmManagementVersion : async () => null,
+  );
+  const appengineAuth = useFetch(
+    canFetchAppEngineVersion ? astarte.client.getAppEngineVersion : async () => null,
+  );
+  const pairingAuth = useFetch(
+    canFetchPairingVersion ? astarte.client.getPairingVersion : async () => null,
+  );
   const realmManagementVersion = useFetch(astarte.client.getUnauthenticatedRealmManagementVersion);
   const appengineVersion = useFetch(astarte.client.getUnauthenticatedAppEngineVersion);
   const pairingVersion = useFetch(astarte.client.getUnauthenticatedPairingVersion);
-  const realmManagementAuth = useFetch(astarte.client.getRealmManagementVersion);
-  const appengineAuth = useFetch(astarte.client.getAppEngineVersion);
-  const pairingAuth = useFetch(astarte.client.getPairingVersion);
   const flowHealth = useFetch(config.features.flow ? astarte.client.getFlowHealth : async () => {});
   const deviceRegistrationLimitFetcher = useFetch(
     canFetchDeviceRegistrationLimit && canFetchDeviceStats
@@ -486,13 +495,13 @@ const HomePage = (): React.ReactElement => {
         <Col xs={6} className={cellSpacingClass}>
           <ApiStatusCard
             appengine={appEngineHealth.status}
-            appengineVersion={appengineVersion.value}
+            appengineVersion={appengineVersion.value || appengineAuth.value}
             appengineAuth={appengineAuth.value}
             realmManagement={realmManagementHealth.status}
-            realmManagementVersion={realmManagementVersion.value}
+            realmManagementVersion={realmManagementVersion.value || realmManagementAuth.value}
             realmManagementAuth={realmManagementAuth.value}
             pairing={pairingHealth.status}
-            pairingVersion={pairingVersion.value}
+            pairingVersion={pairingVersion.value || pairingAuth.value}
             pairingAuth={pairingAuth.value}
             showFlowStatus={config.features.flow}
             flow={config.features.flow ? flowHealth.status : null}

--- a/src/InterfacesPage.tsx
+++ b/src/InterfacesPage.tsx
@@ -90,7 +90,7 @@ const ErrorRow = ({ onRetry, errorMessage }: ErrorRowProps): React.ReactElement 
   <ListGroup.Item>
     <Empty
       title={
-        errorMessage?.includes('401')
+        errorMessage?.includes('401') || errorMessage?.includes('403')
           ? "The JWT token is invalid or does not match the realm's public key."
           : "Couldn't load available interfaces"
       }

--- a/src/RealmSettingsPage.tsx
+++ b/src/RealmSettingsPage.tsx
@@ -88,7 +88,7 @@ const ErrorRow = ({ onRetry, errorMessage }: ErrorRowProps): React.ReactElement 
   <ListGroup.Item>
     <Empty
       title={
-        errorMessage?.includes('401')
+        errorMessage?.includes('401') || errorMessage?.includes('403')
           ? "The JWT token is invalid or does not match the realm's public key."
           : "Couldn't load realm settings"
       }

--- a/src/TriggerDeliveryPoliciesPage.tsx
+++ b/src/TriggerDeliveryPoliciesPage.tsx
@@ -68,7 +68,7 @@ const ErrorRow = ({ onRetry, errorMessage }: ErrorRowProps): React.ReactElement 
   <ListGroup.Item>
     <Empty
       title={
-        errorMessage?.includes('401')
+        errorMessage?.includes('401') || errorMessage?.includes('403')
           ? "The JWT token is invalid or does not match the realm's public key."
           : "Couldn't load available delivery policies"
       }

--- a/src/TriggersPage.tsx
+++ b/src/TriggersPage.tsx
@@ -68,7 +68,7 @@ const ErrorRow = ({ onRetry, errorMessage }: ErrorRowProps): React.ReactElement 
   <ListGroup.Item>
     <Empty
       title={
-        errorMessage?.includes('401')
+        errorMessage?.includes('401') || errorMessage?.includes('403')
           ? "The JWT token is invalid or does not match the realm's public key."
           : "Couldn't load available triggers"
       }


### PR DESCRIPTION
This update improves how we fetch API versions by introducing permission checks:  
- Before making requests, the app verifies if the user has the required permissions (`canFetch*`).  
- Prevents unnecessary requests when permissions are missing.  
- Uses fallback mechanisms to fetch versions from either authenticated or unauthenticated endpoints.  

Generated valid/invalid ```appengine``` token:
[Screencast from 2025-02-21 10-13-35.webm](https://github.com/user-attachments/assets/b199aa14-075e-4a63-a5b9-1e6e6a6a7979)

Generated valid/invalid ```all-realm-apis``` token:
[Screencast from 2025-02-21 10-30-19.webm](https://github.com/user-attachments/assets/4861187a-d810-4d88-bb44-cce6f0b74d81)

_The reason the pairing version is showing is a problem on the Astarte side, and the reason it didn't log out is because every API has to return a 403 to log out._
