### PR TITLE
chore(ci): update GitHub Actions to v4

### DIFF
--- a/.github/workflows/build-compatibility.yml
+++ b/.github/workflows/build-compatibility.yml
@@ -20,13 +20,13 @@ jobs:
           - 16
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             **/node_modules

--- a/.github/workflows/functionality-tests.yml
+++ b/.github/workflows/functionality-tests.yml
@@ -17,13 +17,13 @@ jobs:
           - 16
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             **/node_modules


### PR DESCRIPTION
Updated the following GitHub Actions to version 4:
- actions/checkout@v4
- actions/setup-node@v4
- actions/cache@v4

Ensures compatibility with the latest improvements and security patches