### PR TITLE
chore(release): prepare v1.2.1-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.1-rc.0] - 2025-08-22
+### Fixed
+- Correctly handle navigating to a trigger page when its name contains special characters ([#499](https://github.com/astarte-platform/astarte-dashboard/pull/499)).
+
 ## [1.2.1-alpha.0] - 2025-04-10
 ### Added
 - Support redirection to a specific page after successful authentication

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astarte-dashboard",
-  "version": "1.2.1-alpha.0",
+  "version": "1.2.1-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "astarte-dashboard",
-      "version": "1.2.1-alpha.0",
+      "version": "1.2.1-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@astarte-platform/react-bootstrap": "^5.15.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "astarte-dashboard",
-  "version": "1.2.1-alpha.0",
+  "version": "1.2.1-rc.0",
   "description": "Astarte dashboard",
   "keywords": [
     "astarte",


### PR DESCRIPTION
This change performs some chores to prepare the codebase for releasing 1.2.1-rc.0.
- Bump versions in package.json and package-lock.json.
- Update relevant section in CHANGELOG.md to report the upcoming release.