### PR TITLE
feat: add required flag support to interface mappings

### DIFF
--- a/cypress/e2e/interface_builder.cy.js
+++ b/cypress/e2e/interface_builder.cy.js
@@ -9,6 +9,7 @@ const parseMappingOptions = (mapping) => {
     databaseRetention: _.get(mapping, 'database_retention_policy', 'no_ttl'),
     databaseTTL: _.get(mapping, 'database_retention_ttl'),
     allowUnset: _.get(mapping, 'allow_unset', false),
+    required: _.get(mapping, 'required', false),
   };
 };
 
@@ -94,6 +95,7 @@ const setupInterfaceEditorFromUI = (iface) => {
         databaseRetention,
         databaseTTL,
         allowUnset,
+        required,
       } = parseMappingOptions(mapping);
       if (iface.type === 'properties') {
         if (allowUnset) {
@@ -101,7 +103,15 @@ const setupInterfaceEditorFromUI = (iface) => {
         } else {
           cy.get('#mappingAllowUnset').scrollIntoView().uncheck();
         }
-      } else if (iface.type === 'datastream' && iface.aggregation !== 'object') {
+      }
+      if (iface.aggregation === 'object') {
+        if (required) {
+          cy.get('#mappingRequired').scrollIntoView().check();
+        } else {
+          cy.get('#mappingRequired').scrollIntoView().uncheck();
+        }
+      }
+      if (iface.type === 'datastream' && iface.aggregation !== 'object') {
         cy.get('#mappingReliability').scrollIntoView().select(reliability);
         cy.get('#mappingRetention').scrollIntoView().select(retention);
         cy.get('#mappingDatabaseRetention').scrollIntoView().select(databaseRetention);
@@ -152,13 +162,21 @@ const checkMappingEditorUIValues = ({ mapping, type, aggregation = 'individual' 
       databaseRetention,
       databaseTTL,
       allowUnset,
+      required,
     } = parseMappingOptions(mapping);
     if (type === 'properties') {
       cy.get('#mappingAllowUnset')
         .scrollIntoView()
         .should('be.visible')
         .and(allowUnset ? 'be.checked' : 'not.be.checked');
-    } else if (type === 'datastream' && aggregation !== 'object') {
+    }
+    if (aggregation === 'object') {
+      cy.get('#mappingRequired')
+        .scrollIntoView()
+        .should('be.visible')
+        .and(required ? 'be.checked' : 'not.be.checked');
+    }
+    if (type === 'datastream' && aggregation !== 'object') {
       cy.get('#mappingReliability')
         .scrollIntoView()
         .should('be.visible')

--- a/cypress/fixtures/test.astarte.AggregatedObjectInterface.json
+++ b/cypress/fixtures/test.astarte.AggregatedObjectInterface.json
@@ -10,7 +10,8 @@
       {
         "endpoint": "/sensors/%{sensor_id}/value/binaryblob",
         "type": "binaryblob",
-        "explicit_timestamp": true
+        "explicit_timestamp": true,
+        "required": true
       },
       {
         "endpoint": "/sensors/%{sensor_id}/value/boolean",

--- a/src/astarte-client/models/Mapping/index.ts
+++ b/src/astarte-client/models/Mapping/index.ts
@@ -43,6 +43,8 @@ interface AstarteMappingObject {
 
   explicitTimestamp?: boolean;
 
+  required?: boolean;
+
   description?: string;
 
   documentation?: string;
@@ -91,6 +93,7 @@ const astarteMappingObjectSchema: yup.ObjectSchema<AstarteMappingObject> = yup
       .notRequired(),
     allowUnset: yup.boolean().notRequired(),
     explicitTimestamp: yup.boolean().notRequired(),
+    required: yup.boolean().notRequired(),
     description: yup.string().max(1000).notRequired(),
     documentation: yup.string().max(100000).notRequired(),
   })
@@ -121,6 +124,8 @@ class AstarteMapping {
 
   explicitTimestamp?: boolean;
 
+  required?: boolean;
+
   description?: string;
 
   documentation?: string;
@@ -136,6 +141,7 @@ class AstarteMapping {
     this.databaseRetentionTtl = validatedObj.databaseRetentionTtl;
     this.allowUnset = validatedObj.allowUnset;
     this.explicitTimestamp = validatedObj.explicitTimestamp;
+    this.required = validatedObj.required;
     this.description = validatedObj.description;
     this.documentation = validatedObj.documentation;
   }

--- a/src/astarte-client/transforms/mapping.ts
+++ b/src/astarte-client/transforms/mapping.ts
@@ -30,6 +30,7 @@ export const fromAstarteMappingDTO = (dto: AstarteMappingDTO): AstarteMapping =>
     databaseRetentionTtl: dto.database_retention_ttl,
     allowUnset: dto.allow_unset,
     explicitTimestamp: dto.explicit_timestamp,
+    required: dto.required,
     description: dto.description,
     documentation: dto.doc,
   });
@@ -44,6 +45,7 @@ export const toAstarteMappingDTO = (obj: AstarteMapping): AstarteMappingDTO => (
   database_retention_ttl: obj.databaseRetentionTtl,
   allow_unset: obj.allowUnset,
   explicit_timestamp: obj.explicitTimestamp,
+  required: obj.required,
   description: obj.description,
   doc: obj.documentation,
 });

--- a/src/astarte-client/types/dto/mapping.d.ts
+++ b/src/astarte-client/types/dto/mapping.d.ts
@@ -41,6 +41,7 @@ export interface AstarteMappingDTO {
   database_retention_ttl?: number;
   allow_unset?: boolean;
   explicit_timestamp?: boolean;
+  required?: boolean;
   description?: string;
   doc?: string;
 }

--- a/src/components/InterfaceEditor.tsx
+++ b/src/components/InterfaceEditor.tsx
@@ -111,6 +111,12 @@ const MappingRow = ({ className, mapping, onEdit, onDelete }: MappingRowProps) =
             <p>True</p>
           </>
         )}
+        {mapping.required && (
+          <>
+            <h5>Required</h5>
+            <p>True</p>
+          </>
+        )}
         {mapping.explicitTimestamp && (
           <>
             <h5>Explicit Timestamp</h5>

--- a/src/components/MappingEditor.tsx
+++ b/src/components/MappingEditor.tsx
@@ -62,6 +62,7 @@ export default ({
   const isPropertiesInterface = interfaceType === 'properties';
   const isDatastreamIndividualInterface =
     interfaceType === 'datastream' && interfaceAggregation === 'individual';
+  const isObjectAggregated = interfaceAggregation === 'object';
   const isDevice = interfaceOwner === 'device';
   const showMappingExpiry = mapping.retention === 'volatile' || mapping.retention === 'stored';
   const showInterfaceDatabaseRetentionTtl = mapping.databaseRetentionPolicy === 'use_ttl';
@@ -129,6 +130,26 @@ export default ({
                 />
                 <Form.Control.Feedback type="invalid">
                   {mappingValidationErrors.allowUnset}
+                </Form.Control.Feedback>
+              </Form.Group>
+            </Col>
+          )}
+          {isObjectAggregated && (
+            <Col sm={4}>
+              <Form.Group controlId="mappingRequired">
+                <Form.Label>Mapping options</Form.Label>
+                <Form.Check
+                  type="checkbox"
+                  label="Required"
+                  checked={!!mapping.required}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    const required = !!e.target.checked;
+                    onChange({ ...mapping, required: required || undefined });
+                  }}
+                  isInvalid={mappingValidationErrors.required != null}
+                />
+                <Form.Control.Feedback type="invalid">
+                  {mappingValidationErrors.required}
                 </Form.Control.Feedback>
               </Form.Group>
             </Col>


### PR DESCRIPTION
With this PR, the required flag is settable from the astarte dashboard on interface creation, and interfaces with required mappings show the required property appropriately.