### PR TITLE
feat: support runtime configuration via environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:20.3.1 as builder
 
+ARG vite_show_dashboard_sidebar=true
+ENV VITE_SHOW_DASHBOARD_SIDEBAR=${vite_show_dashboard_sidebar}
+
 WORKDIR /app
 ADD . .
 RUN apt-get -qq update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,22 @@
 FROM node:20.3.1 as builder
 
-ARG vite_show_dashboard_sidebar=true
-ENV VITE_SHOW_DASHBOARD_SIDEBAR=${vite_show_dashboard_sidebar}
-
 WORKDIR /app
-ADD . .
+ADD package*.json ./
 RUN apt-get -qq update
 RUN apt-get -qq install netbase build-essential autoconf libffi-dev
 RUN npm ci --production
+
+ADD . .
 RUN npm run build
 
 FROM nginx:1
+
+# INSTALL JQ for the set-dashboard-config.sh script
+RUN apt-get update -qq && apt-get install -qq -y jq && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /app/build/ /usr/share/nginx/html/
 ADD default.conf /etc/nginx/conf.d/
+ADD config.json.template /usr/share/nginx/html/config.json.template
+
+ADD set-dashboard-config.sh /docker-entrypoint.d/set-dashboard-config.sh
+RUN chmod +x /docker-entrypoint.d/set-dashboard-config.sh

--- a/config.json.template
+++ b/config.json.template
@@ -1,0 +1,13 @@
+{
+  "astarte_api_url": "",
+  "default_auth": "",
+  "enable_flow_preview": false,
+  "auth": [
+    {
+      "type": ""
+    }
+  ],
+  "ui": {
+    "hideSidebar": false
+  }
+}

--- a/default.conf
+++ b/default.conf
@@ -2,6 +2,11 @@ server {
     listen       80;
     server_name  localhost;
 
+    location = /user-config/config.json {
+        alias /tmp/runtime-config.json;
+        default_type application/json;
+    }
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;

--- a/set-dashboard-config.sh
+++ b/set-dashboard-config.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# This script dynamically configures the Astarte Dashboard at startup.
+# It merges environment variables with the configuration JSON, ensuring that
+# environment variables take precedence only when explicitly set.
+
+CONFIG_DIR="/usr/share/nginx/html/user-config"
+MOUNTED_CONFIG="$CONFIG_DIR/config.json"
+TEMPLATE_FILE="/usr/share/nginx/html/config.json.template"
+RUNTIME_CONFIG="/tmp/runtime-config.json"
+
+# Check if a user-provided config.json is mounted
+if [ -f "$MOUNTED_CONFIG" ]; then
+    echo "User-mounted config.json found. Conditionally merging with DASHBOARD_ environment variables..."
+    
+    # Use jq to safely override specific keys ONLY if the environment variables are not empty.
+    # This preserves the user's mounted config defaults.
+    jq --arg api "$DASHBOARD_ASTARTE_API_URL" \
+       --arg auth "$DASHBOARD_DEFAULT_AUTH" \
+       --arg auth_type "$DASHBOARD_AUTH_TYPE" \
+       --arg sidebar "$DASHBOARD_SHOW_SIDEBAR" \
+       --arg flow "$DASHBOARD_ENABLE_FLOW_PREVIEW" \
+       '(if $api != "" then .astarte_api_url = $api else . end) |
+        (if $auth != "" then .default_auth = $auth else . end) |
+        (if $auth_type != "" then (.auth[0] = (.auth[0] // {}) | .auth[0].type = $auth_type) else . end) |
+        (if $sidebar == "false" then (.ui = (.ui // {}) | .ui.hideSidebar = true) elif $sidebar == "true" then (.ui = (.ui // {}) | .ui.hideSidebar = false) else . end) |
+        (if $flow == "true" then .enable_flow_preview = true elif $flow == "false" then .enable_flow_preview = false else . end)' \
+       "$MOUNTED_CONFIG" > "$RUNTIME_CONFIG"
+else
+    echo "No user-mounted config.json found. Generating from template using jq..."
+    
+    # Apply defaults directly in the variable expansion to avoid overwriting mounted configs earlier.
+    # Avoid envsubst to prevent JSON injection vulnerabilities.
+    jq --arg api "${DASHBOARD_ASTARTE_API_URL:-http://api.astarte.localhost}" \
+       --arg auth "${DASHBOARD_DEFAULT_AUTH:-token}" \
+       --arg auth_type "${DASHBOARD_AUTH_TYPE:-token}" \
+       --arg sidebar "${DASHBOARD_SHOW_SIDEBAR:-true}" \
+       --arg flow "${DASHBOARD_ENABLE_FLOW_PREVIEW:-false}" \
+       '.astarte_api_url = $api |
+        .default_auth = $auth |
+        .auth[0] = (.auth[0] // {}) |
+        .auth[0].type = $auth_type |
+        .ui = (.ui // {}) |
+        .ui.hideSidebar = ($sidebar == "false") |
+        .enable_flow_preview = ($flow == "true")' \
+       "$TEMPLATE_FILE" > "$RUNTIME_CONFIG"
+fi
+
+echo "Runtime configuration ready at $RUNTIME_CONFIG"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 /*
    This file is part of Astarte.
 
-   Copyright 2020-2021 Ispirata Srl
+   Copyright 2020-2026 SECO Mind Srl
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -110,7 +110,9 @@ const Dashboard = () => {
     <ReduxProvider store={reduxStore}>
       <Container fluid className="px-0">
         <Row className="g-0">
-          <DashboardSidebar />
+          {(import.meta.env.VITE_SHOW_DASHBOARD_SIDEBAR?.toLowerCase() || 'true') === 'true' && (
+            <DashboardSidebar />
+          )}
           <Col className="main-content bg-light vh-100 overflow-auto d-flex flex-column">
             <PageRouter />
           </Col>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ const DashboardSidebar = () => {
   const config = useConfig();
   const astarte = useAstarte();
   const { triggerDeliveryPoliciesSupported } = useAstarte();
-  const isSidebarHidden = config.ui.hideSidebar;
+  const isSidebarHidden = config?.ui?.hideSidebar || false;
 
   if (!astarte.isAuthenticated || isSidebarHidden) {
     return null;
@@ -72,7 +72,7 @@ const DashboardSidebar = () => {
         )}
         {(astarte.token?.can('appEngine', 'GET', '/devices') ||
           astarte.token?.can('appEngine', 'GET', '/groups')) && <Sidebar.Separator />}
-        {config.features.flow && (
+        {config.features?.flow && (
           <>
             {astarte.token?.can('flow', 'GET', '/flows') && (
               <Sidebar.Item label="Flows" link="/flows" icon="flows" />
@@ -106,13 +106,12 @@ const DashboardSidebar = () => {
 const Dashboard = () => {
   const astarte = useAstarte();
   const reduxStore = useMemo(() => createReduxStore(astarte.client), [astarte.client]);
+
   return (
     <ReduxProvider store={reduxStore}>
       <Container fluid className="px-0">
         <Row className="g-0">
-          {(import.meta.env.VITE_SHOW_DASHBOARD_SIDEBAR?.toLowerCase() || 'true') === 'true' && (
-            <DashboardSidebar />
-          )}
+          <DashboardSidebar />
           <Col className="main-content bg-light vh-100 overflow-auto d-flex flex-column">
             <PageRouter />
           </Col>

--- a/src/vite.env.d.ts
+++ b/src/vite.env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SHOW_DASHBOARD_SIDEBAR: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/vite.env.d.ts
+++ b/src/vite.env.d.ts
@@ -1,9 +1,1 @@
 /// <reference types="vite/client" />
-
-interface ImportMetaEnv {
-  readonly VITE_SHOW_DASHBOARD_SIDEBAR: string;
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}


### PR DESCRIPTION
Shifted configuration handling to runtime with environment variables precedence

- Added an NGINX entrypoint script (set-dashboard-config.sh) to dynamically manage config.json at container startup based on environment variables.

- Implemented a merge strategy using jq: the script now reads the read-only mounted config.json (if present) and safely overrides specific keys with the provided environment variables, saving the result to a temporary location served by NGINX.

- Renamed all environment variables to follow the DASHBOARD_... naming convention for consistency with backend services.

- Precedence rule established: Environment variables now strictly take precedence over the base config.json.

- Optimized Dockerfile to leverage layer caching for npm dependencies to reduce build times, and added jq for the runtime configuration management.

An example of additionalEnv in the Kubernetes CR:
``` additionalEnv:
      - name: DASHBOARD_SHOW_SIDEBAR
        value: "true"
      - name: DASHBOARD_ENABLE_FLOW_PREVIEW
        value: "false"
      - name: DASHBOARD_ASTARTE_API_URL
        value: "https://api.astarte.192.168.49.210.sslip.io"
      - name: DASHBOARD_DEFAULT_AUTH
        value: "token"
      - name: DASHBOARD_AUTH_TYPE
        value: "token"
```
By default, the sidebar is set to be shown (true) and the flow preview is disabled (false). The configuration logic follows a strict fallback order: if a property is not set via environment variables, the script falls back to the values specified in the mounted config.json (ConfigMap), and ultimately to its hardcoded default value.