### PR TITLE
"fix(interfaces): resolve explicit_timestamp injection and modal form submission"

### DIFF
--- a/src/components/InterfaceEditor.tsx
+++ b/src/components/InterfaceEditor.tsx
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useId, useState } from 'react';
 import {
   Accordion,
   Badge,
@@ -200,6 +200,7 @@ const MappingModal = ({
   }, []);
 
   const isValidMapping = AstarteMapping.validation.isValidSync(mappingDraft);
+  const formID = useId();
 
   return (
     <Modal show size="lg" centered onHide={onCancel}>
@@ -213,17 +214,15 @@ const MappingModal = ({
           interfaceAggregation={interfaceAggregation}
           mapping={mappingDraft}
           onChange={handleChange}
+          formId={formID}
+          onSubmit={() => onConfirm(mappingDraft)}
         />
       </Modal.Body>
       <Modal.Footer>
         <Button variant="secondary" onClick={onCancel}>
           Cancel
         </Button>
-        <Button
-          variant="primary"
-          onClick={() => onConfirm(mappingDraft)}
-          disabled={!isValidMapping}
-        >
+        <Button variant="primary" disabled={!isValidMapping} type="submit" form={formID}>
           {mapping != null ? 'Update' : 'Add'}
         </Button>
       </Modal.Footer>
@@ -372,7 +371,7 @@ const getInitialDatastreamOptions = (iface: AstarteInterface): DatastreamOptions
   options.databaseRetentionPolicy = mapping.databaseRetentionPolicy;
   options.databaseRetentionTtl =
     options.databaseRetentionPolicy === 'use_ttl' ? mapping.databaseRetentionTtl : undefined;
-  options.explicitTimestamp = mapping.explicitTimestamp != null ? mapping.explicitTimestamp : true;
+  options.explicitTimestamp = mapping.explicitTimestamp != null ? mapping.explicitTimestamp : false;
   return options;
 };
 

--- a/src/components/MappingEditor.tsx
+++ b/src/components/MappingEditor.tsx
@@ -48,6 +48,8 @@ interface Props {
   interfaceOwner: AstarteInterface['ownership'];
   interfaceType: AstarteInterface['type'];
   interfaceAggregation?: AstarteInterface['aggregation'];
+  onSubmit: React.FormEventHandler<HTMLFormElement>;
+  formId: string;
   mapping?: AstarteMapping;
   onChange: (updatedMapping: AstarteMapping) => unknown;
 }
@@ -58,6 +60,8 @@ export default ({
   interfaceAggregation = 'individual',
   mapping = defaultMapping,
   onChange,
+  onSubmit,
+  formId,
 }: Props): React.ReactElement => {
   const isPropertiesInterface = interfaceType === 'properties';
   const isDatastreamIndividualInterface =
@@ -73,7 +77,13 @@ export default ({
   }
 
   return (
-    <Form>
+    <Form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit(e);
+      }}
+      id={formId}
+    >
       <Stack gap={3}>
         <Row className="mb-2 g-3">
           <Col sm={12}>


### PR DESCRIPTION
1. Fixes Issue #541 where 'explicit_timestamp' was wrongly injected with
a default value when opening an existing interface.
2. Fixes a bug in the MappingModal where pressing the 'Enter' key inside
the form caused an implicit submission and a full page hard-refresh.
Resolved by using 'form' id attribute linking the submit button to
the modal's form."