### PR TITLE
fix(delivery-policies): correct readonly state in error handler modal

### DIFF
--- a/src/components/TriggerDeliveryPolicyHandler.tsx
+++ b/src/components/TriggerDeliveryPolicyHandler.tsx
@@ -325,7 +325,7 @@ export default ({ isReadOnly, initialData, onChange }: Props): React.ReactElemen
             }
             setIsAddingHandler(false);
           }}
-          isReadOnly
+          isReadOnly={isReadOnly}
           showModal={isAddingHandler}
         />
       )}
@@ -342,7 +342,7 @@ export default ({ isReadOnly, initialData, onChange }: Props): React.ReactElemen
             }
             setHandlerToEditIndex(null);
           }}
-          isReadOnly
+          isReadOnly={isReadOnly}
           showModal={handlerToEditIndex != null}
         />
       )}


### PR DESCRIPTION
The AddHandlerModal and EditHandlerModal components were forced into a
read-only state due to the use of the JSX boolean shorthand
('isReadOnly' instead of 'isReadOnly={isReadOnly}'). This prevented
users from changing the 'On' and 'Strategy' dropdowns when adding or
editing an error handler.

Signed-off-by: Alioune Gaye <alioune.gaye@secomind.com>